### PR TITLE
Add missing subprograms IC1*.CBL

### DIFF
--- a/src/IC101A.CBL
+++ b/src/IC101A.CBL
@@ -1,0 +1,382 @@
+000100 IDENTIFICATION DIVISION.                                         IC1014.2
+000200 PROGRAM-ID.                                                      IC1014.2
+000300     IC101A.                                                      IC1014.2
+000400****************************************************************  IC1014.2
+000500*                                                              *  IC1014.2
+000600*    VALIDATION FOR:-                                          *  IC1014.2
+000700*                                                              *  IC1014.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1014.2
+000900*                                                              *  IC1014.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1014.2
+001100*                                                              *  IC1014.2
+001200****************************************************************  IC1014.2
+001300*                                                              *  IC1014.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC1014.2
+001500*                                                              *  IC1014.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC1014.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC1014.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC1014.2
+001900*                                                              *  IC1014.2
+002000****************************************************************  IC1014.2
+002100*         THIS ROUTINE CHECKS THE USE OF THE CALL STATEMENT       IC1014.2
+002200*    WITH ONE PARAMETER IN THE USING PHRASE.  SUBSEQUENT CALLS    IC1014.2
+002300*    CHECK THAT THE CALLED ROUTINE REMAINS IN THE LAST USED STATE.IC1014.2
+002400*                                                                 IC1014.2
+002500*        THERE ARE NO DELETE PARAGRAPHS IN THIS ROUTINE           IC1014.2
+002600*    SINCE THESE ARE THE BASIC CALL TESTS AND IF A CALL           IC1014.2
+002700*    STATEMENT IS REJECTED THERE IS NO REASON TO RUN THE ROUTINE. IC1014.2
+002800*                                                                 IC1014.2
+002900*    THE FIRST THREE CALLS USE A DATA-NAME THE SAME AS            IC1014.2
+003000*    THE NAME IN THE SUBPROGRAM.  THE LAST TWO CALLS USE          IC1014.2
+003100*    A DIFFERENT DATA-NAME FROM THE NAME IN THE SUBPROGRAM.       IC1014.2
+003200*    THE PICTURE CLAUSES FOR DATA-NAMES IN THE USING PHRASES      IC1014.2
+003300*    OF THE CALLED AND CALLING PROGRAMS ARE IDENTICAL.            IC1014.2
+003400 ENVIRONMENT DIVISION.                                            IC1014.2
+003500 CONFIGURATION SECTION.                                           IC1014.2
+003600 SOURCE-COMPUTER.                                                 IC1014.2
+003700     XXXXX082.                                                    IC1014.2
+003800 OBJECT-COMPUTER.                                                 IC1014.2
+003900     XXXXX083.                                                    IC1014.2
+004000 INPUT-OUTPUT SECTION.                                            IC1014.2
+004100 FILE-CONTROL.                                                    IC1014.2
+004200     SELECT PRINT-FILE ASSIGN TO                                  IC1014.2
+004300     XXXXX055.                                                    IC1014.2
+004400 DATA DIVISION.                                                   IC1014.2
+004500 FILE SECTION.                                                    IC1014.2
+004600 FD  PRINT-FILE.                                                  IC1014.2
+004700 01  PRINT-REC PICTURE X(120).                                    IC1014.2
+004800 01  DUMMY-RECORD PICTURE X(120).                                 IC1014.2
+004900 WORKING-STORAGE SECTION.                                         IC1014.2
+005000 77  DN1 PICTURE S9  VALUE ZERO.                                  IC1014.2
+005100 77  DN2 PICTURE S9  VALUE ZERO.                                  IC1014.2
+005200 01  TEST-RESULTS.                                                IC1014.2
+005300     02 FILLER                   PIC X      VALUE SPACE.          IC1014.2
+005400     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC1014.2
+005500     02 FILLER                   PIC X      VALUE SPACE.          IC1014.2
+005600     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC1014.2
+005700     02 FILLER                   PIC X      VALUE SPACE.          IC1014.2
+005800     02  PAR-NAME.                                                IC1014.2
+005900       03 FILLER                 PIC X(19)  VALUE SPACE.          IC1014.2
+006000       03  PARDOT-X              PIC X      VALUE SPACE.          IC1014.2
+006100       03 DOTVALUE               PIC 99     VALUE ZERO.           IC1014.2
+006200     02 FILLER                   PIC X(8)   VALUE SPACE.          IC1014.2
+006300     02 RE-MARK                  PIC X(61).                       IC1014.2
+006400 01  TEST-COMPUTED.                                               IC1014.2
+006500     02 FILLER                   PIC X(30)  VALUE SPACE.          IC1014.2
+006600     02 FILLER                   PIC X(17)  VALUE                 IC1014.2
+006700            "       COMPUTED=".                                   IC1014.2
+006800     02 COMPUTED-X.                                               IC1014.2
+006900     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC1014.2
+007000     03 COMPUTED-N               REDEFINES COMPUTED-A             IC1014.2
+007100                                 PIC -9(9).9(9).                  IC1014.2
+007200     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC1014.2
+007300     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC1014.2
+007400     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC1014.2
+007500     03       CM-18V0 REDEFINES COMPUTED-A.                       IC1014.2
+007600         04 COMPUTED-18V0                    PIC -9(18).          IC1014.2
+007700         04 FILLER                           PIC X.               IC1014.2
+007800     03 FILLER PIC X(50) VALUE SPACE.                             IC1014.2
+007900 01  TEST-CORRECT.                                                IC1014.2
+008000     02 FILLER PIC X(30) VALUE SPACE.                             IC1014.2
+008100     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC1014.2
+008200     02 CORRECT-X.                                                IC1014.2
+008300     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC1014.2
+008400     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC1014.2
+008500     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC1014.2
+008600     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC1014.2
+008700     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC1014.2
+008800     03      CR-18V0 REDEFINES CORRECT-A.                         IC1014.2
+008900         04 CORRECT-18V0                     PIC -9(18).          IC1014.2
+009000         04 FILLER                           PIC X.               IC1014.2
+009100     03 FILLER PIC X(2) VALUE SPACE.                              IC1014.2
+009200     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC1014.2
+009300 01  CCVS-C-1.                                                    IC1014.2
+009400     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC1014.2
+009500-    "SS  PARAGRAPH-NAME                                          IC1014.2
+009600-    "       REMARKS".                                            IC1014.2
+009700     02 FILLER                     PIC X(20)    VALUE SPACE.      IC1014.2
+009800 01  CCVS-C-2.                                                    IC1014.2
+009900     02 FILLER                     PIC X        VALUE SPACE.      IC1014.2
+010000     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC1014.2
+010100     02 FILLER                     PIC X(15)    VALUE SPACE.      IC1014.2
+010200     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC1014.2
+010300     02 FILLER                     PIC X(94)    VALUE SPACE.      IC1014.2
+010400 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC1014.2
+010500 01  REC-CT                        PIC 99       VALUE ZERO.       IC1014.2
+010600 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC1014.2
+010700 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC1014.2
+010800 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC1014.2
+010900 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC1014.2
+011000 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC1014.2
+011100 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC1014.2
+011200 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC1014.2
+011300 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC1014.2
+011400 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC1014.2
+011500 01  CCVS-H-1.                                                    IC1014.2
+011600     02  FILLER                    PIC X(39)    VALUE SPACES.     IC1014.2
+011700     02  FILLER                    PIC X(42)    VALUE             IC1014.2
+011800     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC1014.2
+011900     02  FILLER                    PIC X(39)    VALUE SPACES.     IC1014.2
+012000 01  CCVS-H-2A.                                                   IC1014.2
+012100   02  FILLER                        PIC X(40)  VALUE SPACE.      IC1014.2
+012200   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC1014.2
+012300   02  FILLER                        PIC XXXX   VALUE             IC1014.2
+012400     "4.2 ".                                                      IC1014.2
+012500   02  FILLER                        PIC X(28)  VALUE             IC1014.2
+012600            " COPY - NOT FOR DISTRIBUTION".                       IC1014.2
+012700   02  FILLER                        PIC X(41)  VALUE SPACE.      IC1014.2
+012800                                                                  IC1014.2
+012900 01  CCVS-H-2B.                                                   IC1014.2
+013000   02  FILLER                        PIC X(15)  VALUE             IC1014.2
+013100            "TEST RESULT OF ".                                    IC1014.2
+013200   02  TEST-ID                       PIC X(9).                    IC1014.2
+013300   02  FILLER                        PIC X(4)   VALUE             IC1014.2
+013400            " IN ".                                               IC1014.2
+013500   02  FILLER                        PIC X(12)  VALUE             IC1014.2
+013600     " HIGH       ".                                              IC1014.2
+013700   02  FILLER                        PIC X(22)  VALUE             IC1014.2
+013800            " LEVEL VALIDATION FOR ".                             IC1014.2
+013900   02  FILLER                        PIC X(58)  VALUE             IC1014.2
+014000     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1014.2
+014100 01  CCVS-H-3.                                                    IC1014.2
+014200     02  FILLER                      PIC X(34)  VALUE             IC1014.2
+014300            " FOR OFFICIAL USE ONLY    ".                         IC1014.2
+014400     02  FILLER                      PIC X(58)  VALUE             IC1014.2
+014500     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1014.2
+014600     02  FILLER                      PIC X(28)  VALUE             IC1014.2
+014700            "  COPYRIGHT   1985 ".                                IC1014.2
+014800 01  CCVS-E-1.                                                    IC1014.2
+014900     02 FILLER                       PIC X(52)  VALUE SPACE.      IC1014.2
+015000     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC1014.2
+015100     02 ID-AGAIN                     PIC X(9).                    IC1014.2
+015200     02 FILLER                       PIC X(45)  VALUE SPACES.     IC1014.2
+015300 01  CCVS-E-2.                                                    IC1014.2
+015400     02  FILLER                      PIC X(31)  VALUE SPACE.      IC1014.2
+015500     02  FILLER                      PIC X(21)  VALUE SPACE.      IC1014.2
+015600     02 CCVS-E-2-2.                                               IC1014.2
+015700         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC1014.2
+015800         03 FILLER                   PIC X      VALUE SPACE.      IC1014.2
+015900         03 ENDER-DESC               PIC X(44)  VALUE             IC1014.2
+016000            "ERRORS ENCOUNTERED".                                 IC1014.2
+016100 01  CCVS-E-3.                                                    IC1014.2
+016200     02  FILLER                      PIC X(22)  VALUE             IC1014.2
+016300            " FOR OFFICIAL USE ONLY".                             IC1014.2
+016400     02  FILLER                      PIC X(12)  VALUE SPACE.      IC1014.2
+016500     02  FILLER                      PIC X(58)  VALUE             IC1014.2
+016600     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1014.2
+016700     02  FILLER                      PIC X(13)  VALUE SPACE.      IC1014.2
+016800     02 FILLER                       PIC X(15)  VALUE             IC1014.2
+016900             " COPYRIGHT 1985".                                   IC1014.2
+017000 01  CCVS-E-4.                                                    IC1014.2
+017100     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC1014.2
+017200     02 FILLER                       PIC X(4)   VALUE " OF ".     IC1014.2
+017300     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC1014.2
+017400     02 FILLER                       PIC X(40)  VALUE             IC1014.2
+017500      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC1014.2
+017600 01  XXINFO.                                                      IC1014.2
+017700     02 FILLER                       PIC X(19)  VALUE             IC1014.2
+017800            "*** INFORMATION ***".                                IC1014.2
+017900     02 INFO-TEXT.                                                IC1014.2
+018000       04 FILLER                     PIC X(8)   VALUE SPACE.      IC1014.2
+018100       04 XXCOMPUTED                 PIC X(20).                   IC1014.2
+018200       04 FILLER                     PIC X(5)   VALUE SPACE.      IC1014.2
+018300       04 XXCORRECT                  PIC X(20).                   IC1014.2
+018400     02 INF-ANSI-REFERENCE           PIC X(48).                   IC1014.2
+018500 01  HYPHEN-LINE.                                                 IC1014.2
+018600     02 FILLER  PIC IS X VALUE IS SPACE.                          IC1014.2
+018700     02 FILLER  PIC IS X(65)    VALUE IS "************************IC1014.2
+018800-    "*****************************************".                 IC1014.2
+018900     02 FILLER  PIC IS X(54)    VALUE IS "************************IC1014.2
+019000-    "******************************".                            IC1014.2
+019100 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC1014.2
+019200     "IC101A".                                                    IC1014.2
+019300 PROCEDURE DIVISION.                                              IC1014.2
+019400 CCVS1 SECTION.                                                   IC1014.2
+019500 OPEN-FILES.                                                      IC1014.2
+019600     OPEN     OUTPUT PRINT-FILE.                                  IC1014.2
+019700     MOVE CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.   IC1014.2
+019800     MOVE    SPACE TO TEST-RESULTS.                               IC1014.2
+019900     PERFORM  HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.             IC1014.2
+020000     GO TO CCVS1-EXIT.                                            IC1014.2
+020100 CLOSE-FILES.                                                     IC1014.2
+020200     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC1014.2
+020300 TERMINATE-CCVS.                                                  IC1014.2
+020400S    EXIT PROGRAM.                                                IC1014.2
+020500STERMINATE-CALL.                                                  IC1014.2
+020600     STOP     RUN.                                                IC1014.2
+020700 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         IC1014.2
+020800 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           IC1014.2
+020900 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          IC1014.2
+021000 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      IC1014.2
+021100     MOVE "****TEST DELETED****" TO RE-MARK.                      IC1014.2
+021200 PRINT-DETAIL.                                                    IC1014.2
+021300     IF REC-CT NOT EQUAL TO ZERO                                  IC1014.2
+021400             MOVE "." TO PARDOT-X                                 IC1014.2
+021500             MOVE REC-CT TO DOTVALUE.                             IC1014.2
+021600     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      IC1014.2
+021700     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               IC1014.2
+021800        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 IC1014.2
+021900          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 IC1014.2
+022000     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC1014.2
+022100     MOVE SPACE TO CORRECT-X.                                     IC1014.2
+022200     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC1014.2
+022300     MOVE     SPACE TO RE-MARK.                                   IC1014.2
+022400 HEAD-ROUTINE.                                                    IC1014.2
+022500     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC1014.2
+022600     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC1014.2
+022700     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC1014.2
+022800     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC1014.2
+022900 COLUMN-NAMES-ROUTINE.                                            IC1014.2
+023000     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1014.2
+023100     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1014.2
+023200     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC1014.2
+023300 END-ROUTINE.                                                     IC1014.2
+023400     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.IC1014.2
+023500 END-RTN-EXIT.                                                    IC1014.2
+023600     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1014.2
+023700 END-ROUTINE-1.                                                   IC1014.2
+023800      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      IC1014.2
+023900      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               IC1014.2
+024000      ADD PASS-COUNTER TO ERROR-HOLD.                             IC1014.2
+024100*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC1014.2
+024200      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC1014.2
+024300      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC1014.2
+024400      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC1014.2
+024500      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC1014.2
+024600  END-ROUTINE-12.                                                 IC1014.2
+024700      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC1014.2
+024800     IF       ERROR-COUNTER IS EQUAL TO ZERO                      IC1014.2
+024900         MOVE "NO " TO ERROR-TOTAL                                IC1014.2
+025000         ELSE                                                     IC1014.2
+025100         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC1014.2
+025200     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC1014.2
+025300     PERFORM WRITE-LINE.                                          IC1014.2
+025400 END-ROUTINE-13.                                                  IC1014.2
+025500     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC1014.2
+025600         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC1014.2
+025700         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC1014.2
+025800     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC1014.2
+025900     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1014.2
+026000      IF   INSPECT-COUNTER EQUAL TO ZERO                          IC1014.2
+026100          MOVE "NO " TO ERROR-TOTAL                               IC1014.2
+026200      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   IC1014.2
+026300      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            IC1014.2
+026400      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          IC1014.2
+026500     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1014.2
+026600 WRITE-LINE.                                                      IC1014.2
+026700     ADD 1 TO RECORD-COUNT.                                       IC1014.2
+026800Y    IF RECORD-COUNT GREATER 50                                   IC1014.2
+026900Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC1014.2
+027000Y        MOVE SPACE TO DUMMY-RECORD                               IC1014.2
+027100Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC1014.2
+027200Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC1014.2
+027300Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC1014.2
+027400Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC1014.2
+027500Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC1014.2
+027600Y        MOVE ZERO TO RECORD-COUNT.                               IC1014.2
+027700     PERFORM WRT-LN.                                              IC1014.2
+027800 WRT-LN.                                                          IC1014.2
+027900     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC1014.2
+028000     MOVE SPACE TO DUMMY-RECORD.                                  IC1014.2
+028100 BLANK-LINE-PRINT.                                                IC1014.2
+028200     PERFORM WRT-LN.                                              IC1014.2
+028300 FAIL-ROUTINE.                                                    IC1014.2
+028400     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC1014.2
+028500     IF     CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.IC1014.2
+028600     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC1014.2
+028700     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC1014.2
+028800     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1014.2
+028900     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC1014.2
+029000     GO TO  FAIL-ROUTINE-EX.                                      IC1014.2
+029100 FAIL-ROUTINE-WRITE.                                              IC1014.2
+029200     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC1014.2
+029300     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC1014.2
+029400     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC1014.2
+029500     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC1014.2
+029600 FAIL-ROUTINE-EX. EXIT.                                           IC1014.2
+029700 BAIL-OUT.                                                        IC1014.2
+029800     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC1014.2
+029900     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC1014.2
+030000 BAIL-OUT-WRITE.                                                  IC1014.2
+030100     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC1014.2
+030200     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC1014.2
+030300     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1014.2
+030400     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC1014.2
+030500 BAIL-OUT-EX. EXIT.                                               IC1014.2
+030600 CCVS1-EXIT.                                                      IC1014.2
+030700     EXIT.                                                        IC1014.2
+030800 SECT-IC101-0001 SECTION.                                         IC1014.2
+030900 CALL-INIT-1.                                                     IC1014.2
+031000     MOVE "CALL...USING DATA-NM" TO FEATURE.                      IC1014.2
+031100     MOVE "CALL-TEST-01" TO PAR-NAME.                             IC1014.2
+031200 CALL-TEST-1.                                                     IC1014.2
+031300     CALL "IC102A" USING DN1.                                     IC1014.2
+031400     IF DN1 IS EQUAL TO 1                                         IC1014.2
+031500         PERFORM PASS                                             IC1014.2
+031600             GO TO CALL-WRITE-1.                                  IC1014.2
+031700 CALL-FAIL-1.                                                     IC1014.2
+031800     MOVE 1 TO CORRECT-18V0.                                      IC1014.2
+031900     MOVE DN1 TO COMPUTED-18V0.                                   IC1014.2
+032000     PERFORM FAIL.                                                IC1014.2
+032100 CALL-WRITE-1.                                                    IC1014.2
+032200     PERFORM PRINT-DETAIL.                                        IC1014.2
+032300 CALL-INIT-2.                                                     IC1014.2
+032400     MOVE 0 TO DN1.                                               IC1014.2
+032500 CALL-TEST-2.                                                     IC1014.2
+032600     CALL "IC102A" USING DN1.                                     IC1014.2
+032700     IF DN1 IS EQUAL TO 2                                         IC1014.2
+032800         PERFORM PASS                                             IC1014.2
+032900             GO TO CALL-WRITE-2.                                  IC1014.2
+033000 CALL-FAIL-2.                                                     IC1014.2
+033100     MOVE 2 TO CORRECT-18V0.                                      IC1014.2
+033200     MOVE DN1 TO COMPUTED-18V0.                                   IC1014.2
+033300     PERFORM FAIL.                                                IC1014.2
+033400 CALL-WRITE-2.                                                    IC1014.2
+033500     MOVE "CALL-TEST-02" TO PAR-NAME.                             IC1014.2
+033600     PERFORM PRINT-DETAIL.                                        IC1014.2
+033700 CALL-INIT-3.                                                     IC1014.2
+033800     ADD 4 TO DN1.                                                IC1014.2
+033900 CALL-TEST-3.                                                     IC1014.2
+034000     CALL "IC102A" USING DN1.                                     IC1014.2
+034100     IF DN1 IS EQUAL TO 3                                         IC1014.2
+034200         PERFORM PASS                                             IC1014.2
+034300             GO TO CALL-WRITE-3.                                  IC1014.2
+034400 CALL-FAIL-3.                                                     IC1014.2
+034500     MOVE 3 TO CORRECT-18V0.                                      IC1014.2
+034600     MOVE DN1 TO COMPUTED-18V0.                                   IC1014.2
+034700     PERFORM FAIL.                                                IC1014.2
+034800 CALL-WRITE-3.                                                    IC1014.2
+034900     MOVE "CALL-TEST-03" TO PAR-NAME.                             IC1014.2
+035000     PERFORM PRINT-DETAIL.                                        IC1014.2
+035100 CALL-TEST-4.                                                     IC1014.2
+035200     CALL "IC102A" USING DN2.                                     IC1014.2
+035300     IF DN2 IS NOT EQUAL TO 4                                     IC1014.2
+035400             GO TO CALL-FAIL-4.                                   IC1014.2
+035500     PERFORM PASS.                                                IC1014.2
+035600     GO TO CALL-WRITE-4.                                          IC1014.2
+035700 CALL-FAIL-4.                                                     IC1014.2
+035800     MOVE 4 TO CORRECT-18V0.                                      IC1014.2
+035900     MOVE DN2 TO COMPUTED-18V0.                                   IC1014.2
+036000     PERFORM FAIL.                                                IC1014.2
+036100 CALL-WRITE-4.                                                    IC1014.2
+036200     MOVE "CALL-TEST-04" TO PAR-NAME.                             IC1014.2
+036300     PERFORM PRINT-DETAIL.                                        IC1014.2
+036400 CALL-INIT-5.                                                     IC1014.2
+036500     MOVE 0 TO DN2.                                               IC1014.2
+036600 CALL-TEST-5.                                                     IC1014.2
+036700     CALL "IC102A" USING DN2.                                     IC1014.2
+036800     IF DN2 IS EQUAL TO 5                                         IC1014.2
+036900         PERFORM PASS                                             IC1014.2
+037000             GO TO CALL-WRITE-5.                                  IC1014.2
+037100 CALL-FAIL-5.                                                     IC1014.2
+037200     MOVE 5 TO CORRECT-18V0.                                      IC1014.2
+037300     MOVE DN2 TO COMPUTED-18V0.                                   IC1014.2
+037400     PERFORM FAIL.                                                IC1014.2
+037500 CALL-WRITE-5.                                                    IC1014.2
+037600     MOVE "CALL-TEST-05" TO PAR-NAME.                             IC1014.2
+037700     PERFORM PRINT-DETAIL.                                        IC1014.2
+037800 CALL-END-ROUTINE.                                                IC1014.2
+037900     GO TO CCVS-EXIT.                                             IC1014.2
+038000 CCVS-EXIT SECTION.                                               IC1014.2
+038100 CCVS-999999.                                                     IC1014.2
+038200     GO TO CLOSE-FILES.                                           IC1014.2

--- a/src/IC103A.CBL
+++ b/src/IC103A.CBL
@@ -1,0 +1,497 @@
+000100 IDENTIFICATION DIVISION.                                         IC1034.2
+000200 PROGRAM-ID.                                                      IC1034.2
+000300     IC103A.                                                      IC1034.2
+000400****************************************************************  IC1034.2
+000500*                                                              *  IC1034.2
+000600*    VALIDATION FOR:-                                          *  IC1034.2
+000700*                                                              *  IC1034.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1034.2
+000900*                                                              *  IC1034.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1034.2
+001100*                                                              *  IC1034.2
+001200****************************************************************  IC1034.2
+001300*                                                              *  IC1034.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC1034.2
+001500*                                                              *  IC1034.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC1034.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC1034.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC1034.2
+001900*                                                              *  IC1034.2
+002000****************************************************************  IC1034.2
+002100*        THIS PROGRAM TESTS THE USE OF MULTIPLE DATA-NAMES        IC1034.2
+002200*    IN THE USING PHRASE OF THE CALL STATEMENT.  TWO 01 GROUP     IC1034.2
+002300*    ITEMS AND AN ELEMENTARY 77 ITEM ARE THE PARAMETERS.  THE     IC1034.2
+002400*    DATA DEFINITIONS FOR THE GROUP ITEM PARAMETERS ARE NOT       IC1034.2
+002500*    THE SAME AS IN THE SUBPROGRAM BUT THE NUMBER OF CHARACTERS   IC1034.2
+002600*    ARE IDENTICAL.                                               IC1034.2
+002700*        THIS PROGRAM ALSO CALLS A SUBPROGRAM WITH MORE           IC1034.2
+002800*    THAN ONE EXIT PROGRAM STATEMENT.                             IC1034.2
+002900 ENVIRONMENT DIVISION.                                            IC1034.2
+003000 CONFIGURATION SECTION.                                           IC1034.2
+003100 SOURCE-COMPUTER.                                                 IC1034.2
+003200     XXXXX082.                                                    IC1034.2
+003300 OBJECT-COMPUTER.                                                 IC1034.2
+003400     XXXXX083.                                                    IC1034.2
+003500 INPUT-OUTPUT SECTION.                                            IC1034.2
+003600 FILE-CONTROL.                                                    IC1034.2
+003700     SELECT PRINT-FILE ASSIGN TO                                  IC1034.2
+003800     XXXXX055.                                                    IC1034.2
+003900 DATA DIVISION.                                                   IC1034.2
+004000 FILE SECTION.                                                    IC1034.2
+004100 FD  PRINT-FILE.                                                  IC1034.2
+004200 01  PRINT-REC PICTURE X(120).                                    IC1034.2
+004300 01  DUMMY-RECORD PICTURE X(120).                                 IC1034.2
+004400 WORKING-STORAGE SECTION.                                         IC1034.2
+004500 77  MAIN-DN1 PICTURE 999.                                        IC1034.2
+004600 77  MAIN-DN2 PICTURE S99 COMPUTATIONAL.                          IC1034.2
+004700 77  ELEM-77   PICTURE V9(4) COMPUTATIONAL.                       IC1034.2
+004800 01  GROUP-01.                                                    IC1034.2
+004900     02 ALPHA-NUM-FIELD  PIC X(5).                                IC1034.2
+005000     02 GROUP-LEV2.                                               IC1034.2
+005100        03 NUMER-FIELD PIC 99.                                    IC1034.2
+005200        03 ALPHA-FIELD PIC A(3).                                  IC1034.2
+005300 01  GROUP-02.                                                    IC1034.2
+005400     02  NUM-ITEM PIC S99.                                        IC1034.2
+005500     02  ALPHA-EDITED PICTURE X(6).                               IC1034.2
+005600 01  TEST-RESULTS.                                                IC1034.2
+005700     02 FILLER                   PIC X      VALUE SPACE.          IC1034.2
+005800     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC1034.2
+005900     02 FILLER                   PIC X      VALUE SPACE.          IC1034.2
+006000     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC1034.2
+006100     02 FILLER                   PIC X      VALUE SPACE.          IC1034.2
+006200     02  PAR-NAME.                                                IC1034.2
+006300       03 FILLER                 PIC X(19)  VALUE SPACE.          IC1034.2
+006400       03  PARDOT-X              PIC X      VALUE SPACE.          IC1034.2
+006500       03 DOTVALUE               PIC 99     VALUE ZERO.           IC1034.2
+006600     02 FILLER                   PIC X(8)   VALUE SPACE.          IC1034.2
+006700     02 RE-MARK                  PIC X(61).                       IC1034.2
+006800 01  TEST-COMPUTED.                                               IC1034.2
+006900     02 FILLER                   PIC X(30)  VALUE SPACE.          IC1034.2
+007000     02 FILLER                   PIC X(17)  VALUE                 IC1034.2
+007100            "       COMPUTED=".                                   IC1034.2
+007200     02 COMPUTED-X.                                               IC1034.2
+007300     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC1034.2
+007400     03 COMPUTED-N               REDEFINES COMPUTED-A             IC1034.2
+007500                                 PIC -9(9).9(9).                  IC1034.2
+007600     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC1034.2
+007700     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC1034.2
+007800     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC1034.2
+007900     03       CM-18V0 REDEFINES COMPUTED-A.                       IC1034.2
+008000         04 COMPUTED-18V0                    PIC -9(18).          IC1034.2
+008100         04 FILLER                           PIC X.               IC1034.2
+008200     03 FILLER PIC X(50) VALUE SPACE.                             IC1034.2
+008300 01  TEST-CORRECT.                                                IC1034.2
+008400     02 FILLER PIC X(30) VALUE SPACE.                             IC1034.2
+008500     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC1034.2
+008600     02 CORRECT-X.                                                IC1034.2
+008700     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC1034.2
+008800     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC1034.2
+008900     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC1034.2
+009000     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC1034.2
+009100     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC1034.2
+009200     03      CR-18V0 REDEFINES CORRECT-A.                         IC1034.2
+009300         04 CORRECT-18V0                     PIC -9(18).          IC1034.2
+009400         04 FILLER                           PIC X.               IC1034.2
+009500     03 FILLER PIC X(2) VALUE SPACE.                              IC1034.2
+009600     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC1034.2
+009700 01  CCVS-C-1.                                                    IC1034.2
+009800     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC1034.2
+009900-    "SS  PARAGRAPH-NAME                                          IC1034.2
+010000-    "       REMARKS".                                            IC1034.2
+010100     02 FILLER                     PIC X(20)    VALUE SPACE.      IC1034.2
+010200 01  CCVS-C-2.                                                    IC1034.2
+010300     02 FILLER                     PIC X        VALUE SPACE.      IC1034.2
+010400     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC1034.2
+010500     02 FILLER                     PIC X(15)    VALUE SPACE.      IC1034.2
+010600     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC1034.2
+010700     02 FILLER                     PIC X(94)    VALUE SPACE.      IC1034.2
+010800 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC1034.2
+010900 01  REC-CT                        PIC 99       VALUE ZERO.       IC1034.2
+011000 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC1034.2
+011100 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC1034.2
+011200 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC1034.2
+011300 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC1034.2
+011400 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC1034.2
+011500 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC1034.2
+011600 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC1034.2
+011700 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC1034.2
+011800 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC1034.2
+011900 01  CCVS-H-1.                                                    IC1034.2
+012000     02  FILLER                    PIC X(39)    VALUE SPACES.     IC1034.2
+012100     02  FILLER                    PIC X(42)    VALUE             IC1034.2
+012200     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC1034.2
+012300     02  FILLER                    PIC X(39)    VALUE SPACES.     IC1034.2
+012400 01  CCVS-H-2A.                                                   IC1034.2
+012500   02  FILLER                        PIC X(40)  VALUE SPACE.      IC1034.2
+012600   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC1034.2
+012700   02  FILLER                        PIC XXXX   VALUE             IC1034.2
+012800     "4.2 ".                                                      IC1034.2
+012900   02  FILLER                        PIC X(28)  VALUE             IC1034.2
+013000            " COPY - NOT FOR DISTRIBUTION".                       IC1034.2
+013100   02  FILLER                        PIC X(41)  VALUE SPACE.      IC1034.2
+013200                                                                  IC1034.2
+013300 01  CCVS-H-2B.                                                   IC1034.2
+013400   02  FILLER                        PIC X(15)  VALUE             IC1034.2
+013500            "TEST RESULT OF ".                                    IC1034.2
+013600   02  TEST-ID                       PIC X(9).                    IC1034.2
+013700   02  FILLER                        PIC X(4)   VALUE             IC1034.2
+013800            " IN ".                                               IC1034.2
+013900   02  FILLER                        PIC X(12)  VALUE             IC1034.2
+014000     " HIGH       ".                                              IC1034.2
+014100   02  FILLER                        PIC X(22)  VALUE             IC1034.2
+014200            " LEVEL VALIDATION FOR ".                             IC1034.2
+014300   02  FILLER                        PIC X(58)  VALUE             IC1034.2
+014400     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1034.2
+014500 01  CCVS-H-3.                                                    IC1034.2
+014600     02  FILLER                      PIC X(34)  VALUE             IC1034.2
+014700            " FOR OFFICIAL USE ONLY    ".                         IC1034.2
+014800     02  FILLER                      PIC X(58)  VALUE             IC1034.2
+014900     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1034.2
+015000     02  FILLER                      PIC X(28)  VALUE             IC1034.2
+015100            "  COPYRIGHT   1985 ".                                IC1034.2
+015200 01  CCVS-E-1.                                                    IC1034.2
+015300     02 FILLER                       PIC X(52)  VALUE SPACE.      IC1034.2
+015400     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC1034.2
+015500     02 ID-AGAIN                     PIC X(9).                    IC1034.2
+015600     02 FILLER                       PIC X(45)  VALUE SPACES.     IC1034.2
+015700 01  CCVS-E-2.                                                    IC1034.2
+015800     02  FILLER                      PIC X(31)  VALUE SPACE.      IC1034.2
+015900     02  FILLER                      PIC X(21)  VALUE SPACE.      IC1034.2
+016000     02 CCVS-E-2-2.                                               IC1034.2
+016100         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC1034.2
+016200         03 FILLER                   PIC X      VALUE SPACE.      IC1034.2
+016300         03 ENDER-DESC               PIC X(44)  VALUE             IC1034.2
+016400            "ERRORS ENCOUNTERED".                                 IC1034.2
+016500 01  CCVS-E-3.                                                    IC1034.2
+016600     02  FILLER                      PIC X(22)  VALUE             IC1034.2
+016700            " FOR OFFICIAL USE ONLY".                             IC1034.2
+016800     02  FILLER                      PIC X(12)  VALUE SPACE.      IC1034.2
+016900     02  FILLER                      PIC X(58)  VALUE             IC1034.2
+017000     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1034.2
+017100     02  FILLER                      PIC X(13)  VALUE SPACE.      IC1034.2
+017200     02 FILLER                       PIC X(15)  VALUE             IC1034.2
+017300             " COPYRIGHT 1985".                                   IC1034.2
+017400 01  CCVS-E-4.                                                    IC1034.2
+017500     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC1034.2
+017600     02 FILLER                       PIC X(4)   VALUE " OF ".     IC1034.2
+017700     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC1034.2
+017800     02 FILLER                       PIC X(40)  VALUE             IC1034.2
+017900      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC1034.2
+018000 01  XXINFO.                                                      IC1034.2
+018100     02 FILLER                       PIC X(19)  VALUE             IC1034.2
+018200            "*** INFORMATION ***".                                IC1034.2
+018300     02 INFO-TEXT.                                                IC1034.2
+018400       04 FILLER                     PIC X(8)   VALUE SPACE.      IC1034.2
+018500       04 XXCOMPUTED                 PIC X(20).                   IC1034.2
+018600       04 FILLER                     PIC X(5)   VALUE SPACE.      IC1034.2
+018700       04 XXCORRECT                  PIC X(20).                   IC1034.2
+018800     02 INF-ANSI-REFERENCE           PIC X(48).                   IC1034.2
+018900 01  HYPHEN-LINE.                                                 IC1034.2
+019000     02 FILLER  PIC IS X VALUE IS SPACE.                          IC1034.2
+019100     02 FILLER  PIC IS X(65)    VALUE IS "************************IC1034.2
+019200-    "*****************************************".                 IC1034.2
+019300     02 FILLER  PIC IS X(54)    VALUE IS "************************IC1034.2
+019400-    "******************************".                            IC1034.2
+019500 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC1034.2
+019600     "IC103A".                                                    IC1034.2
+019700 PROCEDURE DIVISION.                                              IC1034.2
+019800 CCVS1 SECTION.                                                   IC1034.2
+019900 OPEN-FILES.                                                      IC1034.2
+020000     OPEN     OUTPUT PRINT-FILE.                                  IC1034.2
+020100     MOVE CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.   IC1034.2
+020200     MOVE    SPACE TO TEST-RESULTS.                               IC1034.2
+020300     PERFORM  HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.             IC1034.2
+020400     GO TO CCVS1-EXIT.                                            IC1034.2
+020500 CLOSE-FILES.                                                     IC1034.2
+020600     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC1034.2
+020700 TERMINATE-CCVS.                                                  IC1034.2
+020800S    EXIT PROGRAM.                                                IC1034.2
+020900STERMINATE-CALL.                                                  IC1034.2
+021000     STOP     RUN.                                                IC1034.2
+021100 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         IC1034.2
+021200 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           IC1034.2
+021300 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          IC1034.2
+021400 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      IC1034.2
+021500     MOVE "****TEST DELETED****" TO RE-MARK.                      IC1034.2
+021600 PRINT-DETAIL.                                                    IC1034.2
+021700     IF REC-CT NOT EQUAL TO ZERO                                  IC1034.2
+021800             MOVE "." TO PARDOT-X                                 IC1034.2
+021900             MOVE REC-CT TO DOTVALUE.                             IC1034.2
+022000     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      IC1034.2
+022100     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               IC1034.2
+022200        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 IC1034.2
+022300          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 IC1034.2
+022400     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC1034.2
+022500     MOVE SPACE TO CORRECT-X.                                     IC1034.2
+022600     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC1034.2
+022700     MOVE     SPACE TO RE-MARK.                                   IC1034.2
+022800 HEAD-ROUTINE.                                                    IC1034.2
+022900     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC1034.2
+023000     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC1034.2
+023100     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC1034.2
+023200     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC1034.2
+023300 COLUMN-NAMES-ROUTINE.                                            IC1034.2
+023400     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1034.2
+023500     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1034.2
+023600     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC1034.2
+023700 END-ROUTINE.                                                     IC1034.2
+023800     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.IC1034.2
+023900 END-RTN-EXIT.                                                    IC1034.2
+024000     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1034.2
+024100 END-ROUTINE-1.                                                   IC1034.2
+024200      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      IC1034.2
+024300      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               IC1034.2
+024400      ADD PASS-COUNTER TO ERROR-HOLD.                             IC1034.2
+024500*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC1034.2
+024600      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC1034.2
+024700      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC1034.2
+024800      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC1034.2
+024900      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC1034.2
+025000  END-ROUTINE-12.                                                 IC1034.2
+025100      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC1034.2
+025200     IF       ERROR-COUNTER IS EQUAL TO ZERO                      IC1034.2
+025300         MOVE "NO " TO ERROR-TOTAL                                IC1034.2
+025400         ELSE                                                     IC1034.2
+025500         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC1034.2
+025600     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC1034.2
+025700     PERFORM WRITE-LINE.                                          IC1034.2
+025800 END-ROUTINE-13.                                                  IC1034.2
+025900     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC1034.2
+026000         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC1034.2
+026100         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC1034.2
+026200     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC1034.2
+026300     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1034.2
+026400      IF   INSPECT-COUNTER EQUAL TO ZERO                          IC1034.2
+026500          MOVE "NO " TO ERROR-TOTAL                               IC1034.2
+026600      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   IC1034.2
+026700      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            IC1034.2
+026800      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          IC1034.2
+026900     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1034.2
+027000 WRITE-LINE.                                                      IC1034.2
+027100     ADD 1 TO RECORD-COUNT.                                       IC1034.2
+027200Y    IF RECORD-COUNT GREATER 50                                   IC1034.2
+027300Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC1034.2
+027400Y        MOVE SPACE TO DUMMY-RECORD                               IC1034.2
+027500Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC1034.2
+027600Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC1034.2
+027700Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC1034.2
+027800Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC1034.2
+027900Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC1034.2
+028000Y        MOVE ZERO TO RECORD-COUNT.                               IC1034.2
+028100     PERFORM WRT-LN.                                              IC1034.2
+028200 WRT-LN.                                                          IC1034.2
+028300     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC1034.2
+028400     MOVE SPACE TO DUMMY-RECORD.                                  IC1034.2
+028500 BLANK-LINE-PRINT.                                                IC1034.2
+028600     PERFORM WRT-LN.                                              IC1034.2
+028700 FAIL-ROUTINE.                                                    IC1034.2
+028800     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC1034.2
+028900     IF     CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.IC1034.2
+029000     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC1034.2
+029100     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC1034.2
+029200     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1034.2
+029300     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC1034.2
+029400     GO TO  FAIL-ROUTINE-EX.                                      IC1034.2
+029500 FAIL-ROUTINE-WRITE.                                              IC1034.2
+029600     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC1034.2
+029700     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC1034.2
+029800     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC1034.2
+029900     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC1034.2
+030000 FAIL-ROUTINE-EX. EXIT.                                           IC1034.2
+030100 BAIL-OUT.                                                        IC1034.2
+030200     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC1034.2
+030300     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC1034.2
+030400 BAIL-OUT-WRITE.                                                  IC1034.2
+030500     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC1034.2
+030600     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC1034.2
+030700     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1034.2
+030800     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC1034.2
+030900 BAIL-OUT-EX. EXIT.                                               IC1034.2
+031000 CCVS1-EXIT.                                                      IC1034.2
+031100     EXIT.                                                        IC1034.2
+031200 SECT-IC103-0001 SECTION.                                         IC1034.2
+031300*        THE TESTS IN THIS SECTION CALL A SUBPROGRAM WHICH        IC1034.2
+031400*    HAS FOUR EXIT PROGRAM STATEMENTS.  A DIFFERENT EXIT IS       IC1034.2
+031500*    TAKEN FOR EACH CALL TO THE SUBPROGRAM.                       IC1034.2
+031600 EXIT-INIT.                                                       IC1034.2
+031700     MOVE "MULTIPLE EXIT PROGRM" TO FEATURE.                      IC1034.2
+031800 EXIT-INIT-001.                                                   IC1034.2
+031900     MOVE 0 TO MAIN-DN2.                                          IC1034.2
+032000     MOVE 1 TO MAIN-DN1.                                          IC1034.2
+032100 EXIT-TEST-001.                                                   IC1034.2
+032200     CALL "IC105A" USING MAIN-DN1 MAIN-DN2.                       IC1034.2
+032300     IF MAIN-DN2 EQUAL TO 1                                       IC1034.2
+032400         PERFORM PASS                                             IC1034.2
+032500         GO TO EXIT-WRITE-001.                                    IC1034.2
+032600 EXIT-FAIL-001.                                                   IC1034.2
+032700     MOVE MAIN-DN1 TO CORRECT-18V0.                               IC1034.2
+032800     MOVE MAIN-DN2 TO COMPUTED-18V0.                              IC1034.2
+032900     MOVE "FIRST EXIT FROM SUBPROGRAM" TO RE-MARK.                IC1034.2
+033000     PERFORM FAIL.                                                IC1034.2
+033100 EXIT-WRITE-001.                                                  IC1034.2
+033200     MOVE "EXIT-TEST-01" TO PAR-NAME.                             IC1034.2
+033300     PERFORM PRINT-DETAIL.                                        IC1034.2
+033400 EXIT-INIT-002.                                                   IC1034.2
+033500     MOVE 0 TO MAIN-DN2.                                          IC1034.2
+033600     MOVE 2 TO MAIN-DN1.                                          IC1034.2
+033700 EXIT-TEST-002.                                                   IC1034.2
+033800     CALL "IC105A" USING MAIN-DN1 MAIN-DN2.                       IC1034.2
+033900     IF MAIN-DN2 EQUAL TO 2                                       IC1034.2
+034000          PERFORM PASS                                            IC1034.2
+034100          GO TO EXIT-WRITE-002.                                   IC1034.2
+034200 EXIT-FAIL-002.                                                   IC1034.2
+034300     MOVE MAIN-DN1 TO CORRECT-18V0.                               IC1034.2
+034400     MOVE MAIN-DN2 TO COMPUTED-18V0.                              IC1034.2
+034500     MOVE "SECOND EXIT FROM SUBPROGRAM" TO RE-MARK.               IC1034.2
+034600     PERFORM FAIL.                                                IC1034.2
+034700 EXIT-WRITE-002.                                                  IC1034.2
+034800     MOVE "EXIT-TEST-02" TO PAR-NAME.                             IC1034.2
+034900     PERFORM PRINT-DETAIL.                                        IC1034.2
+035000 EXIT-INIT-003.                                                   IC1034.2
+035100     MOVE 0 TO MAIN-DN2.                                          IC1034.2
+035200     MOVE 3 TO MAIN-DN1.                                          IC1034.2
+035300 EXIT-TEST-003.                                                   IC1034.2
+035400     CALL "IC105A" USING MAIN-DN1 MAIN-DN2.                       IC1034.2
+035500     IF MAIN-DN2 NOT EQUAL TO 3                                   IC1034.2
+035600         GO TO EXIT-FAIL-003.                                     IC1034.2
+035700     PERFORM PASS.                                                IC1034.2
+035800     GO TO EXIT-WRITE-003.                                        IC1034.2
+035900 EXIT-FAIL-003.                                                   IC1034.2
+036000     MOVE MAIN-DN1 TO CORRECT-18V0.                               IC1034.2
+036100     MOVE MAIN-DN2 TO COMPUTED-18V0.                              IC1034.2
+036200     MOVE "THIRD EXIT FROM SUBPROGRAM" TO RE-MARK.                IC1034.2
+036300     PERFORM FAIL.                                                IC1034.2
+036400 EXIT-WRITE-003.                                                  IC1034.2
+036500     MOVE "EXIT-TEST-03" TO PAR-NAME.                             IC1034.2
+036600     PERFORM PRINT-DETAIL.                                        IC1034.2
+036700 EXIT-INIT-004.                                                   IC1034.2
+036800     MOVE 0 TO MAIN-DN2.                                          IC1034.2
+036900     MOVE 4 TO MAIN-DN1.                                          IC1034.2
+037000 EXIT-TEST-004.                                                   IC1034.2
+037100     CALL "IC105A" USING MAIN-DN1 MAIN-DN2.                       IC1034.2
+037200     IF MAIN-DN2 NOT EQUAL TO 4                                   IC1034.2
+037300         GO TO EXIT-FAIL-004.                                     IC1034.2
+037400     PERFORM PASS.                                                IC1034.2
+037500     GO TO EXIT-WRITE-004.                                        IC1034.2
+037600 EXIT-FAIL-004.                                                   IC1034.2
+037700     MOVE MAIN-DN1 TO CORRECT-18V0.                               IC1034.2
+037800     MOVE MAIN-DN2 TO COMPUTED-18V0.                              IC1034.2
+037900     MOVE "FOURTH EXIT FROM SUBPROGRAM" TO RE-MARK.               IC1034.2
+038000     PERFORM FAIL.                                                IC1034.2
+038100 EXIT-WRITE-004.                                                  IC1034.2
+038200     MOVE "EXIT-TEST-04" TO PAR-NAME.                             IC1034.2
+038300     PERFORM PRINT-DETAIL.                                        IC1034.2
+038400     GO TO SECT-IC103-0002.                                       IC1034.2
+038500 EXIT-DELETES.                                                    IC1034.2
+038600*        IF THE SUBPROGRAM WITH MULTIPLE EXIT PROGRAM             IC1034.2
+038700*    STATEMENTS CANNOT BE INCLUDED IN THE RUN UNIT                IC1034.2
+038800*    DELETE PARAGRAPH EXIT-INIT-001 THRU EXIT-WRITE-004.          IC1034.2
+038900     PERFORM DE-LETE.                                             IC1034.2
+039000     MOVE "EXIT-TEST-01" TO PAR-NAME.                             IC1034.2
+039100     PERFORM PRINT-DETAIL.                                        IC1034.2
+039200     PERFORM DE-LETE.                                             IC1034.2
+039300     MOVE "EXIT-TEST-02" TO PAR-NAME.                             IC1034.2
+039400     PERFORM PRINT-DETAIL.                                        IC1034.2
+039500     PERFORM DE-LETE.                                             IC1034.2
+039600     MOVE "EXIT-TEST-03" TO PAR-NAME.                             IC1034.2
+039700     PERFORM PRINT-DETAIL.                                        IC1034.2
+039800     PERFORM DE-LETE.                                             IC1034.2
+039900     MOVE "EXIT-TEST-04" TO PAR-NAME.                             IC1034.2
+040000     PERFORM PRINT-DETAIL.                                        IC1034.2
+040100 SECT-IC103-0002 SECTION.                                         IC1034.2
+040200*        THIS SECTION CALLS A SUBPROGRAM WITH TWO GROUP ITEMS     IC1034.2
+040300*    AND ONE ELEMENTARY ITEM IN THE USING PHRASE. THE ITEM        IC1034.2
+040400*    DESCRIPTIONS ARE DIFFERENT IN THE SUBPROGRAM FROM THE MAIN   IC1034.2
+040500*    PROGRAM, BUT THE NUMBER OF CHARACTERS IS IDENTICAL.          IC1034.2
+040600*    REFERENCE  X3.23-1974,  SECTION XII, 3.1 AND 3.2.            IC1034.2
+040700 CALL-INIT-06.                                                    IC1034.2
+040800     MOVE "CALL-TEST-06" TO PAR-NAME.                             IC1034.2
+040900     MOVE 0 TO NUMER-FIELD  ELEM-77 NUM-ITEM.                     IC1034.2
+041000     MOVE SPACE TO ALPHA-NUM-FIELD ALPHA-FIELD ALPHA-EDITED.      IC1034.2
+041100     MOVE "CALL USING DN SERIES" TO FEATURE.                      IC1034.2
+041200 CALL-TEST-06.                                                    IC1034.2
+041300     CALL "IC104A" USING GROUP-01 ELEM-77 GROUP-02.               IC1034.2
+041400     GO TO CALL-TEST-06-01.                                       IC1034.2
+041500 CALL-DELETE-06.                                                  IC1034.2
+041600     PERFORM DE-LETE.                                             IC1034.2
+041700     PERFORM PRINT-DETAIL.                                        IC1034.2
+041800     GO TO CCVS-EXIT.                                             IC1034.2
+041900*       IF IC104 CANNOT BE INCLUDED IN THE RUN UNIT               IC1034.2
+042000*    DELETE THE PARAGRAPH CALL-TEST-06.                           IC1034.2
+042100 CALL-TEST-06-01.                                                 IC1034.2
+042200     IF ALPHA-NUM-FIELD NOT EQUAL TO "IC104"                      IC1034.2
+042300         GO TO CALL-FAIL-06-01.                                   IC1034.2
+042400     PERFORM PASS.                                                IC1034.2
+042500     GO TO CALL-WRITE-06-01.                                      IC1034.2
+042600 CALL-FAIL-06-01.                                                 IC1034.2
+042700     MOVE ALPHA-NUM-FIELD TO COMPUTED-A.                          IC1034.2
+042800     MOVE "IC104" TO CORRECT-A.                                   IC1034.2
+042900     PERFORM FAIL.                                                IC1034.2
+043000     MOVE "ALPHANUMERIC PARAMETER" TO RE-MARK.                    IC1034.2
+043100 CALL-WRITE-06-01.                                                IC1034.2
+043200     ADD 1 TO REC-CT.                                             IC1034.2
+043300     PERFORM PRINT-DETAIL.                                        IC1034.2
+043400 CALL-TEST-06-02.                                                 IC1034.2
+043500     IF NUMER-FIELD EQUAL TO 25                                   IC1034.2
+043600         PERFORM PASS                                             IC1034.2
+043700         GO TO CALL-WRITE-06-02.                                  IC1034.2
+043800 CALL-FAIL-06-02.                                                 IC1034.2
+043900     PERFORM FAIL.                                                IC1034.2
+044000     MOVE NUMER-FIELD TO COMPUTED-18V0.                           IC1034.2
+044100     MOVE 25 TO CORRECT-18V0.                                     IC1034.2
+044200     MOVE "NUMERIC DISPLAY PARAMETER" TO RE-MARK.                 IC1034.2
+044300 CALL-WRITE-06-02.                                                IC1034.2
+044400     ADD 1 TO REC-CT.                                             IC1034.2
+044500     PERFORM PRINT-DETAIL.                                        IC1034.2
+044600 CALL-TEST-06-03.                                                 IC1034.2
+044700     IF ALPHA-FIELD EQUAL TO "YES"                                IC1034.2
+044800         PERFORM PASS                                             IC1034.2
+044900         GO TO CALL-WRITE-06-03.                                  IC1034.2
+045000 CALL-FAIL-06-03.                                                 IC1034.2
+045100     PERFORM FAIL.                                                IC1034.2
+045200     MOVE ALPHA-FIELD TO COMPUTED-A.                              IC1034.2
+045300     MOVE "YES" TO CORRECT-A.                                     IC1034.2
+045400     MOVE "ALPHABETIC PARAMETER" TO RE-MARK.                      IC1034.2
+045500 CALL-WRITE-06-03.                                                IC1034.2
+045600     ADD 1 TO REC-CT.                                             IC1034.2
+045700     PERFORM PRINT-DETAIL.                                        IC1034.2
+045800 CALL-TEST-06-04.                                                 IC1034.2
+045900     IF ELEM-77 EQUAL TO 0.7654                                   IC1034.2
+046000         PERFORM PASS                                             IC1034.2
+046100         GO TO CALL-WRITE-06-04.                                  IC1034.2
+046200 CALL-FAIL-06-04.                                                 IC1034.2
+046300     PERFORM FAIL.                                                IC1034.2
+046400     MOVE ELEM-77 TO COMPUTED-4V14.                               IC1034.2
+046500     MOVE 0.7654 TO CORRECT-4V14.                                 IC1034.2
+046600     MOVE "COMPUTATIONAL PARAMETER" TO RE-MARK.                   IC1034.2
+046700 CALL-WRITE-06-04.                                                IC1034.2
+046800     ADD 1 TO REC-CT.                                             IC1034.2
+046900     PERFORM PRINT-DETAIL.                                        IC1034.2
+047000 CALL-TEST-06-05.                                                 IC1034.2
+047100     IF NUM-ITEM EQUAL TO 25                                      IC1034.2
+047200         PERFORM PASS                                             IC1034.2
+047300         GO TO CALL-WRITE-06-05.                                  IC1034.2
+047400 CALL-FAIL-06-05.                                                 IC1034.2
+047500     PERFORM FAIL.                                                IC1034.2
+047600     MOVE NUM-ITEM TO COMPUTED-18V0.                              IC1034.2
+047700     MOVE 25 TO CORRECT-18V0.                                     IC1034.2
+047800     MOVE "SIGNED NUMERIC PARAMETER" TO RE-MARK.                  IC1034.2
+047900 CALL-WRITE-06-05.                                                IC1034.2
+048000     ADD 1 TO REC-CT.                                             IC1034.2
+048100     PERFORM PRINT-DETAIL.                                        IC1034.2
+048200 CALL-TEST-06-06.                                                 IC1034.2
+048300     IF ALPHA-EDITED EQUAL TO "AB C0D"                            IC1034.2
+048400         PERFORM PASS                                             IC1034.2
+048500         GO TO CALL-WRITE-06-06.                                  IC1034.2
+048600 CALL-FAIL-06-06.                                                 IC1034.2
+048700     PERFORM FAIL.                                                IC1034.2
+048800     MOVE ALPHA-EDITED TO COMPUTED-A.                             IC1034.2
+048900     MOVE "AB C0D" TO CORRECT-A.                                  IC1034.2
+049000     MOVE "ALPHANUMERIC EDITED" TO RE-MARK.                       IC1034.2
+049100 CALL-WRITE-06-06.                                                IC1034.2
+049200     ADD 1 TO REC-CT.                                             IC1034.2
+049300     PERFORM PRINT-DETAIL.                                        IC1034.2
+049400     GO TO CCVS-EXIT.                                             IC1034.2
+049500 CCVS-EXIT SECTION.                                               IC1034.2
+049600 CCVS-999999.                                                     IC1034.2
+049700     GO TO CLOSE-FILES.                                           IC1034.2

--- a/src/IC104A.CBL
+++ b/src/IC104A.CBL
@@ -1,0 +1,71 @@
+000100 IDENTIFICATION DIVISION.                                         IC1044.2
+000200 PROGRAM-ID.                                                      IC1044.2
+000300     IC104A.                                                      IC1044.2
+000400****************************************************************  IC1044.2
+000500*                                                              *  IC1044.2
+000600*    VALIDATION FOR:-                                          *  IC1044.2
+000700*                                                              *  IC1044.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1044.2
+000900*                                                              *  IC1044.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1044.2
+001100*                                                              *  IC1044.2
+001200****************************************************************  IC1044.2
+001300*                                                              *  IC1044.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC1044.2
+001500*                                                              *  IC1044.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC1044.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC1044.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC1044.2
+001900*                                                              *  IC1044.2
+002000****************************************************************  IC1044.2
+002100*        THE SUBPROGRAM IC104 HAS THREE OPERANDS IN THE           IC1044.2
+002200*    USING PHRASE OF THE PROCEDURE DIVISION HEADER.  TWO          IC1044.2
+002300*    OPERANDS ARE 01 GROUP ITEMS AND THE THIRD OPERAND IS         IC1044.2
+002400*    AN ELEMENTARY 77 ITEM.  THE DATA DESCRIPTIONS OF THESE       IC1044.2
+002500*    OPERANDS IN THE LINKAGE SECTION ARE NOT THE SAME AS THE      IC1044.2
+002600*    DATA DESCRIPTIONS IN THE WORKING-STORAGE SECTION OF THE      IC1044.2
+002700*    CALLING PROGRAM, BUT AN EQUAL NUMBER OF CHARACTER            IC1044.2
+002800*    POSITIONS ARE DEFINED.  THE CALLING PROGRAM IS IC103.        IC1044.2
+002900 ENVIRONMENT DIVISION.                                            IC1044.2
+003000 CONFIGURATION SECTION.                                           IC1044.2
+003100 SOURCE-COMPUTER.                                                 IC1044.2
+003200     XXXXX082.                                                    IC1044.2
+003300 OBJECT-COMPUTER.                                                 IC1044.2
+003400     XXXXX083.                                                    IC1044.2
+003500 INPUT-OUTPUT SECTION.                                            IC1044.2
+003600 FILE-CONTROL.                                                    IC1044.2
+003700     SELECT PRINT-FILE ASSIGN TO                                  IC1044.2
+003800     XXXXX055.                                                    IC1044.2
+003900 DATA DIVISION.                                                   IC1044.2
+004000 FILE SECTION.                                                    IC1044.2
+004100 FD  PRINT-FILE.                                                  IC1044.2
+004200 01  PRINT-REC PICTURE X(120).                                    IC1044.2
+004300 01  DUMMY-RECORD PICTURE X(120).                                 IC1044.2
+004400 WORKING-STORAGE SECTION.                                         IC1044.2
+004500 01  CONSTANT-VALUES.                                             IC1044.2
+004600     02  AN-CONSTANT PIC X(5) VALUE "IC104".                      IC1044.2
+004700     02  NUM-CONSTANT PIC 99V9999 VALUE 0.7654.                   IC1044.2
+004800 LINKAGE SECTION.                                                 IC1044.2
+004900 01  GRP-01.                                                      IC1044.2
+005000     02  AN-FIELD PICTURE X(5).                                   IC1044.2
+005100     02  NUM-DISPLAY PIC 99.                                      IC1044.2
+005200     02  GRP-LEVEL.                                               IC1044.2
+005300         03  A-FIELD PICTURE A(3).                                IC1044.2
+005400 77  ELEM-01 PIC  V9(4) COMPUTATIONAL.                            IC1044.2
+005500 01  GRP-02.                                                      IC1044.2
+005600     02  GRP-03.                                                  IC1044.2
+005700         03  NUM-ITEM PICTURE S99.                                IC1044.2
+005800         03  EDITED-FIELD  PIC XXBX0X.                            IC1044.2
+005900 PROCEDURE DIVISION USING GRP-01 ELEM-01 GRP-02.                  IC1044.2
+006000 SECT-IC104-0001 SECTION.                                         IC1044.2
+006100*        THIS SECTION SETS THE PARAMETER FIELDS REFERRED TO       IC1044.2
+006200*    IN THE USING PHRASE AND DEFINED IN THE LINKAGE SECTION.      IC1044.2
+006300 CALL-TEST-06.                                                    IC1044.2
+006400     MOVE AN-CONSTANT TO AN-FIELD.                                IC1044.2
+006500     ADD 25 TO NUM-DISPLAY.                                       IC1044.2
+006600     MOVE "YES" TO A-FIELD.                                       IC1044.2
+006700     MOVE NUM-CONSTANT TO ELEM-01.                                IC1044.2
+006800     MOVE NUM-DISPLAY TO NUM-ITEM.                                IC1044.2
+006900     MOVE "ABCD" TO EDITED-FIELD.                                 IC1044.2
+007000 CALL-EXIT-06.                                                    IC1044.2
+007100     EXIT PROGRAM.                                                IC1044.2

--- a/src/IC106A.CBL
+++ b/src/IC106A.CBL
@@ -1,0 +1,530 @@
+000100 IDENTIFICATION DIVISION.                                         IC1064.2
+000200 PROGRAM-ID.                                                      IC1064.2
+000300     IC106A.                                                      IC1064.2
+000400****************************************************************  IC1064.2
+000500*                                                              *  IC1064.2
+000600*    VALIDATION FOR:-                                          *  IC1064.2
+000700*                                                              *  IC1064.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1064.2
+000900*                                                              *  IC1064.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1064.2
+001100*                                                              *  IC1064.2
+001200****************************************************************  IC1064.2
+001300*                                                              *  IC1064.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC1064.2
+001500*                                                              *  IC1064.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC1064.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC1064.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC1064.2
+001900*                                                              *  IC1064.2
+002000****************************************************************  IC1064.2
+002100*        THIS PROGRAM CALLS A SUBPROGRAM WITH TWO TABLES          IC1064.2
+002200*    AND AN INDEX DATA ITEM REFERENCED IN THE USING PHRASE        IC1064.2
+002300*    OF THE CALL STATEMENT.  BOTH OF THE TABLES CONTAIN AN        IC1064.2
+002400*    INDEXED BY CLAUSE.                                           IC1064.2
+002500*        THE TESTS IN THIS PROGRAM VERIFY THAT                    IC1064.2
+002600*           (1)  THE INDICES IN THE MAIN PROGRAM AND THE          IC1064.2
+002700*                SUBPROGRAM ARE SEPARATE,                         IC1064.2
+002800*           (2)  AN INDEX DATA ITEM SET IN A MAIN PROGRAM         IC1064.2
+002900*                CAN BE USED TO SET AN INDEX IN A SUBPROGRAM,     IC1064.2
+003000*           (3)  TABLES CAN BE SHARED BETWEEN A MAIN PROGRAM      IC1064.2
+003100*                AND A SUBPROGRAM.                                IC1064.2
+003200*        THE SUBPROGRAM IC107 IS CALLED BY THIS PROGRAM.          IC1064.2
+003300 ENVIRONMENT DIVISION.                                            IC1064.2
+003400 CONFIGURATION SECTION.                                           IC1064.2
+003500 SOURCE-COMPUTER.                                                 IC1064.2
+003600     XXXXX082.                                                    IC1064.2
+003700 OBJECT-COMPUTER.                                                 IC1064.2
+003800     XXXXX083.                                                    IC1064.2
+003900 INPUT-OUTPUT SECTION.                                            IC1064.2
+004000 FILE-CONTROL.                                                    IC1064.2
+004100     SELECT PRINT-FILE ASSIGN TO                                  IC1064.2
+004200     XXXXX055.                                                    IC1064.2
+004300 DATA DIVISION.                                                   IC1064.2
+004400 FILE SECTION.                                                    IC1064.2
+004500 FD  PRINT-FILE.                                                  IC1064.2
+004600 01  PRINT-REC PICTURE X(120).                                    IC1064.2
+004700 01  DUMMY-RECORD PICTURE X(120).                                 IC1064.2
+004800 WORKING-STORAGE SECTION.                                         IC1064.2
+004900 77  IDN1  USAGE IS INDEX.                                        IC1064.2
+005000 77  INDEX-VALUE PIC 999.                                         IC1064.2
+005100 01  TABLE-1.                                                     IC1064.2
+005200     02  DN1 PICTURE X                                            IC1064.2
+005300             OCCURS 10 TIMES                                      IC1064.2
+005400             INDEXED BY IN1.                                      IC1064.2
+005500 01  TABLE-2.                                                     IC1064.2
+005600     02  DN2 PICTURE X                                            IC1064.2
+005700             OCCURS 10 TIMES                                      IC1064.2
+005800             INDEXED BY IN2.                                      IC1064.2
+005900 01  TEST-RESULTS.                                                IC1064.2
+006000     02 FILLER                   PIC X      VALUE SPACE.          IC1064.2
+006100     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC1064.2
+006200     02 FILLER                   PIC X      VALUE SPACE.          IC1064.2
+006300     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC1064.2
+006400     02 FILLER                   PIC X      VALUE SPACE.          IC1064.2
+006500     02  PAR-NAME.                                                IC1064.2
+006600       03 FILLER                 PIC X(19)  VALUE SPACE.          IC1064.2
+006700       03  PARDOT-X              PIC X      VALUE SPACE.          IC1064.2
+006800       03 DOTVALUE               PIC 99     VALUE ZERO.           IC1064.2
+006900     02 FILLER                   PIC X(8)   VALUE SPACE.          IC1064.2
+007000     02 RE-MARK                  PIC X(61).                       IC1064.2
+007100 01  TEST-COMPUTED.                                               IC1064.2
+007200     02 FILLER                   PIC X(30)  VALUE SPACE.          IC1064.2
+007300     02 FILLER                   PIC X(17)  VALUE                 IC1064.2
+007400            "       COMPUTED=".                                   IC1064.2
+007500     02 COMPUTED-X.                                               IC1064.2
+007600     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC1064.2
+007700     03 COMPUTED-N               REDEFINES COMPUTED-A             IC1064.2
+007800                                 PIC -9(9).9(9).                  IC1064.2
+007900     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC1064.2
+008000     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC1064.2
+008100     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC1064.2
+008200     03       CM-18V0 REDEFINES COMPUTED-A.                       IC1064.2
+008300         04 COMPUTED-18V0                    PIC -9(18).          IC1064.2
+008400         04 FILLER                           PIC X.               IC1064.2
+008500     03 FILLER PIC X(50) VALUE SPACE.                             IC1064.2
+008600 01  TEST-CORRECT.                                                IC1064.2
+008700     02 FILLER PIC X(30) VALUE SPACE.                             IC1064.2
+008800     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC1064.2
+008900     02 CORRECT-X.                                                IC1064.2
+009000     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC1064.2
+009100     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC1064.2
+009200     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC1064.2
+009300     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC1064.2
+009400     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC1064.2
+009500     03      CR-18V0 REDEFINES CORRECT-A.                         IC1064.2
+009600         04 CORRECT-18V0                     PIC -9(18).          IC1064.2
+009700         04 FILLER                           PIC X.               IC1064.2
+009800     03 FILLER PIC X(2) VALUE SPACE.                              IC1064.2
+009900     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC1064.2
+010000 01  CCVS-C-1.                                                    IC1064.2
+010100     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC1064.2
+010200-    "SS  PARAGRAPH-NAME                                          IC1064.2
+010300-    "       REMARKS".                                            IC1064.2
+010400     02 FILLER                     PIC X(20)    VALUE SPACE.      IC1064.2
+010500 01  CCVS-C-2.                                                    IC1064.2
+010600     02 FILLER                     PIC X        VALUE SPACE.      IC1064.2
+010700     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC1064.2
+010800     02 FILLER                     PIC X(15)    VALUE SPACE.      IC1064.2
+010900     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC1064.2
+011000     02 FILLER                     PIC X(94)    VALUE SPACE.      IC1064.2
+011100 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC1064.2
+011200 01  REC-CT                        PIC 99       VALUE ZERO.       IC1064.2
+011300 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC1064.2
+011400 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC1064.2
+011500 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC1064.2
+011600 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC1064.2
+011700 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC1064.2
+011800 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC1064.2
+011900 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC1064.2
+012000 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC1064.2
+012100 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC1064.2
+012200 01  CCVS-H-1.                                                    IC1064.2
+012300     02  FILLER                    PIC X(39)    VALUE SPACES.     IC1064.2
+012400     02  FILLER                    PIC X(42)    VALUE             IC1064.2
+012500     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC1064.2
+012600     02  FILLER                    PIC X(39)    VALUE SPACES.     IC1064.2
+012700 01  CCVS-H-2A.                                                   IC1064.2
+012800   02  FILLER                        PIC X(40)  VALUE SPACE.      IC1064.2
+012900   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC1064.2
+013000   02  FILLER                        PIC XXXX   VALUE             IC1064.2
+013100     "4.2 ".                                                      IC1064.2
+013200   02  FILLER                        PIC X(28)  VALUE             IC1064.2
+013300            " COPY - NOT FOR DISTRIBUTION".                       IC1064.2
+013400   02  FILLER                        PIC X(41)  VALUE SPACE.      IC1064.2
+013500                                                                  IC1064.2
+013600 01  CCVS-H-2B.                                                   IC1064.2
+013700   02  FILLER                        PIC X(15)  VALUE             IC1064.2
+013800            "TEST RESULT OF ".                                    IC1064.2
+013900   02  TEST-ID                       PIC X(9).                    IC1064.2
+014000   02  FILLER                        PIC X(4)   VALUE             IC1064.2
+014100            " IN ".                                               IC1064.2
+014200   02  FILLER                        PIC X(12)  VALUE             IC1064.2
+014300     " HIGH       ".                                              IC1064.2
+014400   02  FILLER                        PIC X(22)  VALUE             IC1064.2
+014500            " LEVEL VALIDATION FOR ".                             IC1064.2
+014600   02  FILLER                        PIC X(58)  VALUE             IC1064.2
+014700     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1064.2
+014800 01  CCVS-H-3.                                                    IC1064.2
+014900     02  FILLER                      PIC X(34)  VALUE             IC1064.2
+015000            " FOR OFFICIAL USE ONLY    ".                         IC1064.2
+015100     02  FILLER                      PIC X(58)  VALUE             IC1064.2
+015200     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1064.2
+015300     02  FILLER                      PIC X(28)  VALUE             IC1064.2
+015400            "  COPYRIGHT   1985 ".                                IC1064.2
+015500 01  CCVS-E-1.                                                    IC1064.2
+015600     02 FILLER                       PIC X(52)  VALUE SPACE.      IC1064.2
+015700     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC1064.2
+015800     02 ID-AGAIN                     PIC X(9).                    IC1064.2
+015900     02 FILLER                       PIC X(45)  VALUE SPACES.     IC1064.2
+016000 01  CCVS-E-2.                                                    IC1064.2
+016100     02  FILLER                      PIC X(31)  VALUE SPACE.      IC1064.2
+016200     02  FILLER                      PIC X(21)  VALUE SPACE.      IC1064.2
+016300     02 CCVS-E-2-2.                                               IC1064.2
+016400         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC1064.2
+016500         03 FILLER                   PIC X      VALUE SPACE.      IC1064.2
+016600         03 ENDER-DESC               PIC X(44)  VALUE             IC1064.2
+016700            "ERRORS ENCOUNTERED".                                 IC1064.2
+016800 01  CCVS-E-3.                                                    IC1064.2
+016900     02  FILLER                      PIC X(22)  VALUE             IC1064.2
+017000            " FOR OFFICIAL USE ONLY".                             IC1064.2
+017100     02  FILLER                      PIC X(12)  VALUE SPACE.      IC1064.2
+017200     02  FILLER                      PIC X(58)  VALUE             IC1064.2
+017300     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1064.2
+017400     02  FILLER                      PIC X(13)  VALUE SPACE.      IC1064.2
+017500     02 FILLER                       PIC X(15)  VALUE             IC1064.2
+017600             " COPYRIGHT 1985".                                   IC1064.2
+017700 01  CCVS-E-4.                                                    IC1064.2
+017800     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC1064.2
+017900     02 FILLER                       PIC X(4)   VALUE " OF ".     IC1064.2
+018000     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC1064.2
+018100     02 FILLER                       PIC X(40)  VALUE             IC1064.2
+018200      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC1064.2
+018300 01  XXINFO.                                                      IC1064.2
+018400     02 FILLER                       PIC X(19)  VALUE             IC1064.2
+018500            "*** INFORMATION ***".                                IC1064.2
+018600     02 INFO-TEXT.                                                IC1064.2
+018700       04 FILLER                     PIC X(8)   VALUE SPACE.      IC1064.2
+018800       04 XXCOMPUTED                 PIC X(20).                   IC1064.2
+018900       04 FILLER                     PIC X(5)   VALUE SPACE.      IC1064.2
+019000       04 XXCORRECT                  PIC X(20).                   IC1064.2
+019100     02 INF-ANSI-REFERENCE           PIC X(48).                   IC1064.2
+019200 01  HYPHEN-LINE.                                                 IC1064.2
+019300     02 FILLER  PIC IS X VALUE IS SPACE.                          IC1064.2
+019400     02 FILLER  PIC IS X(65)    VALUE IS "************************IC1064.2
+019500-    "*****************************************".                 IC1064.2
+019600     02 FILLER  PIC IS X(54)    VALUE IS "************************IC1064.2
+019700-    "******************************".                            IC1064.2
+019800 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC1064.2
+019900     "IC106A".                                                    IC1064.2
+020000 PROCEDURE DIVISION.                                              IC1064.2
+020100 CCVS1 SECTION.                                                   IC1064.2
+020200 OPEN-FILES.                                                      IC1064.2
+020300     OPEN     OUTPUT PRINT-FILE.                                  IC1064.2
+020400     MOVE CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.   IC1064.2
+020500     MOVE    SPACE TO TEST-RESULTS.                               IC1064.2
+020600     PERFORM  HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.             IC1064.2
+020700     GO TO CCVS1-EXIT.                                            IC1064.2
+020800 CLOSE-FILES.                                                     IC1064.2
+020900     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC1064.2
+021000 TERMINATE-CCVS.                                                  IC1064.2
+021100S    EXIT PROGRAM.                                                IC1064.2
+021200STERMINATE-CALL.                                                  IC1064.2
+021300     STOP     RUN.                                                IC1064.2
+021400 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         IC1064.2
+021500 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           IC1064.2
+021600 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          IC1064.2
+021700 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      IC1064.2
+021800     MOVE "****TEST DELETED****" TO RE-MARK.                      IC1064.2
+021900 PRINT-DETAIL.                                                    IC1064.2
+022000     IF REC-CT NOT EQUAL TO ZERO                                  IC1064.2
+022100             MOVE "." TO PARDOT-X                                 IC1064.2
+022200             MOVE REC-CT TO DOTVALUE.                             IC1064.2
+022300     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      IC1064.2
+022400     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               IC1064.2
+022500        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 IC1064.2
+022600          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 IC1064.2
+022700     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC1064.2
+022800     MOVE SPACE TO CORRECT-X.                                     IC1064.2
+022900     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC1064.2
+023000     MOVE     SPACE TO RE-MARK.                                   IC1064.2
+023100 HEAD-ROUTINE.                                                    IC1064.2
+023200     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC1064.2
+023300     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC1064.2
+023400     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC1064.2
+023500     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC1064.2
+023600 COLUMN-NAMES-ROUTINE.                                            IC1064.2
+023700     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1064.2
+023800     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1064.2
+023900     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC1064.2
+024000 END-ROUTINE.                                                     IC1064.2
+024100     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.IC1064.2
+024200 END-RTN-EXIT.                                                    IC1064.2
+024300     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1064.2
+024400 END-ROUTINE-1.                                                   IC1064.2
+024500      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      IC1064.2
+024600      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               IC1064.2
+024700      ADD PASS-COUNTER TO ERROR-HOLD.                             IC1064.2
+024800*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC1064.2
+024900      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC1064.2
+025000      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC1064.2
+025100      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC1064.2
+025200      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC1064.2
+025300  END-ROUTINE-12.                                                 IC1064.2
+025400      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC1064.2
+025500     IF       ERROR-COUNTER IS EQUAL TO ZERO                      IC1064.2
+025600         MOVE "NO " TO ERROR-TOTAL                                IC1064.2
+025700         ELSE                                                     IC1064.2
+025800         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC1064.2
+025900     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC1064.2
+026000     PERFORM WRITE-LINE.                                          IC1064.2
+026100 END-ROUTINE-13.                                                  IC1064.2
+026200     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC1064.2
+026300         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC1064.2
+026400         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC1064.2
+026500     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC1064.2
+026600     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1064.2
+026700      IF   INSPECT-COUNTER EQUAL TO ZERO                          IC1064.2
+026800          MOVE "NO " TO ERROR-TOTAL                               IC1064.2
+026900      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   IC1064.2
+027000      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            IC1064.2
+027100      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          IC1064.2
+027200     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1064.2
+027300 WRITE-LINE.                                                      IC1064.2
+027400     ADD 1 TO RECORD-COUNT.                                       IC1064.2
+027500Y    IF RECORD-COUNT GREATER 50                                   IC1064.2
+027600Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC1064.2
+027700Y        MOVE SPACE TO DUMMY-RECORD                               IC1064.2
+027800Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC1064.2
+027900Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC1064.2
+028000Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC1064.2
+028100Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC1064.2
+028200Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC1064.2
+028300Y        MOVE ZERO TO RECORD-COUNT.                               IC1064.2
+028400     PERFORM WRT-LN.                                              IC1064.2
+028500 WRT-LN.                                                          IC1064.2
+028600     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC1064.2
+028700     MOVE SPACE TO DUMMY-RECORD.                                  IC1064.2
+028800 BLANK-LINE-PRINT.                                                IC1064.2
+028900     PERFORM WRT-LN.                                              IC1064.2
+029000 FAIL-ROUTINE.                                                    IC1064.2
+029100     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC1064.2
+029200     IF     CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.IC1064.2
+029300     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC1064.2
+029400     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC1064.2
+029500     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1064.2
+029600     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC1064.2
+029700     GO TO  FAIL-ROUTINE-EX.                                      IC1064.2
+029800 FAIL-ROUTINE-WRITE.                                              IC1064.2
+029900     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC1064.2
+030000     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC1064.2
+030100     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC1064.2
+030200     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC1064.2
+030300 FAIL-ROUTINE-EX. EXIT.                                           IC1064.2
+030400 BAIL-OUT.                                                        IC1064.2
+030500     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC1064.2
+030600     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC1064.2
+030700 BAIL-OUT-WRITE.                                                  IC1064.2
+030800     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC1064.2
+030900     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC1064.2
+031000     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1064.2
+031100     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC1064.2
+031200 BAIL-OUT-EX. EXIT.                                               IC1064.2
+031300 CCVS1-EXIT.                                                      IC1064.2
+031400     EXIT.                                                        IC1064.2
+031500 SEC-IC106-0001 SECTION.                                          IC1064.2
+031600 LINK-TEST-INITIALIZE.                                            IC1064.2
+031700     MOVE "ABCDEFGHIJ" TO TABLE-1.                                IC1064.2
+031800     MOVE SPACE TO TABLE-2.                                       IC1064.2
+031900     SET IN1 TO 6.                                                IC1064.2
+032000     SET IDN1 TO IN1.                                             IC1064.2
+032100     CALL "IC107A" USING IDN1 TABLE-1 TABLE-2.                    IC1064.2
+032200 LINK-TEST-01.                                                    IC1064.2
+032300     MOVE "SEPARATE INDEXES" TO FEATURE.                          IC1064.2
+032400     MOVE "LINK-TEST-01" TO PAR-NAME.                             IC1064.2
+032500*        THIS TEST VERIFIES THAT IN1 HAS NOT BEEN AFFECTED        IC1064.2
+032600*    BY THE USE OF AN INDEX FOR TABLE-1 IN THE SUBPROGRAM.        IC1064.2
+032700 LINK-TEST-01-01.                                                 IC1064.2
+032800     MOVE 1 TO REC-CT.                                            IC1064.2
+032900     IF DN1 (IN1) EQUAL TO "F"                                    IC1064.2
+033000         PERFORM PASS                                             IC1064.2
+033100         GO TO LINK-WRITE-01-01.                                  IC1064.2
+033200 LINK-FAIL-01-01.                                                 IC1064.2
+033300     PERFORM FAIL.                                                IC1064.2
+033400     MOVE DN1 (IN1) TO COMPUTED-A.                                IC1064.2
+033500     MOVE "F" TO CORRECT-A.                                       IC1064.2
+033600     MOVE "TABLE INDEX DESTROYED" TO RE-MARK.                     IC1064.2
+033700 LINK-WRITE-01-01.                                                IC1064.2
+033800     PERFORM PRINT-DETAIL.                                        IC1064.2
+033900 LINK-TEST-01-02.                                                 IC1064.2
+034000     ADD 1 TO REC-CT.                                             IC1064.2
+034100     IF IN1 EQUAL TO 6                                            IC1064.2
+034200         PERFORM PASS                                             IC1064.2
+034300         GO TO LINK-WRITE-01-02.                                  IC1064.2
+034400 LINK-FAIL-01-02.                                                 IC1064.2
+034500     PERFORM FAIL.                                                IC1064.2
+034600     MOVE 6 TO CORRECT-18V0.                                      IC1064.2
+034700     SET      INDEX-VALUE TO IN1.                                 IC1064.2
+034800     MOVE     INDEX-VALUE TO COMPUTED-18V0.                       IC1064.2
+034900     MOVE "TABLE INDEX DESTROYED" TO RE-MARK.                     IC1064.2
+035000 LINK-WRITE-01-02.                                                IC1064.2
+035100     PERFORM PRINT-DETAIL.                                        IC1064.2
+035200 LINK-TEST-02.                                                    IC1064.2
+035300     MOVE "INDEX DATA ITEM" TO FEATURE.                           IC1064.2
+035400     MOVE "LINK-TEST-02" TO PAR-NAME.                             IC1064.2
+035500*        THIS TEST VERIFIES THAT THE INDEX DATA ITEM WAS          IC1064.2
+035600*    USED IN THE SUBPROGRAM TO SET AN INDEX AND AN INDEX          IC1064.2
+035700*    DATA ITEM.                                                   IC1064.2
+035800 LINK-TEST-02-01.                                                 IC1064.2
+035900     MOVE 1 TO REC-CT.                                            IC1064.2
+036000     IF DN2 (7) IS EQUAL TO "G"                                   IC1064.2
+036100         PERFORM PASS                                             IC1064.2
+036200         GO TO LINK-WRITE-02-01.                                  IC1064.2
+036300 LINK-FAIL-02-01.                                                 IC1064.2
+036400     PERFORM FAIL.                                                IC1064.2
+036500     MOVE DN2 (7) TO COMPUTED-A.                                  IC1064.2
+036600     MOVE "G" TO CORRECT-A.                                       IC1064.2
+036700     MOVE "INDEX DATA ITEM IN LINKAGE SEC" TO RE-MARK.            IC1064.2
+036800 LINK-WRITE-02-01.                                                IC1064.2
+036900     PERFORM PRINT-DETAIL.                                        IC1064.2
+037000 LINK-TEST-02-02.                                                 IC1064.2
+037100     ADD 1 TO REC-CT.                                             IC1064.2
+037200     IF DN2 (6) EQUAL TO "F"                                      IC1064.2
+037300         PERFORM PASS                                             IC1064.2
+037400         GO TO LINK-WRITE-02-02.                                  IC1064.2
+037500 LINK-FAIL-02-02.                                                 IC1064.2
+037600     PERFORM FAIL.                                                IC1064.2
+037700     MOVE DN2 (6) TO COMPUTED-A.                                  IC1064.2
+037800     MOVE "F" TO CORRECT-A.                                       IC1064.2
+037900     MOVE "INDEX DATA ITEM IN LINKAGE SEC" TO RE-MARK.            IC1064.2
+038000 LINK-WRITE-02-02.                                                IC1064.2
+038100     PERFORM PRINT-DETAIL.                                        IC1064.2
+038200 LINK-TEST-03.                                                    IC1064.2
+038300     MOVE "SUBPROGRAM INDEX" TO FEATURE.                          IC1064.2
+038400     MOVE "LINK-TEST-03" TO PAR-NAME.                             IC1064.2
+038500*        THIS TEST  VERIFIES THAT A SUBPROGRAM INDEX FOR          IC1064.2
+038600*    A TABLE DEFINED IN THE LINKAGE SECTION OF IC107 CAN BE       IC1064.2
+038700*    USED TO REFERENCE THE TABLE.                                 IC1064.2
+038800 LINK-TEST-03-01.                                                 IC1064.2
+038900     MOVE 1 TO REC-CT.                                            IC1064.2
+039000     IF DN2 (1) EQUAL TO "A"                                      IC1064.2
+039100         PERFORM PASS                                             IC1064.2
+039200         GO TO LINK-WRITE-03-01.                                  IC1064.2
+039300 LINK-FAIL-03-01.                                                 IC1064.2
+039400     PERFORM FAIL.                                                IC1064.2
+039500     MOVE DN2 (1) TO COMPUTED-A.                                  IC1064.2
+039600     MOVE "A" TO CORRECT-A.                                       IC1064.2
+039700     MOVE "INDEX IN LINKAGE SECTION" TO RE-MARK.                  IC1064.2
+039800 LINK-WRITE-03-01.                                                IC1064.2
+039900     PERFORM PRINT-DETAIL.                                        IC1064.2
+040000 LINK-TEST-03-02.                                                 IC1064.2
+040100     ADD 1 TO REC-CT.                                             IC1064.2
+040200     IF DN2 (2) EQUAL TO "B"                                      IC1064.2
+040300         PERFORM PASS                                             IC1064.2
+040400         GO TO LINK-WRITE-03-02.                                  IC1064.2
+040500 LINK-FAIL-03-02.                                                 IC1064.2
+040600     PERFORM FAIL.                                                IC1064.2
+040700     MOVE DN2 (2) TO COMPUTED-A.                                  IC1064.2
+040800     MOVE "B" TO CORRECT-A.                                       IC1064.2
+040900     MOVE "INDEX IN LINKAGE SECTION" TO RE-MARK.                  IC1064.2
+041000 LINK-WRITE-03-02.                                                IC1064.2
+041100     PERFORM PRINT-DETAIL.                                        IC1064.2
+041200 LINK-TEST-04.                                                    IC1064.2
+041300     MOVE "INDEX DATA ITEM" TO FEATURE.                           IC1064.2
+041400     MOVE "LINK-TEST-04" TO PAR-NAME.                             IC1064.2
+041500*        THIS TEST VERIFIES THAT AN INDEX DATA ITEM               IC1064.2
+041600*    SET IN THE SUBPROGRAM CAN BE USED IN THE MAIN PROGRAM.       IC1064.2
+041700 LINK-TEST-04-01.                                                 IC1064.2
+041800     MOVE 1 TO REC-CT.                                            IC1064.2
+041900     SET IN1 TO IDN1.                                             IC1064.2
+042000     IF IN1 EQUAL TO 3                                            IC1064.2
+042100         PERFORM PASS                                             IC1064.2
+042200         GO TO LINK-WRITE-04-01.                                  IC1064.2
+042300 LINK-FAIL-04-01.                                                 IC1064.2
+042400     MOVE  3  TO CORRECT-18V0.                                    IC1064.2
+042500     SET      INDEX-VALUE TO IN1.                                 IC1064.2
+042600     MOVE     INDEX-VALUE TO COMPUTED-18V0.                       IC1064.2
+042700     PERFORM FAIL.                                                IC1064.2
+042800     MOVE "INDEX DATA ITEM SET IN SUBPROG" TO RE-MARK.            IC1064.2
+042900 LINK-WRITE-04-01.                                                IC1064.2
+043000     PERFORM PRINT-DETAIL.                                        IC1064.2
+043100 LINK-TEST-04-02.                                                 IC1064.2
+043200     ADD 1 TO REC-CT.                                             IC1064.2
+043300     IF DN1 (IN1) EQUAL TO "C"                                    IC1064.2
+043400         PERFORM PASS                                             IC1064.2
+043500         GO TO LINK-WRITE-04-02.                                  IC1064.2
+043600 LINK-FAIL-04-02.                                                 IC1064.2
+043700     MOVE "C" TO CORRECT-A.                                       IC1064.2
+043800     MOVE DN1 (IN1) TO COMPUTED-A.                                IC1064.2
+043900     MOVE "INDEX DATA ITEM SET IN SUBPROG" TO RE-MARK.            IC1064.2
+044000     PERFORM FAIL.                                                IC1064.2
+044100 LINK-WRITE-04-02.                                                IC1064.2
+044200     PERFORM PRINT-DETAIL.                                        IC1064.2
+044300 LINK-TEST-04-03.                                                 IC1064.2
+044400     ADD 1 TO REC-CT.                                             IC1064.2
+044500     IF DN2 (3) EQUAL TO "C"                                      IC1064.2
+044600         PERFORM PASS                                             IC1064.2
+044700         GO TO LINK-WRITE-04-03.                                  IC1064.2
+044800 LINK-FAIL-04-03.                                                 IC1064.2
+044900     PERFORM FAIL.                                                IC1064.2
+045000     MOVE "C" TO CORRECT-A.                                       IC1064.2
+045100     MOVE DN2 (3) TO COMPUTED-A.                                  IC1064.2
+045200     MOVE "INDEX DATA ITEM SET IN SUBPROG" TO RE-MARK.            IC1064.2
+045300 LINK-WRITE-04-03.                                                IC1064.2
+045400     PERFORM PRINT-DETAIL.                                        IC1064.2
+045500 LINK-TEST-05.                                                    IC1064.2
+045600     MOVE "TABLE REFERENCES" TO FEATURE.                          IC1064.2
+045700     MOVE "LINK-TEST-05" TO PAR-NAME.                             IC1064.2
+045800*        THIS TEST VERIFIES THAT DATA WAS MOVED FROM THE          IC1064.2
+045900*    FIRST TABLE IN USING PHRASE TO SECOND TABLE IN USING PHRASE. IC1064.2
+046000*    DATA WAS MOVED IN SUBPROGRAM IC107.                          IC1064.2
+046100 LINK-TEST-05-01.                                                 IC1064.2
+046200     MOVE 1 TO REC-CT.                                            IC1064.2
+046300     IF DN2 (4) EQUAL TO "D"                                      IC1064.2
+046400         PERFORM PASS                                             IC1064.2
+046500         GO TO LINK-WRITE-05-01.                                  IC1064.2
+046600 LINK-FAIL-05-01.                                                 IC1064.2
+046700     PERFORM FAIL.                                                IC1064.2
+046800     MOVE DN2 (4) TO COMPUTED-A.                                  IC1064.2
+046900     MOVE "D" TO CORRECT-A.                                       IC1064.2
+047000     MOVE "TABLES DEFINED IN LINKAGE SEC" TO RE-MARK.             IC1064.2
+047100 LINK-WRITE-05-01.                                                IC1064.2
+047200     PERFORM PRINT-DETAIL.                                        IC1064.2
+047300 LINK-TEST-05-02.                                                 IC1064.2
+047400     ADD 1 TO REC-CT.                                             IC1064.2
+047500     IF DN2 (5) EQUAL TO "E"                                      IC1064.2
+047600         PERFORM PASS                                             IC1064.2
+047700         GO TO LINK-WRITE-05-02.                                  IC1064.2
+047800 LINK-FAIL-05-02.                                                 IC1064.2
+047900     PERFORM FAIL.                                                IC1064.2
+048000     MOVE DN2 (5) TO COMPUTED-A.                                  IC1064.2
+048100     MOVE "E" TO CORRECT-A.                                       IC1064.2
+048200     MOVE "TABLES DEFINED IN LINKAGE SEC" TO RE-MARK.             IC1064.2
+048300 LINK-WRITE-05-02.                                                IC1064.2
+048400     PERFORM PRINT-DETAIL.                                        IC1064.2
+048500 LINK-TEST-06.                                                    IC1064.2
+048600     MOVE "REDEFINED ITEM" TO FEATURE.                            IC1064.2
+048700     MOVE "LINK-TEST-06" TO PAR-NAME.                             IC1064.2
+048800*        THIS TEST VERIFIES THAT DATA WAS MOVED TO                IC1064.2
+048900*    A REDEFINED ITEM IN THE LINKAGE SECTION OF IC107.            IC1064.2
+049000 LINK-TEST-06-01.                                                 IC1064.2
+049100     MOVE 1 TO REC-CT.                                            IC1064.2
+049200     IF DN2 (8) EQUAL TO "X"                                      IC1064.2
+049300         PERFORM PASS                                             IC1064.2
+049400         GO TO LINK-WRITE-06-01.                                  IC1064.2
+049500 LINK-FAIL-06-01.                                                 IC1064.2
+049600     PERFORM FAIL.                                                IC1064.2
+049700     MOVE DN2 (8) TO COMPUTED-A.                                  IC1064.2
+049800     MOVE "X" TO CORRECT-A.                                       IC1064.2
+049900     MOVE "REDEFINED ITEM IN LINKAGE SEC" TO RE-MARK.             IC1064.2
+050000 LINK-WRITE-06-01.                                                IC1064.2
+050100     PERFORM PRINT-DETAIL.                                        IC1064.2
+050200 LINK-TEST-06-02.                                                 IC1064.2
+050300     ADD 1 TO REC-CT.                                             IC1064.2
+050400     IF DN2 (9) EQUAL TO "Y"                                      IC1064.2
+050500         PERFORM PASS                                             IC1064.2
+050600         GO TO LINK-WRITE-06-02.                                  IC1064.2
+050700 LINK-FAIL-06-02.                                                 IC1064.2
+050800     PERFORM FAIL.                                                IC1064.2
+050900     MOVE DN2 (9) TO COMPUTED-A.                                  IC1064.2
+051000     MOVE "Y" TO CORRECT-A.                                       IC1064.2
+051100     MOVE "REDEFINED ITEM IN LINKAGE SEC" TO RE-MARK.             IC1064.2
+051200 LINK-WRITE-06-02.                                                IC1064.2
+051300     PERFORM PRINT-DETAIL.                                        IC1064.2
+051400 LINK-TEST-06-03.                                                 IC1064.2
+051500     ADD 1 TO REC-CT.                                             IC1064.2
+051600     IF DN2 (10) EQUAL TO "Z"                                     IC1064.2
+051700         PERFORM PASS                                             IC1064.2
+051800         GO TO LINK-WRITE-06-03.                                  IC1064.2
+051900 LINK-FAIL-06-03.                                                 IC1064.2
+052000     PERFORM FAIL.                                                IC1064.2
+052100     MOVE DN2 (10) TO COMPUTED-A.                                 IC1064.2
+052200     MOVE "Z" TO CORRECT-A.                                       IC1064.2
+052300     MOVE "REDEFINED ITEM IN LINKAGE SEC" TO RE-MARK.             IC1064.2
+052400 LINK-WRITE-06-03.                                                IC1064.2
+052500     PERFORM PRINT-DETAIL.                                        IC1064.2
+052600 LINK-END-ROUTINE.                                                IC1064.2
+052700     GO TO CCVS-EXIT.                                             IC1064.2
+052800 CCVS-EXIT SECTION.                                               IC1064.2
+052900 CCVS-999999.                                                     IC1064.2
+053000     GO TO CLOSE-FILES.                                           IC1064.2

--- a/src/IC108A.CBL
+++ b/src/IC108A.CBL
@@ -1,0 +1,444 @@
+000100 IDENTIFICATION DIVISION.                                         IC1084.2
+000200 PROGRAM-ID.                                                      IC1084.2
+000300     IC108A.                                                      IC1084.2
+000400****************************************************************  IC1084.2
+000500*                                                              *  IC1084.2
+000600*    VALIDATION FOR:-                                          *  IC1084.2
+000700*                                                              *  IC1084.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1084.2
+000900*                                                              *  IC1084.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1084.2
+001100*                                                              *  IC1084.2
+001200****************************************************************  IC1084.2
+001300*                                                              *  IC1084.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC1084.2
+001500*                                                              *  IC1084.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC1084.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC1084.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC1084.2
+001900*                                                              *  IC1084.2
+002000****************************************************************  IC1084.2
+002100*        THE PROGRAM IC108 IS THE MAIN PROGRAM WHICH STARTS       IC1084.2
+002200*    A SEQUENCE OF CALLS TO THE SUBPROGRAMS IC109A,IC110A AND     IC1084.2
+002300*    IC111A.  PARAMETERS ARE SET IN EACH OF THESE SUBPROGRAMS     IC1084.2
+002400*    AND CHECKED WHEN CONTROL IS RETURNED TO THE MAIN PROGRAM.    IC1084.2
+002500 ENVIRONMENT DIVISION.                                            IC1084.2
+002600 CONFIGURATION SECTION.                                           IC1084.2
+002700 SOURCE-COMPUTER.                                                 IC1084.2
+002800     XXXXX082.                                                    IC1084.2
+002900 OBJECT-COMPUTER.                                                 IC1084.2
+003000     XXXXX083.                                                    IC1084.2
+003100 INPUT-OUTPUT SECTION.                                            IC1084.2
+003200 FILE-CONTROL.                                                    IC1084.2
+003300     SELECT PRINT-FILE ASSIGN TO                                  IC1084.2
+003400     XXXXX055.                                                    IC1084.2
+003500 DATA DIVISION.                                                   IC1084.2
+003600 FILE SECTION.                                                    IC1084.2
+003700 FD  PRINT-FILE.                                                  IC1084.2
+003800 01  PRINT-REC PICTURE X(120).                                    IC1084.2
+003900 01  DUMMY-RECORD PICTURE X(120).                                 IC1084.2
+004000 WORKING-STORAGE SECTION.                                         IC1084.2
+004100 01  GRP-01.                                                      IC1084.2
+004200     02  SUB-CALLED.                                              IC1084.2
+004300         03  DN1 PICTURE X(6).                                    IC1084.2
+004400         03  DN2 PICTURE X(6).                                    IC1084.2
+004500         03  DN3 PICTURE X(6).                                    IC1084.2
+004600     02  TIMES-CALLED.                                            IC1084.2
+004700         03  DN4 PICTURE S999    VALUE ZERO.                      IC1084.2
+004800         03  DN5 PICTURE S999    VALUE ZERO.                      IC1084.2
+004900         03  DN6 PICTURE S999    VALUE ZERO.                      IC1084.2
+005000     02  SPECIAL-FLAGS.                                           IC1084.2
+005100         03  DN7 PICTURE X.                                       IC1084.2
+005200         03  DN8 PICTURE X.                                       IC1084.2
+005300         03  DN9 PICTURE X.                                       IC1084.2
+005400 01  TEST-RESULTS.                                                IC1084.2
+005500     02 FILLER                   PIC X      VALUE SPACE.          IC1084.2
+005600     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC1084.2
+005700     02 FILLER                   PIC X      VALUE SPACE.          IC1084.2
+005800     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC1084.2
+005900     02 FILLER                   PIC X      VALUE SPACE.          IC1084.2
+006000     02  PAR-NAME.                                                IC1084.2
+006100       03 FILLER                 PIC X(19)  VALUE SPACE.          IC1084.2
+006200       03  PARDOT-X              PIC X      VALUE SPACE.          IC1084.2
+006300       03 DOTVALUE               PIC 99     VALUE ZERO.           IC1084.2
+006400     02 FILLER                   PIC X(8)   VALUE SPACE.          IC1084.2
+006500     02 RE-MARK                  PIC X(61).                       IC1084.2
+006600 01  TEST-COMPUTED.                                               IC1084.2
+006700     02 FILLER                   PIC X(30)  VALUE SPACE.          IC1084.2
+006800     02 FILLER                   PIC X(17)  VALUE                 IC1084.2
+006900            "       COMPUTED=".                                   IC1084.2
+007000     02 COMPUTED-X.                                               IC1084.2
+007100     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC1084.2
+007200     03 COMPUTED-N               REDEFINES COMPUTED-A             IC1084.2
+007300                                 PIC -9(9).9(9).                  IC1084.2
+007400     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC1084.2
+007500     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC1084.2
+007600     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC1084.2
+007700     03       CM-18V0 REDEFINES COMPUTED-A.                       IC1084.2
+007800         04 COMPUTED-18V0                    PIC -9(18).          IC1084.2
+007900         04 FILLER                           PIC X.               IC1084.2
+008000     03 FILLER PIC X(50) VALUE SPACE.                             IC1084.2
+008100 01  TEST-CORRECT.                                                IC1084.2
+008200     02 FILLER PIC X(30) VALUE SPACE.                             IC1084.2
+008300     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC1084.2
+008400     02 CORRECT-X.                                                IC1084.2
+008500     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC1084.2
+008600     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC1084.2
+008700     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC1084.2
+008800     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC1084.2
+008900     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC1084.2
+009000     03      CR-18V0 REDEFINES CORRECT-A.                         IC1084.2
+009100         04 CORRECT-18V0                     PIC -9(18).          IC1084.2
+009200         04 FILLER                           PIC X.               IC1084.2
+009300     03 FILLER PIC X(2) VALUE SPACE.                              IC1084.2
+009400     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC1084.2
+009500 01  CCVS-C-1.                                                    IC1084.2
+009600     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC1084.2
+009700-    "SS  PARAGRAPH-NAME                                          IC1084.2
+009800-    "       REMARKS".                                            IC1084.2
+009900     02 FILLER                     PIC X(20)    VALUE SPACE.      IC1084.2
+010000 01  CCVS-C-2.                                                    IC1084.2
+010100     02 FILLER                     PIC X        VALUE SPACE.      IC1084.2
+010200     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC1084.2
+010300     02 FILLER                     PIC X(15)    VALUE SPACE.      IC1084.2
+010400     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC1084.2
+010500     02 FILLER                     PIC X(94)    VALUE SPACE.      IC1084.2
+010600 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC1084.2
+010700 01  REC-CT                        PIC 99       VALUE ZERO.       IC1084.2
+010800 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC1084.2
+010900 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC1084.2
+011000 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC1084.2
+011100 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC1084.2
+011200 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC1084.2
+011300 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC1084.2
+011400 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC1084.2
+011500 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC1084.2
+011600 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC1084.2
+011700 01  CCVS-H-1.                                                    IC1084.2
+011800     02  FILLER                    PIC X(39)    VALUE SPACES.     IC1084.2
+011900     02  FILLER                    PIC X(42)    VALUE             IC1084.2
+012000     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC1084.2
+012100     02  FILLER                    PIC X(39)    VALUE SPACES.     IC1084.2
+012200 01  CCVS-H-2A.                                                   IC1084.2
+012300   02  FILLER                        PIC X(40)  VALUE SPACE.      IC1084.2
+012400   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC1084.2
+012500   02  FILLER                        PIC XXXX   VALUE             IC1084.2
+012600     "4.2 ".                                                      IC1084.2
+012700   02  FILLER                        PIC X(28)  VALUE             IC1084.2
+012800            " COPY - NOT FOR DISTRIBUTION".                       IC1084.2
+012900   02  FILLER                        PIC X(41)  VALUE SPACE.      IC1084.2
+013000                                                                  IC1084.2
+013100 01  CCVS-H-2B.                                                   IC1084.2
+013200   02  FILLER                        PIC X(15)  VALUE             IC1084.2
+013300            "TEST RESULT OF ".                                    IC1084.2
+013400   02  TEST-ID                       PIC X(9).                    IC1084.2
+013500   02  FILLER                        PIC X(4)   VALUE             IC1084.2
+013600            " IN ".                                               IC1084.2
+013700   02  FILLER                        PIC X(12)  VALUE             IC1084.2
+013800     " HIGH       ".                                              IC1084.2
+013900   02  FILLER                        PIC X(22)  VALUE             IC1084.2
+014000            " LEVEL VALIDATION FOR ".                             IC1084.2
+014100   02  FILLER                        PIC X(58)  VALUE             IC1084.2
+014200     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1084.2
+014300 01  CCVS-H-3.                                                    IC1084.2
+014400     02  FILLER                      PIC X(34)  VALUE             IC1084.2
+014500            " FOR OFFICIAL USE ONLY    ".                         IC1084.2
+014600     02  FILLER                      PIC X(58)  VALUE             IC1084.2
+014700     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1084.2
+014800     02  FILLER                      PIC X(28)  VALUE             IC1084.2
+014900            "  COPYRIGHT   1985 ".                                IC1084.2
+015000 01  CCVS-E-1.                                                    IC1084.2
+015100     02 FILLER                       PIC X(52)  VALUE SPACE.      IC1084.2
+015200     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC1084.2
+015300     02 ID-AGAIN                     PIC X(9).                    IC1084.2
+015400     02 FILLER                       PIC X(45)  VALUE SPACES.     IC1084.2
+015500 01  CCVS-E-2.                                                    IC1084.2
+015600     02  FILLER                      PIC X(31)  VALUE SPACE.      IC1084.2
+015700     02  FILLER                      PIC X(21)  VALUE SPACE.      IC1084.2
+015800     02 CCVS-E-2-2.                                               IC1084.2
+015900         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC1084.2
+016000         03 FILLER                   PIC X      VALUE SPACE.      IC1084.2
+016100         03 ENDER-DESC               PIC X(44)  VALUE             IC1084.2
+016200            "ERRORS ENCOUNTERED".                                 IC1084.2
+016300 01  CCVS-E-3.                                                    IC1084.2
+016400     02  FILLER                      PIC X(22)  VALUE             IC1084.2
+016500            " FOR OFFICIAL USE ONLY".                             IC1084.2
+016600     02  FILLER                      PIC X(12)  VALUE SPACE.      IC1084.2
+016700     02  FILLER                      PIC X(58)  VALUE             IC1084.2
+016800     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1084.2
+016900     02  FILLER                      PIC X(13)  VALUE SPACE.      IC1084.2
+017000     02 FILLER                       PIC X(15)  VALUE             IC1084.2
+017100             " COPYRIGHT 1985".                                   IC1084.2
+017200 01  CCVS-E-4.                                                    IC1084.2
+017300     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC1084.2
+017400     02 FILLER                       PIC X(4)   VALUE " OF ".     IC1084.2
+017500     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC1084.2
+017600     02 FILLER                       PIC X(40)  VALUE             IC1084.2
+017700      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC1084.2
+017800 01  XXINFO.                                                      IC1084.2
+017900     02 FILLER                       PIC X(19)  VALUE             IC1084.2
+018000            "*** INFORMATION ***".                                IC1084.2
+018100     02 INFO-TEXT.                                                IC1084.2
+018200       04 FILLER                     PIC X(8)   VALUE SPACE.      IC1084.2
+018300       04 XXCOMPUTED                 PIC X(20).                   IC1084.2
+018400       04 FILLER                     PIC X(5)   VALUE SPACE.      IC1084.2
+018500       04 XXCORRECT                  PIC X(20).                   IC1084.2
+018600     02 INF-ANSI-REFERENCE           PIC X(48).                   IC1084.2
+018700 01  HYPHEN-LINE.                                                 IC1084.2
+018800     02 FILLER  PIC IS X VALUE IS SPACE.                          IC1084.2
+018900     02 FILLER  PIC IS X(65)    VALUE IS "************************IC1084.2
+019000-    "*****************************************".                 IC1084.2
+019100     02 FILLER  PIC IS X(54)    VALUE IS "************************IC1084.2
+019200-    "******************************".                            IC1084.2
+019300 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC1084.2
+019400     "IC108A".                                                    IC1084.2
+019500 PROCEDURE DIVISION.                                              IC1084.2
+019600 CCVS1 SECTION.                                                   IC1084.2
+019700 OPEN-FILES.                                                      IC1084.2
+019800     OPEN     OUTPUT PRINT-FILE.                                  IC1084.2
+019900     MOVE CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.   IC1084.2
+020000     MOVE    SPACE TO TEST-RESULTS.                               IC1084.2
+020100     PERFORM  HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.             IC1084.2
+020200     GO TO CCVS1-EXIT.                                            IC1084.2
+020300 CLOSE-FILES.                                                     IC1084.2
+020400     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC1084.2
+020500 TERMINATE-CCVS.                                                  IC1084.2
+020600S    EXIT PROGRAM.                                                IC1084.2
+020700STERMINATE-CALL.                                                  IC1084.2
+020800     STOP     RUN.                                                IC1084.2
+020900 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         IC1084.2
+021000 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           IC1084.2
+021100 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          IC1084.2
+021200 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      IC1084.2
+021300     MOVE "****TEST DELETED****" TO RE-MARK.                      IC1084.2
+021400 PRINT-DETAIL.                                                    IC1084.2
+021500     IF REC-CT NOT EQUAL TO ZERO                                  IC1084.2
+021600             MOVE "." TO PARDOT-X                                 IC1084.2
+021700             MOVE REC-CT TO DOTVALUE.                             IC1084.2
+021800     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      IC1084.2
+021900     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               IC1084.2
+022000        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 IC1084.2
+022100          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 IC1084.2
+022200     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC1084.2
+022300     MOVE SPACE TO CORRECT-X.                                     IC1084.2
+022400     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC1084.2
+022500     MOVE     SPACE TO RE-MARK.                                   IC1084.2
+022600 HEAD-ROUTINE.                                                    IC1084.2
+022700     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC1084.2
+022800     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC1084.2
+022900     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC1084.2
+023000     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC1084.2
+023100 COLUMN-NAMES-ROUTINE.                                            IC1084.2
+023200     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1084.2
+023300     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1084.2
+023400     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC1084.2
+023500 END-ROUTINE.                                                     IC1084.2
+023600     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.IC1084.2
+023700 END-RTN-EXIT.                                                    IC1084.2
+023800     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1084.2
+023900 END-ROUTINE-1.                                                   IC1084.2
+024000      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      IC1084.2
+024100      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               IC1084.2
+024200      ADD PASS-COUNTER TO ERROR-HOLD.                             IC1084.2
+024300*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC1084.2
+024400      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC1084.2
+024500      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC1084.2
+024600      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC1084.2
+024700      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC1084.2
+024800  END-ROUTINE-12.                                                 IC1084.2
+024900      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC1084.2
+025000     IF       ERROR-COUNTER IS EQUAL TO ZERO                      IC1084.2
+025100         MOVE "NO " TO ERROR-TOTAL                                IC1084.2
+025200         ELSE                                                     IC1084.2
+025300         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC1084.2
+025400     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC1084.2
+025500     PERFORM WRITE-LINE.                                          IC1084.2
+025600 END-ROUTINE-13.                                                  IC1084.2
+025700     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC1084.2
+025800         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC1084.2
+025900         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC1084.2
+026000     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC1084.2
+026100     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1084.2
+026200      IF   INSPECT-COUNTER EQUAL TO ZERO                          IC1084.2
+026300          MOVE "NO " TO ERROR-TOTAL                               IC1084.2
+026400      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   IC1084.2
+026500      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            IC1084.2
+026600      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          IC1084.2
+026700     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1084.2
+026800 WRITE-LINE.                                                      IC1084.2
+026900     ADD 1 TO RECORD-COUNT.                                       IC1084.2
+027000Y    IF RECORD-COUNT GREATER 50                                   IC1084.2
+027100Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC1084.2
+027200Y        MOVE SPACE TO DUMMY-RECORD                               IC1084.2
+027300Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC1084.2
+027400Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC1084.2
+027500Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC1084.2
+027600Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC1084.2
+027700Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC1084.2
+027800Y        MOVE ZERO TO RECORD-COUNT.                               IC1084.2
+027900     PERFORM WRT-LN.                                              IC1084.2
+028000 WRT-LN.                                                          IC1084.2
+028100     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC1084.2
+028200     MOVE SPACE TO DUMMY-RECORD.                                  IC1084.2
+028300 BLANK-LINE-PRINT.                                                IC1084.2
+028400     PERFORM WRT-LN.                                              IC1084.2
+028500 FAIL-ROUTINE.                                                    IC1084.2
+028600     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC1084.2
+028700     IF     CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.IC1084.2
+028800     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC1084.2
+028900     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC1084.2
+029000     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1084.2
+029100     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC1084.2
+029200     GO TO  FAIL-ROUTINE-EX.                                      IC1084.2
+029300 FAIL-ROUTINE-WRITE.                                              IC1084.2
+029400     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC1084.2
+029500     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC1084.2
+029600     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC1084.2
+029700     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC1084.2
+029800 FAIL-ROUTINE-EX. EXIT.                                           IC1084.2
+029900 BAIL-OUT.                                                        IC1084.2
+030000     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC1084.2
+030100     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC1084.2
+030200 BAIL-OUT-WRITE.                                                  IC1084.2
+030300     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC1084.2
+030400     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC1084.2
+030500     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1084.2
+030600     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC1084.2
+030700 BAIL-OUT-EX. EXIT.                                               IC1084.2
+030800 CCVS1-EXIT.                                                      IC1084.2
+030900     EXIT.                                                        IC1084.2
+031000 SECTION-IC108-0001 SECTION.                                      IC1084.2
+031100 CALL-PARAGRAPH.                                                  IC1084.2
+031200*        THE CALL IN THIS PARAGRAPH STARTS THE SEQUENCE           IC1084.2
+031300*    OF CALLS TO THE SUBPROGRAMS.                                 IC1084.2
+031400     MOVE SPACE TO SUB-CALLED.                                    IC1084.2
+031500     MOVE SPACE TO SPECIAL-FLAGS.                                 IC1084.2
+031600     CALL "IC109A" USING GRP-01.                                  IC1084.2
+031700 CALL-TEST-07.                                                    IC1084.2
+031800*        THIS TEST VERIFIES THAT EACH SUBPROGRAM WAS CALLED       IC1084.2
+031900*    BY CHECKING THE PARAMETER FIELDS SET IN EACH SUBPROGRAM.     IC1084.2
+032000     MOVE "SUBPROGRAM CALLS" TO FEATURE.                          IC1084.2
+032100     MOVE "CALL-TEST-07" TO PAR-NAME.                             IC1084.2
+032200 CALL-TEST-07-01.                                                 IC1084.2
+032300     MOVE 1 TO REC-CT.                                            IC1084.2
+032400     IF DN1 IS EQUAL TO "IC109A"                                  IC1084.2
+032500         PERFORM PASS                                             IC1084.2
+032600         GO TO CALL-WRITE-07-01.                                  IC1084.2
+032700 CALL-FAIL-07-01.                                                 IC1084.2
+032800     PERFORM FAIL.                                                IC1084.2
+032900     MOVE DN1 TO COMPUTED-A.                                      IC1084.2
+033000     MOVE "IC109A" TO CORRECT-A.                                  IC1084.2
+033100     MOVE "SUBPROGRAM IC109A ERROR" TO RE-MARK.                   IC1084.2
+033200 CALL-WRITE-07-01.                                                IC1084.2
+033300     PERFORM PRINT-DETAIL.                                        IC1084.2
+033400 CALL-TEST-07-02.                                                 IC1084.2
+033500     ADD 1 TO REC-CT.                                             IC1084.2
+033600     IF DN2 IS EQUAL TO "IC110A"                                  IC1084.2
+033700         PERFORM PASS                                             IC1084.2
+033800         GO TO CALL-WRITE-07-02.                                  IC1084.2
+033900 CALL-FAIL-07-02.                                                 IC1084.2
+034000     PERFORM FAIL.                                                IC1084.2
+034100     MOVE DN2 TO COMPUTED-A.                                      IC1084.2
+034200     MOVE "IC110A" TO CORRECT-A.                                  IC1084.2
+034300     MOVE "SUBPROGRAM IC110A ERROR" TO RE-MARK.                   IC1084.2
+034400 CALL-WRITE-07-02.                                                IC1084.2
+034500     PERFORM PRINT-DETAIL.                                        IC1084.2
+034600 CALL-TEST-07-03.                                                 IC1084.2
+034700     ADD 1 TO REC-CT.                                             IC1084.2
+034800     IF DN3 EQUAL TO "IC111A"                                     IC1084.2
+034900         PERFORM PASS                                             IC1084.2
+035000         GO TO CALL-WRITE-07-03.                                  IC1084.2
+035100 CALL-FAIL-07-03.                                                 IC1084.2
+035200     PERFORM FAIL.                                                IC1084.2
+035300     MOVE DN3 TO COMPUTED-A.                                      IC1084.2
+035400     MOVE "IC111A" TO CORRECT-A.                                  IC1084.2
+035500     MOVE "SUBPROGRAM IC111A ERROR" TO RE-MARK.                   IC1084.2
+035600 CALL-WRITE-07-03.                                                IC1084.2
+035700     PERFORM PRINT-DETAIL.                                        IC1084.2
+035800 CALL-TEST-08.                                                    IC1084.2
+035900*        THIS TEST VERIFIES THAT EACH OF THE SUBPROGRAMS          IC1084.2
+036000*    WERE CALLED ONLY ONCE.                                       IC1084.2
+036100     MOVE "CALL-TEST-08" TO PAR-NAME.                             IC1084.2
+036200     MOVE "SUBPRGMS CALLED ONCE" TO FEATURE.                      IC1084.2
+036300 CALL-TEST-08-01.                                                 IC1084.2
+036400     MOVE 1 TO REC-CT.                                            IC1084.2
+036500     IF DN4 EQUAL TO 1                                            IC1084.2
+036600         PERFORM PASS                                             IC1084.2
+036700         GO TO CALL-WRITE-08-01.                                  IC1084.2
+036800 CALL-FAIL-08-01.                                                 IC1084.2
+036900     PERFORM FAIL.                                                IC1084.2
+037000     MOVE DN4 TO COMPUTED-18V0.                                   IC1084.2
+037100     MOVE 1 TO CORRECT-18V0.                                      IC1084.2
+037200     MOVE "IC109A CALLED N TIMES" TO RE-MARK.                     IC1084.2
+037300 CALL-WRITE-08-01.                                                IC1084.2
+037400     PERFORM PRINT-DETAIL.                                        IC1084.2
+037500 CALL-TEST-08-02.                                                 IC1084.2
+037600     ADD 1 TO REC-CT.                                             IC1084.2
+037700     IF DN5 EQUAL TO 1                                            IC1084.2
+037800         PERFORM PASS                                             IC1084.2
+037900         GO TO CALL-WRITE-08-02.                                  IC1084.2
+038000 CALL-FAIL-08-02.                                                 IC1084.2
+038100     PERFORM FAIL.                                                IC1084.2
+038200     MOVE DN5 TO COMPUTED-18V0.                                   IC1084.2
+038300     MOVE 1 TO CORRECT-18V0.                                      IC1084.2
+038400     MOVE "IC110A CALLED N TIMES" TO RE-MARK.                     IC1084.2
+038500 CALL-WRITE-08-02.                                                IC1084.2
+038600     PERFORM PRINT-DETAIL.                                        IC1084.2
+038700 CALL-TEST-08-03.                                                 IC1084.2
+038800     ADD 1 TO REC-CT.                                             IC1084.2
+038900     IF DN6 EQUAL TO 1                                            IC1084.2
+039000         PERFORM PASS                                             IC1084.2
+039100         GO TO CALL-WRITE-08-03.                                  IC1084.2
+039200 CALL-FAIL-08-03.                                                 IC1084.2
+039300     PERFORM FAIL.                                                IC1084.2
+039400     MOVE DN6 TO COMPUTED-18V0.                                   IC1084.2
+039500     MOVE 1 TO CORRECT-18V0.                                      IC1084.2
+039600     MOVE "IC111A CALLED N TIMES" TO RE-MARK.                     IC1084.2
+039700 CALL-WRITE-08-03.                                                IC1084.2
+039800     PERFORM PRINT-DETAIL.                                        IC1084.2
+039900 LINK-TEST-07.                                                    IC1084.2
+040000*        THIS TEST VERIFIES THAT USING PHRASE OPERANDS            IC1084.2
+040100*    WHICH WERE DEFINED IN SUBPROGRAM WORKING-STORAGE             IC1084.2
+040200*    SECTIONS WERE PROCESSED CORRECTLY.                           IC1084.2
+040300     MOVE "LINK-TEST-07" TO PAR-NAME.                             IC1084.2
+040400     MOVE "USING OPERANDS" TO FEATURE.                            IC1084.2
+040500 LINK-TEST-07-01.                                                 IC1084.2
+040600     MOVE 1 TO REC-CT.                                            IC1084.2
+040700     IF DN7 EQUAL TO "A"                                          IC1084.2
+040800         PERFORM PASS                                             IC1084.2
+040900         GO TO LINK-WRITE-07-01.                                  IC1084.2
+041000 LINK-FAIL-07-01.                                                 IC1084.2
+041100     PERFORM FAIL.                                                IC1084.2
+041200     MOVE DN7 TO COMPUTED-A.                                      IC1084.2
+041300     MOVE "A" TO CORRECT-A.                                       IC1084.2
+041400     MOVE "IC109A WK-STORAGE OPERAND" TO RE-MARK.                 IC1084.2
+041500 LINK-WRITE-07-01.                                                IC1084.2
+041600     PERFORM PRINT-DETAIL.                                        IC1084.2
+041700 LINK-TEST-07-02.                                                 IC1084.2
+041800     ADD 1 TO REC-CT.                                             IC1084.2
+041900     IF DN8 EQUAL TO "A"                                          IC1084.2
+042000         PERFORM PASS                                             IC1084.2
+042100         GO TO LINK-WRITE-07-02.                                  IC1084.2
+042200 LINK-FAIL-07-02.                                                 IC1084.2
+042300     PERFORM FAIL.                                                IC1084.2
+042400     MOVE DN8 TO COMPUTED-A.                                      IC1084.2
+042500     MOVE "A" TO CORRECT-A.                                       IC1084.2
+042600     MOVE "IC110A WK-STORAGE OPERAND" TO RE-MARK.                 IC1084.2
+042700 LINK-WRITE-07-02.                                                IC1084.2
+042800     PERFORM PRINT-DETAIL.                                        IC1084.2
+042900 LINK-TEST-07-03.                                                 IC1084.2
+043000     ADD 1 TO REC-CT.                                             IC1084.2
+043100     IF DN9 EQUAL TO "B"                                          IC1084.2
+043200         PERFORM PASS                                             IC1084.2
+043300         GO TO LINK-WRITE-07-03.                                  IC1084.2
+043400 LINK-FAIL-07-03.                                                 IC1084.2
+043500     PERFORM FAIL.                                                IC1084.2
+043600     MOVE DN9 TO COMPUTED-A.                                      IC1084.2
+043700     MOVE "B" TO CORRECT-A.                                       IC1084.2
+043800     MOVE "IC111A WK-STORAGE OPERAND" TO RE-MARK.                 IC1084.2
+043900 LINK-WRITE-07-03.                                                IC1084.2
+044000     PERFORM PRINT-DETAIL.                                        IC1084.2
+044100     GO TO CCVS-EXIT.                                             IC1084.2
+044200 CCVS-EXIT SECTION.                                               IC1084.2
+044300 CCVS-999999.                                                     IC1084.2
+044400     GO TO CLOSE-FILES.                                           IC1084.2

--- a/src/IC109A.CBL
+++ b/src/IC109A.CBL
@@ -1,0 +1,65 @@
+000100 IDENTIFICATION DIVISION.                                         IC1094.2
+000200 PROGRAM-ID.                                                      IC1094.2
+000300     IC109A.                                                      IC1094.2
+000400****************************************************************  IC1094.2
+000500*                                                              *  IC1094.2
+000600*    VALIDATION FOR:-                                          *  IC1094.2
+000700*                                                              *  IC1094.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1094.2
+000900*                                                              *  IC1094.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1094.2
+001100*                                                              *  IC1094.2
+001200****************************************************************  IC1094.2
+001300*                                                              *  IC1094.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC1094.2
+001500*                                                              *  IC1094.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC1094.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC1094.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC1094.2
+001900*                                                              *  IC1094.2
+002000****************************************************************  IC1094.2
+002100*        THE SUBPROGRAM IC109 IS THE FIRST SUBPROGRAM IN A        IC1094.2
+002200*    SEQUENCE OF CALLS WHICH START IN THE MAIN PROGRAM IC108.     IC1094.2
+002300*    IC109 CALLS IC110 WITH ONE OPERAND IN THE WORKING-STORAGE    IC1094.2
+002400*    SECTION AND ONE OPERAND IN THE LINKAGE SECTION.              IC1094.2
+002500 ENVIRONMENT DIVISION.                                            IC1094.2
+002600 CONFIGURATION SECTION.                                           IC1094.2
+002700 SOURCE-COMPUTER.                                                 IC1094.2
+002800     XXXXX082.                                                    IC1094.2
+002900 OBJECT-COMPUTER.                                                 IC1094.2
+003000     XXXXX083.                                                    IC1094.2
+003100 INPUT-OUTPUT SECTION.                                            IC1094.2
+003200 FILE-CONTROL.                                                    IC1094.2
+003300     SELECT PRINT-FILE ASSIGN TO                                  IC1094.2
+003400     XXXXX055.                                                    IC1094.2
+003500 DATA DIVISION.                                                   IC1094.2
+003600 FILE SECTION.                                                    IC1094.2
+003700 FD  PRINT-FILE.                                                  IC1094.2
+003800 01  PRINT-REC PICTURE X(120).                                    IC1094.2
+003900 01  DUMMY-RECORD PICTURE X(120).                                 IC1094.2
+004000 WORKING-STORAGE SECTION.                                         IC1094.2
+004100 77  WS1 PICTURE X.                                               IC1094.2
+004200 LINKAGE SECTION.                                                 IC1094.2
+004300 01  GRP-01.                                                      IC1094.2
+004400     02  SUB-CALLED.                                              IC1094.2
+004500         03  DN1  PICTURE X(6).                                   IC1094.2
+004600         03  DN2  PICTURE X(6).                                   IC1094.2
+004700         03  DN3  PICTURE X(6).                                   IC1094.2
+004800     02  TIMES-CALLED.                                            IC1094.2
+004900         03  DN4  PICTURE S999.                                   IC1094.2
+005000         03  DN5  PICTURE S999.                                   IC1094.2
+005100         03  DN6  PICTURE S999.                                   IC1094.2
+005200     02  SPECIAL-FLAGS.                                           IC1094.2
+005300         03  DN7 PICTURE X.                                       IC1094.2
+005400         03  DN8 PICTURE X.                                       IC1094.2
+005500         03  DN9 PICTURE X.                                       IC1094.2
+005600 PROCEDURE DIVISION USING GRP-01.                                 IC1094.2
+005700 SECT-IC109-0001 SECTION.                                         IC1094.2
+005800 PARA-IC109.                                                      IC1094.2
+005900     MOVE "IC109A" TO DN1.                                        IC1094.2
+006000     MOVE SPACE TO WS1.                                           IC1094.2
+006100     CALL "IC110A" USING WS1 GRP-01.                              IC1094.2
+006200     ADD 1 TO DN4.                                                IC1094.2
+006300     MOVE WS1 TO DN9.                                             IC1094.2
+006400 EXIT-IC109.                                                      IC1094.2
+006500     EXIT PROGRAM.                                                IC1094.2

--- a/src/IC110A.CBL
+++ b/src/IC110A.CBL
@@ -1,0 +1,69 @@
+000100 IDENTIFICATION DIVISION.                                         IC1104.2
+000200 PROGRAM-ID.                                                      IC1104.2
+000300     IC110A.                                                      IC1104.2
+000400****************************************************************  IC1104.2
+000500*                                                              *  IC1104.2
+000600*    VALIDATION FOR:-                                          *  IC1104.2
+000700*                                                              *  IC1104.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1104.2
+000900*                                                              *  IC1104.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1104.2
+001100*                                                              *  IC1104.2
+001200****************************************************************  IC1104.2
+001300*                                                              *  IC1104.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC1104.2
+001500*                                                              *  IC1104.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC1104.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC1104.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC1104.2
+001900*                                                              *  IC1104.2
+002000****************************************************************  IC1104.2
+002100*        THE SUBPROGRAM IC110 IS THE SECOND SUBPROGRAM IN A       IC1104.2
+002200*    SEQUENCE OF CALLS WHICH START IN THE MAIN PROGRAM IC108.     IC1104.2
+002300*    THIS SUBPROGRAM CALLS IC111 WITH OPERANDS IN THE LINKAGE     IC1104.2
+002400*    SECTION AND IN THE WORKING-STORAGE SECTION.  THE SUBPROGRAM  IC1104.2
+002500*    IC110 IS CALLED BY IC109.                                    IC1104.2
+002600 ENVIRONMENT DIVISION.                                            IC1104.2
+002700 CONFIGURATION SECTION.                                           IC1104.2
+002800 SOURCE-COMPUTER.                                                 IC1104.2
+002900     XXXXX082.                                                    IC1104.2
+003000 OBJECT-COMPUTER.                                                 IC1104.2
+003100     XXXXX083.                                                    IC1104.2
+003200 INPUT-OUTPUT SECTION.                                            IC1104.2
+003300 FILE-CONTROL.                                                    IC1104.2
+003400     SELECT PRINT-FILE ASSIGN TO                                  IC1104.2
+003500     XXXXX055.                                                    IC1104.2
+003600 DATA DIVISION.                                                   IC1104.2
+003700 FILE SECTION.                                                    IC1104.2
+003800 FD  PRINT-FILE.                                                  IC1104.2
+003900 01  PRINT-REC PICTURE X(120).                                    IC1104.2
+004000 01  DUMMY-RECORD PICTURE X(120).                                 IC1104.2
+004100 WORKING-STORAGE SECTION.                                         IC1104.2
+004200 77  WS2 PICTURE X.                                               IC1104.2
+004300 LINKAGE SECTION.                                                 IC1104.2
+004400 01  GRP-01.                                                      IC1104.2
+004500     02  SUB-CALLED.                                              IC1104.2
+004600         03  DN1 PICTURE X(6).                                    IC1104.2
+004700         03  DN2 PICTURE X(6).                                    IC1104.2
+004800         03  DN3 PICTURE X(6).                                    IC1104.2
+004900     02  TIMES-CALLED.                                            IC1104.2
+005000         03  DN4 PICTURE S999.                                    IC1104.2
+005100         03  DN5 PICTURE S999.                                    IC1104.2
+005200         03  DN6 PICTURE S999.                                    IC1104.2
+005300     02  SPECIAL-FLAGS.                                           IC1104.2
+005400         03  DN7 PICTURE X.                                       IC1104.2
+005500         03  DN8 PICTURE X.                                       IC1104.2
+005600         03  DN9 PICTURE X.                                       IC1104.2
+005700 01  LS1 PICTURE X.                                               IC1104.2
+005800 PROCEDURE DIVISION USING LS1 GRP-01.                             IC1104.2
+005900 SECT-IC110-0001 SECTION.                                         IC1104.2
+006000 PARA-IC110.                                                      IC1104.2
+006100     MOVE "IC110A" TO DN2.                                        IC1104.2
+006200     MOVE SPACE TO WS2.                                           IC1104.2
+006300     CALL "IC111A" USING LS1 GRP-01 WS2.                          IC1104.2
+006400     MOVE WS2 TO DN7.                                             IC1104.2
+006500     MOVE LS1 TO DN8.                                             IC1104.2
+006600     ADD 1 TO DN5.                                                IC1104.2
+006700     MOVE "B" TO LS1.                                             IC1104.2
+006800 EXIT-IC110.                                                      IC1104.2
+006900     EXIT PROGRAM.                                                IC1104.2

--- a/src/IC112A.CBL
+++ b/src/IC112A.CBL
@@ -1,0 +1,555 @@
+000100 IDENTIFICATION DIVISION.                                         IC1124.2
+000200 PROGRAM-ID.                                                      IC1124.2
+000300     IC112A.                                                      IC1124.2
+000400****************************************************************  IC1124.2
+000500*                                                              *  IC1124.2
+000600*    VALIDATION FOR:-                                          *  IC1124.2
+000700*                                                              *  IC1124.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1124.2
+000900*                                                              *  IC1124.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1124.2
+001100*                                                              *  IC1124.2
+001200****************************************************************  IC1124.2
+001300*                                                              *  IC1124.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC1124.2
+001500*                                                              *  IC1124.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC1124.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC1124.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC1124.2
+001900*                                                              *  IC1124.2
+002000****************************************************************  IC1124.2
+002100****************************************************************  IC1124.2
+002200*                                                                 IC1124.2
+002300*         THE ROUTINE IC112 IS A MAIN PROGRAM WHICH HAS A FILE    IC1124.2
+002400*    DESCRIPTION FOR A SEQUENTIAL MASS STORAGE FILE WITH FIXED    IC1124.2
+002500*    LENGTH RECORDS.  THE FILE IS CREATED, CLOSED AND OPENED AS   IC1124.2
+002600*    AN INPUT FILE.  THE MAIN ROUTINE READS THE FILE AND VERIFIES IC1124.2
+002700*    THAT THE FILE IS CORRECT.  THE FILE IS CLOSED AND OPENED     IC1124.2
+002800*    AGAIN AS AN INPUT FILE.  A RECORD IS READ AND A CALL IS MADE IC1124.2
+002900*    TO THE SUBPROGRAM IC113 WITH THE FILE DESCRIPTION 01 RECORD  IC1124.2
+003000*    LISTED AS ONE OF THE OPERANDS OF THE USING PHRASE.  THE      IC1124.2
+003100*    SUBPROGRAM IC113 COMPARES THE FIELDS IN THE INPUT RECORD TO  IC1124.2
+003200*    THE VALUES WRITTEN WHEN THE FILE WAS CREATED.                IC1124.2
+003300*                                                                 IC1124.2
+003400*         THIS PROGRAM WAS ADAPTED FROM THE SEQUENTIAL I-O TEST   IC1124.2
+003500*    CONTAINED IN ROUTINE SQ104.  IF ANY ERRORS OCCUR IN RUNNING  IC1124.2
+003600*    THE ROUTINE SQ104, THE RESULTS OF THE TESTS IN THE ROUTINES  IC1124.2
+003700*    IC112 AND IC113 ARE INCONCLUSIVE.                            IC1124.2
+003800*                                                                 IC1124.2
+003900*******************************************                       IC1124.2
+004000 ENVIRONMENT DIVISION.                                            IC1124.2
+004100 CONFIGURATION SECTION.                                           IC1124.2
+004200 SOURCE-COMPUTER.                                                 IC1124.2
+004300     XXXXX082.                                                    IC1124.2
+004400 OBJECT-COMPUTER.                                                 IC1124.2
+004500     XXXXX083.                                                    IC1124.2
+004600 INPUT-OUTPUT SECTION.                                            IC1124.2
+004700 FILE-CONTROL.                                                    IC1124.2
+004800     SELECT PRINT-FILE ASSIGN TO                                  IC1124.2
+004900     XXXXX055.                                                    IC1124.2
+005000     SELECT SQ-FS3 ASSIGN TO                                      IC1124.2
+005100     XXXXX014                                                     IC1124.2
+005200     ORGANIZATION IS SEQUENTIAL                                   IC1124.2
+005300     ACCESS MODE IS SEQUENTIAL.                                   IC1124.2
+005400 DATA DIVISION.                                                   IC1124.2
+005500 FILE SECTION.                                                    IC1124.2
+005600 FD  PRINT-FILE.                                                  IC1124.2
+005700 01  PRINT-REC PICTURE X(120).                                    IC1124.2
+005800 01  DUMMY-RECORD PICTURE X(120).                                 IC1124.2
+005900 FD  SQ-FS3                                                       IC1124.2
+006000     BLOCK CONTAINS 120 CHARACTERS                                IC1124.2
+006100     RECORD CONTAINS 120 CHARACTERS                               IC1124.2
+006200     LABEL RECORDS ARE STANDARD                                   IC1124.2
+006300C    VALUE OF                                                     IC1124.2
+006400C    XXXXX074                                                     IC1124.2
+006500C    IS                                                           IC1124.2
+006600C    XXXXX075                                                     IC1124.2
+006700G    XXXXX069                                                     IC1124.2
+006800     DATA RECORD SQ-FS3R1-F-G-120.                                IC1124.2
+006900 01  SQ-FS3R1-F-G-120.                                            IC1124.2
+007000     02  FILLER PIC X(120).                                       IC1124.2
+007100 WORKING-STORAGE SECTION.                                         IC1124.2
+007200 01  WRK-CS-09V00 PICTURE S9(9) USAGE COMP VALUE ZERO.            IC1124.2
+007300 01  RECORDS-IN-ERROR  PIC S9(5) USAGE COMP VALUE 0.              IC1124.2
+007400 01  ERROR-FLAG PICTURE 9 VALUE 0.                                IC1124.2
+007500 01  EOF-FLAG PICTURE 9 VALUE 0.                                  IC1124.2
+007600 01  FILE-RECORD-INFORMATION-REC.                                 IC1124.2
+007700     03 FILE-RECORD-INFO-SKELETON.                                IC1124.2
+007800        05 FILLER                 PICTURE X(48)       VALUE       IC1124.2
+007900             "FILE=      ,RECORD=      /0,RECNO=000000,UPDT=00".  IC1124.2
+008000        05 FILLER                 PICTURE X(46)       VALUE       IC1124.2
+008100             ",ODO=0000,PGM=     ,LRECL=000000,BLKSIZ  =0000".    IC1124.2
+008200        05 FILLER                 PICTURE X(26)       VALUE       IC1124.2
+008300             ",LFIL=000000,ORG=  ,LBLR= ".                        IC1124.2
+008400        05 FILLER                 PICTURE X(37)       VALUE       IC1124.2
+008500             ",RECKEY=                             ".             IC1124.2
+008600        05 FILLER                 PICTURE X(38)       VALUE       IC1124.2
+008700             ",ALTKEY1=                             ".            IC1124.2
+008800        05 FILLER                 PICTURE X(38)       VALUE       IC1124.2
+008900             ",ALTKEY2=                             ".            IC1124.2
+009000        05 FILLER                 PICTURE X(7)        VALUE SPACE.IC1124.2
+009100     03 FILE-RECORD-INFO          OCCURS  10  TIMES.              IC1124.2
+009200        05 FILE-RECORD-INFO-P1-120.                               IC1124.2
+009300           07 FILLER              PIC X(5).                       IC1124.2
+009400           07 XFILE-NAME           PIC X(6).                      IC1124.2
+009500           07 FILLER              PIC X(8).                       IC1124.2
+009600           07 XRECORD-NAME         PIC X(6).                      IC1124.2
+009700           07 FILLER              PIC X(1).                       IC1124.2
+009800           07 REELUNIT-NUMBER     PIC 9(1).                       IC1124.2
+009900           07 FILLER              PIC X(7).                       IC1124.2
+010000           07 XRECORD-NUMBER       PIC 9(6).                      IC1124.2
+010100           07 FILLER              PIC X(6).                       IC1124.2
+010200           07 UPDATE-NUMBER       PIC 9(2).                       IC1124.2
+010300           07 FILLER              PIC X(5).                       IC1124.2
+010400           07 ODO-NUMBER          PIC 9(4).                       IC1124.2
+010500           07 FILLER              PIC X(5).                       IC1124.2
+010600           07 XPROGRAM-NAME        PIC X(5).                      IC1124.2
+010700           07 FILLER              PIC X(7).                       IC1124.2
+010800           07 XRECORD-LENGTH       PIC 9(6).                      IC1124.2
+010900           07 FILLER              PIC X(7).                       IC1124.2
+011000           07 CHARS-OR-RECORDS    PIC X(2).                       IC1124.2
+011100           07 FILLER              PIC X(1).                       IC1124.2
+011200           07 XBLOCK-SIZE          PIC 9(4).                      IC1124.2
+011300           07 FILLER              PIC X(6).                       IC1124.2
+011400           07 RECORDS-IN-FILE     PIC 9(6).                       IC1124.2
+011500           07 FILLER              PIC X(5).                       IC1124.2
+011600           07 XFILE-ORGANIZATION   PIC X(2).                      IC1124.2
+011700           07 FILLER              PIC X(6).                       IC1124.2
+011800           07 XLABEL-TYPE          PIC X(1).                      IC1124.2
+011900        05 FILE-RECORD-INFO-P121-240.                             IC1124.2
+012000           07 FILLER              PIC X(8).                       IC1124.2
+012100           07 XRECORD-KEY          PIC X(29).                     IC1124.2
+012200           07 FILLER              PIC X(9).                       IC1124.2
+012300           07 ALTERNATE-KEY1      PIC X(29).                      IC1124.2
+012400           07 FILLER              PIC X(9).                       IC1124.2
+012500           07 ALTERNATE-KEY2      PIC X(29).                      IC1124.2
+012600           07 FILLER              PIC X(7).                       IC1124.2
+012700 01  TEST-RESULTS.                                                IC1124.2
+012800     02 FILLER                   PIC X      VALUE SPACE.          IC1124.2
+012900     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC1124.2
+013000     02 FILLER                   PIC X      VALUE SPACE.          IC1124.2
+013100     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC1124.2
+013200     02 FILLER                   PIC X      VALUE SPACE.          IC1124.2
+013300     02  PAR-NAME.                                                IC1124.2
+013400       03 FILLER                 PIC X(19)  VALUE SPACE.          IC1124.2
+013500       03  PARDOT-X              PIC X      VALUE SPACE.          IC1124.2
+013600       03 DOTVALUE               PIC 99     VALUE ZERO.           IC1124.2
+013700     02 FILLER                   PIC X(8)   VALUE SPACE.          IC1124.2
+013800     02 RE-MARK                  PIC X(61).                       IC1124.2
+013900 01  TEST-COMPUTED.                                               IC1124.2
+014000     02 FILLER                   PIC X(30)  VALUE SPACE.          IC1124.2
+014100     02 FILLER                   PIC X(17)  VALUE                 IC1124.2
+014200            "       COMPUTED=".                                   IC1124.2
+014300     02 COMPUTED-X.                                               IC1124.2
+014400     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC1124.2
+014500     03 COMPUTED-N               REDEFINES COMPUTED-A             IC1124.2
+014600                                 PIC -9(9).9(9).                  IC1124.2
+014700     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC1124.2
+014800     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC1124.2
+014900     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC1124.2
+015000     03       CM-18V0 REDEFINES COMPUTED-A.                       IC1124.2
+015100         04 COMPUTED-18V0                    PIC -9(18).          IC1124.2
+015200         04 FILLER                           PIC X.               IC1124.2
+015300     03 FILLER PIC X(50) VALUE SPACE.                             IC1124.2
+015400 01  TEST-CORRECT.                                                IC1124.2
+015500     02 FILLER PIC X(30) VALUE SPACE.                             IC1124.2
+015600     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC1124.2
+015700     02 CORRECT-X.                                                IC1124.2
+015800     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC1124.2
+015900     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC1124.2
+016000     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC1124.2
+016100     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC1124.2
+016200     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC1124.2
+016300     03      CR-18V0 REDEFINES CORRECT-A.                         IC1124.2
+016400         04 CORRECT-18V0                     PIC -9(18).          IC1124.2
+016500         04 FILLER                           PIC X.               IC1124.2
+016600     03 FILLER PIC X(2) VALUE SPACE.                              IC1124.2
+016700     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC1124.2
+016800 01  CCVS-C-1.                                                    IC1124.2
+016900     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC1124.2
+017000-    "SS  PARAGRAPH-NAME                                          IC1124.2
+017100-    "       REMARKS".                                            IC1124.2
+017200     02 FILLER                     PIC X(20)    VALUE SPACE.      IC1124.2
+017300 01  CCVS-C-2.                                                    IC1124.2
+017400     02 FILLER                     PIC X        VALUE SPACE.      IC1124.2
+017500     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC1124.2
+017600     02 FILLER                     PIC X(15)    VALUE SPACE.      IC1124.2
+017700     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC1124.2
+017800     02 FILLER                     PIC X(94)    VALUE SPACE.      IC1124.2
+017900 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC1124.2
+018000 01  REC-CT                        PIC 99       VALUE ZERO.       IC1124.2
+018100 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC1124.2
+018200 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC1124.2
+018300 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC1124.2
+018400 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC1124.2
+018500 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC1124.2
+018600 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC1124.2
+018700 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC1124.2
+018800 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC1124.2
+018900 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC1124.2
+019000 01  CCVS-H-1.                                                    IC1124.2
+019100     02  FILLER                    PIC X(39)    VALUE SPACES.     IC1124.2
+019200     02  FILLER                    PIC X(42)    VALUE             IC1124.2
+019300     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC1124.2
+019400     02  FILLER                    PIC X(39)    VALUE SPACES.     IC1124.2
+019500 01  CCVS-H-2A.                                                   IC1124.2
+019600   02  FILLER                        PIC X(40)  VALUE SPACE.      IC1124.2
+019700   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC1124.2
+019800   02  FILLER                        PIC XXXX   VALUE             IC1124.2
+019900     "4.2 ".                                                      IC1124.2
+020000   02  FILLER                        PIC X(28)  VALUE             IC1124.2
+020100            " COPY - NOT FOR DISTRIBUTION".                       IC1124.2
+020200   02  FILLER                        PIC X(41)  VALUE SPACE.      IC1124.2
+020300                                                                  IC1124.2
+020400 01  CCVS-H-2B.                                                   IC1124.2
+020500   02  FILLER                        PIC X(15)  VALUE             IC1124.2
+020600            "TEST RESULT OF ".                                    IC1124.2
+020700   02  TEST-ID                       PIC X(9).                    IC1124.2
+020800   02  FILLER                        PIC X(4)   VALUE             IC1124.2
+020900            " IN ".                                               IC1124.2
+021000   02  FILLER                        PIC X(12)  VALUE             IC1124.2
+021100     " HIGH       ".                                              IC1124.2
+021200   02  FILLER                        PIC X(22)  VALUE             IC1124.2
+021300            " LEVEL VALIDATION FOR ".                             IC1124.2
+021400   02  FILLER                        PIC X(58)  VALUE             IC1124.2
+021500     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1124.2
+021600 01  CCVS-H-3.                                                    IC1124.2
+021700     02  FILLER                      PIC X(34)  VALUE             IC1124.2
+021800            " FOR OFFICIAL USE ONLY    ".                         IC1124.2
+021900     02  FILLER                      PIC X(58)  VALUE             IC1124.2
+022000     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1124.2
+022100     02  FILLER                      PIC X(28)  VALUE             IC1124.2
+022200            "  COPYRIGHT   1985 ".                                IC1124.2
+022300 01  CCVS-E-1.                                                    IC1124.2
+022400     02 FILLER                       PIC X(52)  VALUE SPACE.      IC1124.2
+022500     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC1124.2
+022600     02 ID-AGAIN                     PIC X(9).                    IC1124.2
+022700     02 FILLER                       PIC X(45)  VALUE SPACES.     IC1124.2
+022800 01  CCVS-E-2.                                                    IC1124.2
+022900     02  FILLER                      PIC X(31)  VALUE SPACE.      IC1124.2
+023000     02  FILLER                      PIC X(21)  VALUE SPACE.      IC1124.2
+023100     02 CCVS-E-2-2.                                               IC1124.2
+023200         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC1124.2
+023300         03 FILLER                   PIC X      VALUE SPACE.      IC1124.2
+023400         03 ENDER-DESC               PIC X(44)  VALUE             IC1124.2
+023500            "ERRORS ENCOUNTERED".                                 IC1124.2
+023600 01  CCVS-E-3.                                                    IC1124.2
+023700     02  FILLER                      PIC X(22)  VALUE             IC1124.2
+023800            " FOR OFFICIAL USE ONLY".                             IC1124.2
+023900     02  FILLER                      PIC X(12)  VALUE SPACE.      IC1124.2
+024000     02  FILLER                      PIC X(58)  VALUE             IC1124.2
+024100     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1124.2
+024200     02  FILLER                      PIC X(13)  VALUE SPACE.      IC1124.2
+024300     02 FILLER                       PIC X(15)  VALUE             IC1124.2
+024400             " COPYRIGHT 1985".                                   IC1124.2
+024500 01  CCVS-E-4.                                                    IC1124.2
+024600     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC1124.2
+024700     02 FILLER                       PIC X(4)   VALUE " OF ".     IC1124.2
+024800     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC1124.2
+024900     02 FILLER                       PIC X(40)  VALUE             IC1124.2
+025000      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC1124.2
+025100 01  XXINFO.                                                      IC1124.2
+025200     02 FILLER                       PIC X(19)  VALUE             IC1124.2
+025300            "*** INFORMATION ***".                                IC1124.2
+025400     02 INFO-TEXT.                                                IC1124.2
+025500       04 FILLER                     PIC X(8)   VALUE SPACE.      IC1124.2
+025600       04 XXCOMPUTED                 PIC X(20).                   IC1124.2
+025700       04 FILLER                     PIC X(5)   VALUE SPACE.      IC1124.2
+025800       04 XXCORRECT                  PIC X(20).                   IC1124.2
+025900     02 INF-ANSI-REFERENCE           PIC X(48).                   IC1124.2
+026000 01  HYPHEN-LINE.                                                 IC1124.2
+026100     02 FILLER  PIC IS X VALUE IS SPACE.                          IC1124.2
+026200     02 FILLER  PIC IS X(65)    VALUE IS "************************IC1124.2
+026300-    "*****************************************".                 IC1124.2
+026400     02 FILLER  PIC IS X(54)    VALUE IS "************************IC1124.2
+026500-    "******************************".                            IC1124.2
+026600 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC1124.2
+026700     "IC112A".                                                    IC1124.2
+026800 PROCEDURE DIVISION.                                              IC1124.2
+026900 CCVS1 SECTION.                                                   IC1124.2
+027000 OPEN-FILES.                                                      IC1124.2
+027100     OPEN     OUTPUT PRINT-FILE.                                  IC1124.2
+027200     MOVE CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.   IC1124.2
+027300     MOVE    SPACE TO TEST-RESULTS.                               IC1124.2
+027400     PERFORM  HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.             IC1124.2
+027500     GO TO CCVS1-EXIT.                                            IC1124.2
+027600 CLOSE-FILES.                                                     IC1124.2
+027700     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC1124.2
+027800 TERMINATE-CCVS.                                                  IC1124.2
+027900S    EXIT PROGRAM.                                                IC1124.2
+028000STERMINATE-CALL.                                                  IC1124.2
+028100     STOP     RUN.                                                IC1124.2
+028200 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         IC1124.2
+028300 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           IC1124.2
+028400 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          IC1124.2
+028500 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      IC1124.2
+028600     MOVE "****TEST DELETED****" TO RE-MARK.                      IC1124.2
+028700 PRINT-DETAIL.                                                    IC1124.2
+028800     IF REC-CT NOT EQUAL TO ZERO                                  IC1124.2
+028900             MOVE "." TO PARDOT-X                                 IC1124.2
+029000             MOVE REC-CT TO DOTVALUE.                             IC1124.2
+029100     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      IC1124.2
+029200     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               IC1124.2
+029300        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 IC1124.2
+029400          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 IC1124.2
+029500     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC1124.2
+029600     MOVE SPACE TO CORRECT-X.                                     IC1124.2
+029700     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC1124.2
+029800     MOVE     SPACE TO RE-MARK.                                   IC1124.2
+029900 HEAD-ROUTINE.                                                    IC1124.2
+030000     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC1124.2
+030100     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC1124.2
+030200     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC1124.2
+030300     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC1124.2
+030400 COLUMN-NAMES-ROUTINE.                                            IC1124.2
+030500     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1124.2
+030600     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1124.2
+030700     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC1124.2
+030800 END-ROUTINE.                                                     IC1124.2
+030900     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.IC1124.2
+031000 END-RTN-EXIT.                                                    IC1124.2
+031100     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1124.2
+031200 END-ROUTINE-1.                                                   IC1124.2
+031300      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      IC1124.2
+031400      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               IC1124.2
+031500      ADD PASS-COUNTER TO ERROR-HOLD.                             IC1124.2
+031600*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC1124.2
+031700      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC1124.2
+031800      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC1124.2
+031900      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC1124.2
+032000      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC1124.2
+032100  END-ROUTINE-12.                                                 IC1124.2
+032200      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC1124.2
+032300     IF       ERROR-COUNTER IS EQUAL TO ZERO                      IC1124.2
+032400         MOVE "NO " TO ERROR-TOTAL                                IC1124.2
+032500         ELSE                                                     IC1124.2
+032600         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC1124.2
+032700     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC1124.2
+032800     PERFORM WRITE-LINE.                                          IC1124.2
+032900 END-ROUTINE-13.                                                  IC1124.2
+033000     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC1124.2
+033100         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC1124.2
+033200         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC1124.2
+033300     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC1124.2
+033400     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1124.2
+033500      IF   INSPECT-COUNTER EQUAL TO ZERO                          IC1124.2
+033600          MOVE "NO " TO ERROR-TOTAL                               IC1124.2
+033700      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   IC1124.2
+033800      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            IC1124.2
+033900      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          IC1124.2
+034000     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1124.2
+034100 WRITE-LINE.                                                      IC1124.2
+034200     ADD 1 TO RECORD-COUNT.                                       IC1124.2
+034300Y    IF RECORD-COUNT GREATER 50                                   IC1124.2
+034400Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC1124.2
+034500Y        MOVE SPACE TO DUMMY-RECORD                               IC1124.2
+034600Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC1124.2
+034700Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC1124.2
+034800Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC1124.2
+034900Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC1124.2
+035000Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC1124.2
+035100Y        MOVE ZERO TO RECORD-COUNT.                               IC1124.2
+035200     PERFORM WRT-LN.                                              IC1124.2
+035300 WRT-LN.                                                          IC1124.2
+035400     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC1124.2
+035500     MOVE SPACE TO DUMMY-RECORD.                                  IC1124.2
+035600 BLANK-LINE-PRINT.                                                IC1124.2
+035700     PERFORM WRT-LN.                                              IC1124.2
+035800 FAIL-ROUTINE.                                                    IC1124.2
+035900     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC1124.2
+036000     IF     CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.IC1124.2
+036100     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC1124.2
+036200     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC1124.2
+036300     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1124.2
+036400     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC1124.2
+036500     GO TO  FAIL-ROUTINE-EX.                                      IC1124.2
+036600 FAIL-ROUTINE-WRITE.                                              IC1124.2
+036700     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC1124.2
+036800     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC1124.2
+036900     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC1124.2
+037000     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC1124.2
+037100 FAIL-ROUTINE-EX. EXIT.                                           IC1124.2
+037200 BAIL-OUT.                                                        IC1124.2
+037300     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC1124.2
+037400     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC1124.2
+037500 BAIL-OUT-WRITE.                                                  IC1124.2
+037600     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC1124.2
+037700     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC1124.2
+037800     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1124.2
+037900     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC1124.2
+038000 BAIL-OUT-EX. EXIT.                                               IC1124.2
+038100 CCVS1-EXIT.                                                      IC1124.2
+038200     EXIT.                                                        IC1124.2
+038300 SECT-IC112-0001 SECTION.                                         IC1124.2
+038400 SEQ-INIT-007.                                                    IC1124.2
+038500     MOVE FILE-RECORD-INFO-SKELETON                               IC1124.2
+038600          TO FILE-RECORD-INFO-P1-120 (1).                         IC1124.2
+038700     MOVE "SQ-FS3" TO XFILE-NAME (1).                             IC1124.2
+038800     MOVE "R1-F-G" TO XRECORD-NAME (1).                           IC1124.2
+038900     MOVE CCVS-PGM-ID TO XPROGRAM-NAME (1).                       IC1124.2
+039000     MOVE 120 TO XRECORD-LENGTH (1).                              IC1124.2
+039100     MOVE "CH" TO CHARS-OR-RECORDS (1).                           IC1124.2
+039200     MOVE 120 TO XBLOCK-SIZE (1).                                 IC1124.2
+039300     MOVE 000649 TO RECORDS-IN-FILE (1).                          IC1124.2
+039400     MOVE "SQ" TO XFILE-ORGANIZATION (1).                         IC1124.2
+039500     MOVE "S" TO XLABEL-TYPE (1).                                 IC1124.2
+039600     MOVE 000001 TO XRECORD-NUMBER (1).                           IC1124.2
+039700     OPEN OUTPUT SQ-FS3.                                          IC1124.2
+039800 SEQ-TEST-007.                                                    IC1124.2
+039900     MOVE FILE-RECORD-INFO-P1-120 (1) TO SQ-FS3R1-F-G-120.        IC1124.2
+040000     WRITE SQ-FS3R1-F-G-120.                                      IC1124.2
+040100     IF XRECORD-NUMBER (1) EQUAL TO 649                           IC1124.2
+040200        GO TO SEQ-WRITE-007.                                      IC1124.2
+040300     ADD 1 TO XRECORD-NUMBER (1).                                 IC1124.2
+040400     GO TO SEQ-TEST-007.                                          IC1124.2
+040500 SEQ-WRITE-007.                                                   IC1124.2
+040600     MOVE "CREATE FILE SQ-FS3" TO FEATURE.                        IC1124.2
+040700     MOVE "SEQ-TEST-007" TO PAR-NAME.                             IC1124.2
+040800     MOVE "FILE CREATED, RECS =" TO COMPUTED-A.                   IC1124.2
+040900     MOVE XRECORD-NUMBER (1) TO CORRECT-18V0.                     IC1124.2
+041000     PERFORM PRINT-DETAIL.                                        IC1124.2
+041100     CLOSE SQ-FS3.                                                IC1124.2
+041200*        A MASS STORAGE SEQUENTIAL FILE WITH 120 CHARACTER        IC1124.2
+041300*    RECORDS HAS BEEN CREATED.  THE FILE CONTAINS 649 RECORDS.    IC1124.2
+041400 SEQ-INIT-008.                                                    IC1124.2
+041500     MOVE ZERO TO WRK-CS-09V00.                                   IC1124.2
+041600*        THIS TEST READS AND CHECKS THE FILE CREATED IN           IC1124.2
+041700*    SEQ-TEST-007.                                                IC1124.2
+041800     OPEN INPUT SQ-FS3.                                           IC1124.2
+041900 SEQ-TEST-008.                                                    IC1124.2
+042000     READ SQ-FS3 RECORD                                           IC1124.2
+042100         AT END GO TO SEQ-TEST-008-1.                             IC1124.2
+042200     MOVE SQ-FS3R1-F-G-120 TO FILE-RECORD-INFO-P1-120 (1).        IC1124.2
+042300     ADD 1 TO WRK-CS-09V00.                                       IC1124.2
+042400     IF WRK-CS-09V00 GREATER THAN 649                             IC1124.2
+042500         MOVE "MORE THAN 649 RECORDS" TO RE-MARK                  IC1124.2
+042600         GO TO SEQ-FAIL-008.                                      IC1124.2
+042700     IF WRK-CS-09V00 NOT EQUAL TO XRECORD-NUMBER (1)              IC1124.2
+042800         ADD 1 TO RECORDS-IN-ERROR                                IC1124.2
+042900         GO TO SEQ-TEST-008.                                      IC1124.2
+043000     IF XFILE-NAME (1) NOT EQUAL TO "SQ-FS3"                      IC1124.2
+043100         ADD 1 TO RECORDS-IN-ERROR                                IC1124.2
+043200         GO TO SEQ-TEST-008.                                      IC1124.2
+043300     IF XLABEL-TYPE (1) NOT EQUAL TO "S"                          IC1124.2
+043400     ADD 1 TO RECORDS-IN-ERROR.                                   IC1124.2
+043500     GO TO SEQ-TEST-008.                                          IC1124.2
+043600 SEQ-TEST-008-1.                                                  IC1124.2
+043700     IF RECORDS-IN-ERROR EQUAL TO ZERO                            IC1124.2
+043800          GO TO SEQ-PASS-008.                                     IC1124.2
+043900     MOVE "ERRORS IN READING SQ-FS3" TO RE-MARK.                  IC1124.2
+044000 SEQ-FAIL-008.                                                    IC1124.2
+044100     MOVE RECORDS-IN-ERROR TO CORRECT-18V0.                       IC1124.2
+044200     PERFORM FAIL.                                                IC1124.2
+044300     GO TO SEQ-WRITE-008.                                         IC1124.2
+044400 SEQ-PASS-008.                                                    IC1124.2
+044500     PERFORM PASS.                                                IC1124.2
+044600     MOVE "FILE VERIFIED RECS =" TO COMPUTED-A.                   IC1124.2
+044700     MOVE WRK-CS-09V00 TO CORRECT-18V0.                           IC1124.2
+044800 SEQ-WRITE-008.                                                   IC1124.2
+044900     MOVE "SEQ-TEST-008" TO PAR-NAME.                             IC1124.2
+045000     MOVE "VERIFY FILE SQ-FS3" TO FEATURE.                        IC1124.2
+045100     PERFORM PRINT-DETAIL.                                        IC1124.2
+045200 SEQ-CLOSE-008.                                                   IC1124.2
+045300     CLOSE SQ-FS3.                                                IC1124.2
+045400 LINK-INIT-08.                                                    IC1124.2
+045500     MOVE ZERO TO WRK-CS-09V00.                                   IC1124.2
+045600     MOVE ZERO TO RECORDS-IN-ERROR.                               IC1124.2
+045700     OPEN INPUT SQ-FS3.                                           IC1124.2
+045800*                                                                 IC1124.2
+045900*         LINK-TEST-08 READS THE FILE SQ-FS3 AND CALLS THE SUB-   IC1124.2
+046000*    PROGRAM IC113 TO CHECK THE FIELDS IN THE RECORD.  THE FILE   IC1124.2
+046100*    DESCRIPTION RECORD IS ONE OF THE OPERANDS IN THE USING       IC1124.2
+046200*    PHRASE OF THE CALL STATEMENT.                                IC1124.2
+046300*                                                                 IC1124.2
+046400     MOVE ZERO TO ERROR-FLAG.                                     IC1124.2
+046500 LINK-TEST-08.                                                    IC1124.2
+046600     READ SQ-FS3 RECORD                                           IC1124.2
+046700          AT END    MOVE "UNEXPECTED EOF" TO COMPUTED-A           IC1124.2
+046800                    MOVE 1 TO EOF-FLAG                            IC1124.2
+046900                    GO TO LINK-FAIL-08.                           IC1124.2
+047000     CALL "IC113A" USING RECORDS-IN-ERROR   SQ-FS3R1-F-G-120      IC1124.2
+047100             ERROR-FLAG  WRK-CS-09V00.                            IC1124.2
+047200     IF WRK-CS-09V00 LESS THAN 649                                IC1124.2
+047300          GO TO LINK-TEST-08.                                     IC1124.2
+047400 LINK-TEST-08-01.                                                 IC1124.2
+047500     IF ERROR-FLAG EQUAL TO ZERO                                  IC1124.2
+047600          GO TO LINK-PASS-08.                                     IC1124.2
+047700     MOVE "ERROR IN RECORD(S)" TO COMPUTED-A.                     IC1124.2
+047800 LINK-FAIL-08.                                                    IC1124.2
+047900     MOVE RECORDS-IN-ERROR TO CORRECT-18V0.                       IC1124.2
+048000     MOVE "CORRECT COL. = RECORDS-IN-ERROR" TO RE-MARK.           IC1124.2
+048100     PERFORM FAIL.                                                IC1124.2
+048200     GO TO LINK-WRITE-08.                                         IC1124.2
+048300 LINK-PASS-08.                                                    IC1124.2
+048400     PERFORM PASS.                                                IC1124.2
+048500 LINK-WRITE-08.                                                   IC1124.2
+048600     MOVE "LINK-TEST-08" TO PAR-NAME.                             IC1124.2
+048700     MOVE "USING FD 01 RECORD" TO FEATURE.                        IC1124.2
+048800     PERFORM PRINT-DETAIL.                                        IC1124.2
+048900 LINK-INIT-09.                                                    IC1124.2
+049000     MOVE ZERO TO RECORDS-IN-ERROR  ERROR-FLAG.                   IC1124.2
+049100*                                                                 IC1124.2
+049200*         LINK-TEST-09 READS THE FILE SQ-FS3.  THE AT END PHRASE  IC1124.2
+049300*    OF THE READ STATEMENT SHOULD BE EXECUTED.  A CALL TO THE     IC1124.2
+049400*    SUBPROGRAM IC113 IS CONTAINED IN THE AT END PHRASE WITH      IC1124.2
+049500*    THE FD 01 RECORD AS ONE OF THE USING OPERANDS.               IC1124.2
+049600*                                                                 IC1124.2
+049700 LINK-TEST-09-01.                                                 IC1124.2
+049800     IF EOF-FLAG EQUAL TO 1                                       IC1124.2
+049900           CALL "IC113A" USING RECORDS-IN-ERROR   SQ-FS3R1-F-G-120IC1124.2
+050000                              ERROR-FLAG  WRK-CS-09V00            IC1124.2
+050100           GO TO LINK-TEST-09-02.                                 IC1124.2
+050200 LINK-TEST-09.                                                    IC1124.2
+050300     READ SQ-FS3                                                  IC1124.2
+050400          AT END CALL "IC113A" USING RECORDS-IN-ERROR             IC1124.2
+050500                      SQ-FS3R1-F-G-120  ERROR-FLAG WRK-CS-09V00   IC1124.2
+050600                 GO TO LINK-TEST-09-02.                           IC1124.2
+050700     MOVE "MORE THAN 649 RECORDS" TO RE-MARK.                     IC1124.2
+050800     GO TO LINK-FAIL-09.                                          IC1124.2
+050900 LINK-TEST-09-02.                                                 IC1124.2
+051000     IF ERROR-FLAG EQUAL TO 1                                     IC1124.2
+051100          GO TO LINK-PASS-09.                                     IC1124.2
+051200     MOVE "ERROR FLAG NOT SET IN SUBPRGRM" TO RE-MARK.            IC1124.2
+051300 LINK-FAIL-09.                                                    IC1124.2
+051400     PERFORM FAIL.                                                IC1124.2
+051500     GO TO LINK-WRITE-09.                                         IC1124.2
+051600 LINK-PASS-09.                                                    IC1124.2
+051700     PERFORM PASS.                                                IC1124.2
+051800 LINK-WRITE-09.                                                   IC1124.2
+051900     MOVE "LINK-TEST-09" TO PAR-NAME.                             IC1124.2
+052000     MOVE "CALL AFTER AT END" TO FEATURE.                         IC1124.2
+052100     PERFORM PRINT-DETAIL.                                        IC1124.2
+052200     CLOSE   SQ-FS3.                                              IC1124.2
+052300 EXIT-IC112.                                                      IC1124.2
+052400     EXIT.                                                        IC1124.2
+052500XFILE-DUMP SECTION.                                               IC1124.2
+052600XFILE-3-DUMP-INIT.                                                IC1124.2
+052700X    OPEN INPUT SQ-FS3.                                           IC1124.2
+052800X    MOVE ZERO TO WRK-CS-09V00.                                   IC1124.2
+052900XFILE-3-DUMP.                                                     IC1124.2
+053000X    ADD 1 TO WRK-CS-09V00.                                       IC1124.2
+053100X    IF WRK-CS-09V00 GREATER THAN 649                             IC1124.2
+053200X         GO TO FILE-3-DUMP-EXTRA.                                IC1124.2
+053300X    READ SQ-FS3 RECORD AT END                                    IC1124.2
+053400X         GO TO FILE-3-DUMP-END.                                  IC1124.2
+053500X    PERFORM FILE-3-DUMP-WRITE.                                   IC1124.2
+053600X    GO TO FILE-3-DUMP.                                           IC1124.2
+053700XFILE-3-DUMP-WRITE.                                               IC1124.2
+053800X    MOVE SQ-FS3R1-F-G-120 TO DUMMY-RECORD.                       IC1124.2
+053900X    PERFORM WRITE-LINE.                                          IC1124.2
+054000XFILE-3-DUMP-EXTRA.                                               IC1124.2
+054100X    PERFORM BLANK-LINE-PRINT 5 TIMES.                            IC1124.2
+054200XFILE-3-DUMP-MORE.                                                IC1124.2
+054300X    READ SQ-FS3 RECORD AT END                                    IC1124.2
+054400X         GO TO FILE-3-DUMP-END.                                  IC1124.2
+054500X    PERFORM FILE-3-DUMP-WRITE.                                   IC1124.2
+054600X    ADD 1 TO WRK-CS-09V00.                                       IC1124.2
+054700X    IF WRK-CS-09V00 LESS THAN 669                                IC1124.2
+054800X         GO TO FILE-3-DUMP-MORE.                                 IC1124.2
+054900XFILE-3-DUMP-END.                                                 IC1124.2
+055000X    CLOSE SQ-FS3.                                                IC1124.2
+055100XFILE-3-DUMP-EXIT.                                                IC1124.2
+055200X    EXIT.                                                        IC1124.2
+055300 CCVS-EXIT SECTION.                                               IC1124.2
+055400 CCVS-999999.                                                     IC1124.2
+055500     GO TO CLOSE-FILES.                                           IC1124.2

--- a/src/IC114A.CBL
+++ b/src/IC114A.CBL
@@ -1,0 +1,471 @@
+000100 IDENTIFICATION DIVISION.                                         IC1144.2
+000200 PROGRAM-ID.                                                      IC1144.2
+000300     IC114A.                                                      IC1144.2
+000400****************************************************************  IC1144.2
+000500*                                                              *  IC1144.2
+000600*    VALIDATION FOR:-                                          *  IC1144.2
+000700*                                                              *  IC1144.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1144.2
+000900*                                                              *  IC1144.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1144.2
+001100*                                                              *  IC1144.2
+001200****************************************************************  IC1144.2
+001300*                                                              *  IC1144.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC1144.2
+001500*                                                              *  IC1144.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC1144.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC1144.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC1144.2
+001900*                                                              *  IC1144.2
+002000****************************************************************  IC1144.2
+002100*                                                                 IC1144.2
+002200*         THE ROUTINE IC114 IS A MAIN PROGRAM WHICH CALLS THE     IC1144.2
+002300*    SUBPROGRAM IC115.  THE PURPOSE OF THESE PROGRAMS IS TO       IC1144.2
+002400*    VERIFY THAT A FILE SECTION, A WORKING-STORAGE SECTION, AND   IC1144.2
+002500*    A LINKAGE SECTION CAN APPEAR IN A SUBPROGRAM, AND A FILE     IC1144.2
+002600*    CAN BE WRITTEN AND READ WITHIN A SUBPROGRAM.                 IC1144.2
+002700*                                                                 IC1144.2
+002800*         THE PROGRAM IC114 CALLS IC115 TO CREATE AND VERIFY THE  IC1144.2
+002900*    FILE.  SUBSEQUENT CALLS TO THE SUBPROGRAM ARE MADE TO READ   IC1144.2
+003000*    THE FILE AND RETURN A RECORD TO THE MAIN PROGRAM WHICH CHECKSIC1144.2
+003100*    THE RECORD CONTENTS.                                         IC1144.2
+003200*                                                                 IC1144.2
+003300*         THE SUBPROGRAM IC115 IS ADAPTED FROM THE SEQUENTIAL I-O IC1144.2
+003400*    ROUTINE SQ104.  IF SQ104 DOES NOT EXECUTE CORRECTLY THEN     IC1144.2
+003500*    THE RESULTS OF THESE TESTS ARE INCONCLUSIVE.                 IC1144.2
+003600*                                                                 IC1144.2
+003700****************************************************************  IC1144.2
+003800 ENVIRONMENT DIVISION.                                            IC1144.2
+003900 CONFIGURATION SECTION.                                           IC1144.2
+004000 SOURCE-COMPUTER.                                                 IC1144.2
+004100     XXXXX082.                                                    IC1144.2
+004200 OBJECT-COMPUTER.                                                 IC1144.2
+004300     XXXXX083.                                                    IC1144.2
+004400 INPUT-OUTPUT SECTION.                                            IC1144.2
+004500 FILE-CONTROL.                                                    IC1144.2
+004600     SELECT PRINT-FILE ASSIGN TO                                  IC1144.2
+004700     XXXXX055.                                                    IC1144.2
+004800 DATA DIVISION.                                                   IC1144.2
+004900 FILE SECTION.                                                    IC1144.2
+005000 FD  PRINT-FILE.                                                  IC1144.2
+005100 01  PRINT-REC PICTURE X(120).                                    IC1144.2
+005200 01  DUMMY-RECORD PICTURE X(120).                                 IC1144.2
+005300 WORKING-STORAGE SECTION.                                         IC1144.2
+005400 01  GROUP-LINKAGE-VARIABLES.                                     IC1144.2
+005500         02  COUNT-OF-RECORDS  PICTURE 9(6).                      IC1144.2
+005600     02  RECORDS-IN-ERROR  PICTURE 9(6).                          IC1144.2
+005700     02  ERROR-FLAG  PICTURE 9.                                   IC1144.2
+005800     02  EOF-FLAG  PICTURE 9.                                     IC1144.2
+005900     02  CALL-FLAG  PICTURE 9.                                    IC1144.2
+006000 01  FILE-REC-SQ-FS3.                                             IC1144.2
+006100     02  XFILE-NAME-GROUP.                                        IC1144.2
+006200         03  FILLER   PIC X(5).                                   IC1144.2
+006300         03  XFILE-NAME   PIC X(6).                               IC1144.2
+006400     02  XRECORD-NAME-GROUP.                                      IC1144.2
+006500         03  FILLER   PIC X(8).                                   IC1144.2
+006600         03  XRECORD-NAME   PIC X(6).                             IC1144.2
+006700     02  REELUNIT-NUMBER-GROUP.                                   IC1144.2
+006800         03  FILLER   PIC X(1).                                   IC1144.2
+006900         03  REELUNIT-NUMBER   PIC 9(1).                          IC1144.2
+007000     02  FILLER   PIC X(7).                                       IC1144.2
+007100     02  XRECORD-NUMBER   PIC 9(6).                               IC1144.2
+007200     02  FILLER   PIC X(79).                                      IC1144.2
+007300     02  XLABEL-TYPE   PIC X(1).                                  IC1144.2
+007400 01  TEST-RESULTS.                                                IC1144.2
+007500     02 FILLER                   PIC X      VALUE SPACE.          IC1144.2
+007600     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC1144.2
+007700     02 FILLER                   PIC X      VALUE SPACE.          IC1144.2
+007800     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC1144.2
+007900     02 FILLER                   PIC X      VALUE SPACE.          IC1144.2
+008000     02  PAR-NAME.                                                IC1144.2
+008100       03 FILLER                 PIC X(19)  VALUE SPACE.          IC1144.2
+008200       03  PARDOT-X              PIC X      VALUE SPACE.          IC1144.2
+008300       03 DOTVALUE               PIC 99     VALUE ZERO.           IC1144.2
+008400     02 FILLER                   PIC X(8)   VALUE SPACE.          IC1144.2
+008500     02 RE-MARK                  PIC X(61).                       IC1144.2
+008600 01  TEST-COMPUTED.                                               IC1144.2
+008700     02 FILLER                   PIC X(30)  VALUE SPACE.          IC1144.2
+008800     02 FILLER                   PIC X(17)  VALUE                 IC1144.2
+008900            "       COMPUTED=".                                   IC1144.2
+009000     02 COMPUTED-X.                                               IC1144.2
+009100     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC1144.2
+009200     03 COMPUTED-N               REDEFINES COMPUTED-A             IC1144.2
+009300                                 PIC -9(9).9(9).                  IC1144.2
+009400     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC1144.2
+009500     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC1144.2
+009600     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC1144.2
+009700     03       CM-18V0 REDEFINES COMPUTED-A.                       IC1144.2
+009800         04 COMPUTED-18V0                    PIC -9(18).          IC1144.2
+009900         04 FILLER                           PIC X.               IC1144.2
+010000     03 FILLER PIC X(50) VALUE SPACE.                             IC1144.2
+010100 01  TEST-CORRECT.                                                IC1144.2
+010200     02 FILLER PIC X(30) VALUE SPACE.                             IC1144.2
+010300     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC1144.2
+010400     02 CORRECT-X.                                                IC1144.2
+010500     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC1144.2
+010600     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC1144.2
+010700     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC1144.2
+010800     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC1144.2
+010900     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC1144.2
+011000     03      CR-18V0 REDEFINES CORRECT-A.                         IC1144.2
+011100         04 CORRECT-18V0                     PIC -9(18).          IC1144.2
+011200         04 FILLER                           PIC X.               IC1144.2
+011300     03 FILLER PIC X(2) VALUE SPACE.                              IC1144.2
+011400     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC1144.2
+011500 01  CCVS-C-1.                                                    IC1144.2
+011600     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC1144.2
+011700-    "SS  PARAGRAPH-NAME                                          IC1144.2
+011800-    "       REMARKS".                                            IC1144.2
+011900     02 FILLER                     PIC X(20)    VALUE SPACE.      IC1144.2
+012000 01  CCVS-C-2.                                                    IC1144.2
+012100     02 FILLER                     PIC X        VALUE SPACE.      IC1144.2
+012200     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC1144.2
+012300     02 FILLER                     PIC X(15)    VALUE SPACE.      IC1144.2
+012400     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC1144.2
+012500     02 FILLER                     PIC X(94)    VALUE SPACE.      IC1144.2
+012600 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC1144.2
+012700 01  REC-CT                        PIC 99       VALUE ZERO.       IC1144.2
+012800 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC1144.2
+012900 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC1144.2
+013000 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC1144.2
+013100 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC1144.2
+013200 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC1144.2
+013300 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC1144.2
+013400 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC1144.2
+013500 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC1144.2
+013600 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC1144.2
+013700 01  CCVS-H-1.                                                    IC1144.2
+013800     02  FILLER                    PIC X(39)    VALUE SPACES.     IC1144.2
+013900     02  FILLER                    PIC X(42)    VALUE             IC1144.2
+014000     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC1144.2
+014100     02  FILLER                    PIC X(39)    VALUE SPACES.     IC1144.2
+014200 01  CCVS-H-2A.                                                   IC1144.2
+014300   02  FILLER                        PIC X(40)  VALUE SPACE.      IC1144.2
+014400   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC1144.2
+014500   02  FILLER                        PIC XXXX   VALUE             IC1144.2
+014600     "4.2 ".                                                      IC1144.2
+014700   02  FILLER                        PIC X(28)  VALUE             IC1144.2
+014800            " COPY - NOT FOR DISTRIBUTION".                       IC1144.2
+014900   02  FILLER                        PIC X(41)  VALUE SPACE.      IC1144.2
+015000                                                                  IC1144.2
+015100 01  CCVS-H-2B.                                                   IC1144.2
+015200   02  FILLER                        PIC X(15)  VALUE             IC1144.2
+015300            "TEST RESULT OF ".                                    IC1144.2
+015400   02  TEST-ID                       PIC X(9).                    IC1144.2
+015500   02  FILLER                        PIC X(4)   VALUE             IC1144.2
+015600            " IN ".                                               IC1144.2
+015700   02  FILLER                        PIC X(12)  VALUE             IC1144.2
+015800     " HIGH       ".                                              IC1144.2
+015900   02  FILLER                        PIC X(22)  VALUE             IC1144.2
+016000            " LEVEL VALIDATION FOR ".                             IC1144.2
+016100   02  FILLER                        PIC X(58)  VALUE             IC1144.2
+016200     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1144.2
+016300 01  CCVS-H-3.                                                    IC1144.2
+016400     02  FILLER                      PIC X(34)  VALUE             IC1144.2
+016500            " FOR OFFICIAL USE ONLY    ".                         IC1144.2
+016600     02  FILLER                      PIC X(58)  VALUE             IC1144.2
+016700     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1144.2
+016800     02  FILLER                      PIC X(28)  VALUE             IC1144.2
+016900            "  COPYRIGHT   1985 ".                                IC1144.2
+017000 01  CCVS-E-1.                                                    IC1144.2
+017100     02 FILLER                       PIC X(52)  VALUE SPACE.      IC1144.2
+017200     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC1144.2
+017300     02 ID-AGAIN                     PIC X(9).                    IC1144.2
+017400     02 FILLER                       PIC X(45)  VALUE SPACES.     IC1144.2
+017500 01  CCVS-E-2.                                                    IC1144.2
+017600     02  FILLER                      PIC X(31)  VALUE SPACE.      IC1144.2
+017700     02  FILLER                      PIC X(21)  VALUE SPACE.      IC1144.2
+017800     02 CCVS-E-2-2.                                               IC1144.2
+017900         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC1144.2
+018000         03 FILLER                   PIC X      VALUE SPACE.      IC1144.2
+018100         03 ENDER-DESC               PIC X(44)  VALUE             IC1144.2
+018200            "ERRORS ENCOUNTERED".                                 IC1144.2
+018300 01  CCVS-E-3.                                                    IC1144.2
+018400     02  FILLER                      PIC X(22)  VALUE             IC1144.2
+018500            " FOR OFFICIAL USE ONLY".                             IC1144.2
+018600     02  FILLER                      PIC X(12)  VALUE SPACE.      IC1144.2
+018700     02  FILLER                      PIC X(58)  VALUE             IC1144.2
+018800     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1144.2
+018900     02  FILLER                      PIC X(13)  VALUE SPACE.      IC1144.2
+019000     02 FILLER                       PIC X(15)  VALUE             IC1144.2
+019100             " COPYRIGHT 1985".                                   IC1144.2
+019200 01  CCVS-E-4.                                                    IC1144.2
+019300     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC1144.2
+019400     02 FILLER                       PIC X(4)   VALUE " OF ".     IC1144.2
+019500     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC1144.2
+019600     02 FILLER                       PIC X(40)  VALUE             IC1144.2
+019700      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC1144.2
+019800 01  XXINFO.                                                      IC1144.2
+019900     02 FILLER                       PIC X(19)  VALUE             IC1144.2
+020000            "*** INFORMATION ***".                                IC1144.2
+020100     02 INFO-TEXT.                                                IC1144.2
+020200       04 FILLER                     PIC X(8)   VALUE SPACE.      IC1144.2
+020300       04 XXCOMPUTED                 PIC X(20).                   IC1144.2
+020400       04 FILLER                     PIC X(5)   VALUE SPACE.      IC1144.2
+020500       04 XXCORRECT                  PIC X(20).                   IC1144.2
+020600     02 INF-ANSI-REFERENCE           PIC X(48).                   IC1144.2
+020700 01  HYPHEN-LINE.                                                 IC1144.2
+020800     02 FILLER  PIC IS X VALUE IS SPACE.                          IC1144.2
+020900     02 FILLER  PIC IS X(65)    VALUE IS "************************IC1144.2
+021000-    "*****************************************".                 IC1144.2
+021100     02 FILLER  PIC IS X(54)    VALUE IS "************************IC1144.2
+021200-    "******************************".                            IC1144.2
+021300 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC1144.2
+021400     "IC114A".                                                    IC1144.2
+021500 PROCEDURE DIVISION.                                              IC1144.2
+021600 CCVS1 SECTION.                                                   IC1144.2
+021700 OPEN-FILES.                                                      IC1144.2
+021800     OPEN     OUTPUT PRINT-FILE.                                  IC1144.2
+021900     MOVE CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.   IC1144.2
+022000     MOVE    SPACE TO TEST-RESULTS.                               IC1144.2
+022100     PERFORM  HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.             IC1144.2
+022200     GO TO CCVS1-EXIT.                                            IC1144.2
+022300 CLOSE-FILES.                                                     IC1144.2
+022400     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC1144.2
+022500 TERMINATE-CCVS.                                                  IC1144.2
+022600S    EXIT PROGRAM.                                                IC1144.2
+022700STERMINATE-CALL.                                                  IC1144.2
+022800     STOP     RUN.                                                IC1144.2
+022900 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         IC1144.2
+023000 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           IC1144.2
+023100 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          IC1144.2
+023200 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      IC1144.2
+023300     MOVE "****TEST DELETED****" TO RE-MARK.                      IC1144.2
+023400 PRINT-DETAIL.                                                    IC1144.2
+023500     IF REC-CT NOT EQUAL TO ZERO                                  IC1144.2
+023600             MOVE "." TO PARDOT-X                                 IC1144.2
+023700             MOVE REC-CT TO DOTVALUE.                             IC1144.2
+023800     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      IC1144.2
+023900     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               IC1144.2
+024000        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 IC1144.2
+024100          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 IC1144.2
+024200     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC1144.2
+024300     MOVE SPACE TO CORRECT-X.                                     IC1144.2
+024400     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC1144.2
+024500     MOVE     SPACE TO RE-MARK.                                   IC1144.2
+024600 HEAD-ROUTINE.                                                    IC1144.2
+024700     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC1144.2
+024800     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC1144.2
+024900     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC1144.2
+025000     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC1144.2
+025100 COLUMN-NAMES-ROUTINE.                                            IC1144.2
+025200     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1144.2
+025300     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1144.2
+025400     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC1144.2
+025500 END-ROUTINE.                                                     IC1144.2
+025600     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.IC1144.2
+025700 END-RTN-EXIT.                                                    IC1144.2
+025800     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1144.2
+025900 END-ROUTINE-1.                                                   IC1144.2
+026000      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      IC1144.2
+026100      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               IC1144.2
+026200      ADD PASS-COUNTER TO ERROR-HOLD.                             IC1144.2
+026300*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC1144.2
+026400      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC1144.2
+026500      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC1144.2
+026600      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC1144.2
+026700      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC1144.2
+026800  END-ROUTINE-12.                                                 IC1144.2
+026900      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC1144.2
+027000     IF       ERROR-COUNTER IS EQUAL TO ZERO                      IC1144.2
+027100         MOVE "NO " TO ERROR-TOTAL                                IC1144.2
+027200         ELSE                                                     IC1144.2
+027300         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC1144.2
+027400     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC1144.2
+027500     PERFORM WRITE-LINE.                                          IC1144.2
+027600 END-ROUTINE-13.                                                  IC1144.2
+027700     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC1144.2
+027800         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC1144.2
+027900         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC1144.2
+028000     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC1144.2
+028100     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1144.2
+028200      IF   INSPECT-COUNTER EQUAL TO ZERO                          IC1144.2
+028300          MOVE "NO " TO ERROR-TOTAL                               IC1144.2
+028400      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   IC1144.2
+028500      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            IC1144.2
+028600      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          IC1144.2
+028700     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1144.2
+028800 WRITE-LINE.                                                      IC1144.2
+028900     ADD 1 TO RECORD-COUNT.                                       IC1144.2
+029000Y    IF RECORD-COUNT GREATER 50                                   IC1144.2
+029100Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC1144.2
+029200Y        MOVE SPACE TO DUMMY-RECORD                               IC1144.2
+029300Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC1144.2
+029400Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC1144.2
+029500Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC1144.2
+029600Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC1144.2
+029700Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC1144.2
+029800Y        MOVE ZERO TO RECORD-COUNT.                               IC1144.2
+029900     PERFORM WRT-LN.                                              IC1144.2
+030000 WRT-LN.                                                          IC1144.2
+030100     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC1144.2
+030200     MOVE SPACE TO DUMMY-RECORD.                                  IC1144.2
+030300 BLANK-LINE-PRINT.                                                IC1144.2
+030400     PERFORM WRT-LN.                                              IC1144.2
+030500 FAIL-ROUTINE.                                                    IC1144.2
+030600     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC1144.2
+030700     IF     CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.IC1144.2
+030800     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC1144.2
+030900     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC1144.2
+031000     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1144.2
+031100     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC1144.2
+031200     GO TO  FAIL-ROUTINE-EX.                                      IC1144.2
+031300 FAIL-ROUTINE-WRITE.                                              IC1144.2
+031400     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC1144.2
+031500     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC1144.2
+031600     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC1144.2
+031700     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC1144.2
+031800 FAIL-ROUTINE-EX. EXIT.                                           IC1144.2
+031900 BAIL-OUT.                                                        IC1144.2
+032000     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC1144.2
+032100     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC1144.2
+032200 BAIL-OUT-WRITE.                                                  IC1144.2
+032300     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC1144.2
+032400     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC1144.2
+032500     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1144.2
+032600     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC1144.2
+032700 BAIL-OUT-EX. EXIT.                                               IC1144.2
+032800 CCVS1-EXIT.                                                      IC1144.2
+032900     EXIT.                                                        IC1144.2
+033000 LINK-TEST-10.                                                    IC1144.2
+033100     MOVE 1 TO CALL-FLAG.                                         IC1144.2
+033200*                                                                 IC1144.2
+033300*         THIS TEST CALLS IC115 WHICH CREATES THE FILE SQ-FS3.    IC1144.2
+033400*    THIS FILE IS A MASS STORAGE SEQUENTIAL FILE WITH 120         IC1144.2
+033500*    CHARACTER RECORDS.  THERE ARE 649 RECORDS IN THE FILE.       IC1144.2
+033600*                                                                 IC1144.2
+033700     CALL "IC115A" USING GROUP-LINKAGE-VARIABLES                  IC1144.2
+033800                        FILE-REC-SQ-FS3.                          IC1144.2
+033900     IF COUNT-OF-RECORDS EQUAL TO 649                             IC1144.2
+034000              GO TO LINK-PASS-10.                                 IC1144.2
+034100 LINK-FAIL-10.                                                    IC1144.2
+034200     PERFORM FAIL.                                                IC1144.2
+034300     MOVE "FILE NOT CREATED IN IC115" TO RE-MARK.                 IC1144.2
+034400     MOVE "RECS WRITTEN =" TO COMPUTED-A.                         IC1144.2
+034500     GO TO LINK-WRITE-10.                                         IC1144.2
+034600 LINK-PASS-10.                                                    IC1144.2
+034700     PERFORM PASS.                                                IC1144.2
+034800     MOVE "FILE CREATED, RECS =" TO COMPUTED-A.                   IC1144.2
+034900 LINK-WRITE-10.                                                   IC1144.2
+035000     MOVE "LINK-TEST-10" TO PAR-NAME.                             IC1144.2
+035100     MOVE "CREATE FILE SQ-FS3" TO FEATURE.                        IC1144.2
+035200     MOVE COUNT-OF-RECORDS TO CORRECT-18V0.                       IC1144.2
+035300     PERFORM PRINT-DETAIL.                                        IC1144.2
+035400 LINK-TEST-11.                                                    IC1144.2
+035500     MOVE 2 TO CALL-FLAG.                                         IC1144.2
+035600     MOVE ZERO TO COUNT-OF-RECORDS RECORDS-IN-ERROR               IC1144.2
+035700                  ERROR-FLAG EOF-FLAG.                            IC1144.2
+035800     CALL "IC115A" USING GROUP-LINKAGE-VARIABLES                  IC1144.2
+035900                        FILE-REC-SQ-FS3.                          IC1144.2
+036000     IF ERROR-FLAG EQUAL TO ZERO                                  IC1144.2
+036100              GO TO LINK-PASS-11.                                 IC1144.2
+036200     IF COUNT-OF-RECORDS GREATER THAN 649                         IC1144.2
+036300              MOVE "MORE THAN 649 RECORDS" TO RE-MARK             IC1144.2
+036400              GO TO LINK-FAIL-11.                                 IC1144.2
+036500     MOVE "ERRORS IN READING SQ-FS3" TO RE-MARK.                  IC1144.2
+036600 LINK-FAIL-11.                                                    IC1144.2
+036700     MOVE "RECORDS-IN-ERROR =" TO COMPUTED-A.                     IC1144.2
+036800     MOVE RECORDS-IN-ERROR TO CORRECT-18V0.                       IC1144.2
+036900     GO TO LINK-WRITE-11.                                         IC1144.2
+037000 LINK-PASS-11.                                                    IC1144.2
+037100     MOVE "FILE VERIFIED RECS =" TO COMPUTED-A.                   IC1144.2
+037200     MOVE COUNT-OF-RECORDS TO CORRECT-18V0.                       IC1144.2
+037300     PERFORM PASS.                                                IC1144.2
+037400 LINK-WRITE-11.                                                   IC1144.2
+037500     MOVE "LINK-TEST-11" TO PAR-NAME.                             IC1144.2
+037600     MOVE "VERIFY FILE SQ-FS3" TO FEATURE.                        IC1144.2
+037700     PERFORM PRINT-DETAIL.                                        IC1144.2
+037800 LINK-INIT-12.                                                    IC1144.2
+037900     MOVE 3 TO CALL-FLAG.                                         IC1144.2
+038000     MOVE ZERO TO COUNT-OF-RECORDS RECORDS-IN-ERROR               IC1144.2
+038100                  ERROR-FLAG EOF-FLAG.                            IC1144.2
+038200     CALL "IC115A" USING GROUP-LINKAGE-VARIABLES                  IC1144.2
+038300                        FILE-REC-SQ-FS3.                          IC1144.2
+038400*         CALL IC115 TO OPEN FILE SQ-FS3.                         IC1144.2
+038500     MOVE 4 TO CALL-FLAG.                                         IC1144.2
+038600 LINK-TEST-12.                                                    IC1144.2
+038700     CALL "IC115A" USING GROUP-LINKAGE-VARIABLES                  IC1144.2
+038800                        FILE-REC-SQ-FS3.                          IC1144.2
+038900*                                                                 IC1144.2
+039000*        THIS TEST REPEATEDLY CALLS IC115 TO READ THE FILE SQ-FS3.IC1144.2
+039100*    THE CONTENTS OF EACH DATA RECORD IS CHECKED FOR VALID DATA.  IC1144.2
+039200*                                                                 IC1144.2
+039300     IF EOF-FLAG EQUAL TO 1                                       IC1144.2
+039400              GO TO LINK-TEST-12-01.                              IC1144.2
+039500     ADD 1 TO COUNT-OF-RECORDS.                                   IC1144.2
+039600     IF COUNT-OF-RECORDS GREATER THAN 649                         IC1144.2
+039700              GO TO LINK-FAIL-12-02.                              IC1144.2
+039800     IF COUNT-OF-RECORDS NOT EQUAL TO XRECORD-NUMBER              IC1144.2
+039900              GO TO LINK-FAIL-12-01.                              IC1144.2
+040000     IF REELUNIT-NUMBER-GROUP NOT EQUAL TO "/0"                   IC1144.2
+040100              GO TO LINK-FAIL-12-01.                              IC1144.2
+040200     IF XFILE-NAME NOT EQUAL TO "SQ-FS3"                          IC1144.2
+040300              GO TO LINK-FAIL-12-01.                              IC1144.2
+040400     IF XRECORD-NAME NOT EQUAL TO "R1-F-G"                        IC1144.2
+040500              GO TO LINK-FAIL-12-01.                              IC1144.2
+040600     IF XLABEL-TYPE NOT EQUAL TO "S"                              IC1144.2
+040700              GO TO LINK-FAIL-12-01.                              IC1144.2
+040800     GO TO LINK-TEST-12.                                          IC1144.2
+040900 LINK-FAIL-12-01.                                                 IC1144.2
+041000     ADD 1 TO RECORDS-IN-ERROR.                                   IC1144.2
+041100     MOVE 1 TO ERROR-FLAG.                                        IC1144.2
+041200     GO TO LINK-TEST-12.                                          IC1144.2
+041300 LINK-FAIL-12-02.                                                 IC1144.2
+041400     MOVE "MORE THAN 649 RECORDS" TO RE-MARK.                     IC1144.2
+041500     GO TO LINK-FAIL-12.                                          IC1144.2
+041600 LINK-TEST-12-01.                                                 IC1144.2
+041700     IF COUNT-OF-RECORDS LESS THAN 649                            IC1144.2
+041800              GO TO LINK-FAIL-12-04.                              IC1144.2
+041900     IF ERROR-FLAG EQUAL TO ZERO                                  IC1144.2
+042000              GO TO LINK-PASS-12.                                 IC1144.2
+042100 LINK-FAIL-12-03.                                                 IC1144.2
+042200     MOVE "RECORDS-IN-ERROR =" TO COMPUTED-A.                     IC1144.2
+042300     MOVE RECORDS-IN-ERROR TO CORRECT-18V0.                       IC1144.2
+042400 LINK-FAIL-12.                                                    IC1144.2
+042500     PERFORM FAIL.                                                IC1144.2
+042600     GO TO LINK-WRITE-12.                                         IC1144.2
+042700 LINK-FAIL-12-04.                                                 IC1144.2
+042800     MOVE "UNEXPECTED EOF" TO RE-MARK.                            IC1144.2
+042900     MOVE "RECORDS READ =" TO COMPUTED-A.                         IC1144.2
+043000     MOVE COUNT-OF-RECORDS TO CORRECT-18V0.                       IC1144.2
+043100     GO TO LINK-FAIL-12.                                          IC1144.2
+043200 LINK-PASS-12.                                                    IC1144.2
+043300     PERFORM PASS.                                                IC1144.2
+043400 LINK-WRITE-12.                                                   IC1144.2
+043500     MOVE "LINK-TEST-12" TO PAR-NAME.                             IC1144.2
+043600     MOVE "READ IN SUBPRGM" TO FEATURE.                           IC1144.2
+043700     PERFORM PRINT-DETAIL.                                        IC1144.2
+043800 LINK-CLOSE-12.                                                   IC1144.2
+043900     MOVE 5 TO CALL-FLAG.                                         IC1144.2
+044000     CALL "IC115A" USING GROUP-LINKAGE-VARIABLES                  IC1144.2
+044100                        FILE-REC-SQ-FS3.                          IC1144.2
+044200 TERMINATE-ROUTINE.                                               IC1144.2
+044300     EXIT.                                                        IC1144.2
+044400XFILE-DUMP SECTION.                                               IC1144.2
+044500XFILE-DUMP-INIT.                                                  IC1144.2
+044600X    MOVE 3 TO CALL-FLAG.                                         IC1144.2
+044700X    MOVE ZERO TO EOF-FLAG COUNT-OF-RECORDS.                      IC1144.2
+044800X    CALL "IC115A" USING GROUP-LINKAGE-VARIABLES                  IC1144.2
+044900X                       FILE-REC-SQ-FS3.                          IC1144.2
+045000X    MOVE 4 TO CALL-FLAG.                                         IC1144.2
+045100XFILE-3-DUMP.                                                     IC1144.2
+045200X    CALL "IC115A" USING GROUP-LINKAGE-VARIABLES                  IC1144.2
+045300X                       FILE-REC-SQ-FS3.                          IC1144.2
+045400X    IF EOF-FLAG EQUAL TO 1                                       IC1144.2
+045500X             GO TO FILE-3-DUMP-END.                              IC1144.2
+045600X    ADD 1 TO COUNT-OF-RECORDS.                                   IC1144.2
+045700X    IF COUNT-OF-RECORDS EQUAL TO 650                             IC1144.2
+045800X             PERFORM BLANK-LINE-PRINT 5 TIMES.                   IC1144.2
+045900X    MOVE FILE-REC-SQ-FS3 TO DUMMY-RECORD.                        IC1144.2
+046000X    PERFORM WRITE-LINE.                                          IC1144.2
+046100X    IF COUNT-OF-RECORDS LESS THAN 669                            IC1144.2
+046200X             GO TO FILE-3-DUMP.                                  IC1144.2
+046300XFILE-3-DUMP-END.                                                 IC1144.2
+046400X    MOVE 5 TO CALL-FLAG.                                         IC1144.2
+046500X    CALL "IC115A" USING GROUP-LINKAGE-VARIABLES                  IC1144.2
+046600X                       FILE-REC-SQ-FS3.                          IC1144.2
+046700XFILE-3-DUMP-EXIT.                                                IC1144.2
+046800X    EXIT.                                                        IC1144.2
+046900 CCVS-EXIT SECTION.                                               IC1144.2
+047000 CCVS-999999.                                                     IC1144.2
+047100     GO TO CLOSE-FILES.                                           IC1144.2

--- a/src/IC116M.CBL
+++ b/src/IC116M.CBL
@@ -1,0 +1,343 @@
+000100 IDENTIFICATION DIVISION.                                         IC1164.2
+000200 PROGRAM-ID.                                                      IC1164.2
+000300     IC116M.                                                      IC1164.2
+000400****************************************************************  IC1164.2
+000500*                                                              *  IC1164.2
+000600*    VALIDATION FOR:-                                          *  IC1164.2
+000700*                                                              *  IC1164.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1164.2
+000900*                                                              *  IC1164.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1164.2
+001100*                                                              *  IC1164.2
+001200****************************************************************  IC1164.2
+001300*                                                              *  IC1164.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC1164.2
+001500*                                                              *  IC1164.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC1164.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC1164.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC1164.2
+001900*                                                              *  IC1164.2
+002000****************************************************************  IC1164.2
+002100*                                                                 IC1164.2
+002200*        THE PROGRAM IC116 AND THE SUBPROGRAMS IC117 AND IC118    IC1164.2
+002300*    TEST THE CALL STATEMENT WITHOUT THE OPTIONAL USING PHRASE    IC1164.2
+002400*    AND THE PROCEDURE DIVISION HEADER WITHOUT THE OPTIONAL       IC1164.2
+002500*    USING PHRASE IN THE SUBPROGRAMS.  THE MAIN PROGRAM IC116     IC1164.2
+002600*    CALLS THE SUBPROGRAM IC117 WHICH IN TURN CALLS THE SUBPRO-   IC1164.2
+002700*    GRAM IC118.  THE SUBPROGRAMS CONTAIN DISPLAY STATEMENTS WHICHIC1164.2
+002800*    SHOW THE EXECUTION SEQUENCE FOR THE PROGRAMS.                IC1164.2
+002900*                                                                 IC1164.2
+003000*    REFERENCE - AMERICAN NATIONAL STANDARD PROGRAMMING LANGUAGE  IC1164.2
+003100*                    COBOL, X3.23-1974                            IC1164.2
+003200*                SECTION XII, INTER-PROGRAM COMMUNICATION MODULE. IC1164.2
+003300*                                                                 IC1164.2
+003400******************************************************************IC1164.2
+003500 ENVIRONMENT DIVISION.                                            IC1164.2
+003600 CONFIGURATION SECTION.                                           IC1164.2
+003700 SOURCE-COMPUTER.                                                 IC1164.2
+003800     XXXXX082.                                                    IC1164.2
+003900 OBJECT-COMPUTER.                                                 IC1164.2
+004000     XXXXX083.                                                    IC1164.2
+004100 INPUT-OUTPUT SECTION.                                            IC1164.2
+004200 FILE-CONTROL.                                                    IC1164.2
+004300     SELECT PRINT-FILE ASSIGN TO                                  IC1164.2
+004400     XXXXX055.                                                    IC1164.2
+004500 DATA DIVISION.                                                   IC1164.2
+004600 FILE SECTION.                                                    IC1164.2
+004700 FD  PRINT-FILE.                                                  IC1164.2
+004800 01  PRINT-REC PICTURE X(120).                                    IC1164.2
+004900 01  DUMMY-RECORD PICTURE X(120).                                 IC1164.2
+005000 WORKING-STORAGE SECTION.                                         IC1164.2
+005100 01  SUMMARY-MESSAGE-1.                                           IC1164.2
+005200     02  FILLER          PICTURE X(10)  VALUE SPACE.              IC1164.2
+005300     02  FILLER          PICTURE X(46)                            IC1164.2
+005400         VALUE "THERE SHOULD BE THREE DISPLAY MESSAGES ON THE ".  IC1164.2
+005500     02  FILLER          PICTURE X(23)                            IC1164.2
+005600         VALUE "DEFAULT DISPLAY DEVICE.".                         IC1164.2
+005700 01  SUMMARY-MESSAGE-2.                                           IC1164.2
+005800     02  FILLER          PICTURE X(10)  VALUE SPACE.              IC1164.2
+005900     02  FILLER          PICTURE X(44)                            IC1164.2
+006000         VALUE "IF THERE ARE NOT THREE DISPLAY MESSAGES THE ".    IC1164.2
+006100     02  FILLER          PICTURE X(33)                            IC1164.2
+006200         VALUE "OPTIONAL USING PHRASE TESTS FAIL.".               IC1164.2
+006300 01  TEST-RESULTS.                                                IC1164.2
+006400     02 FILLER                   PIC X      VALUE SPACE.          IC1164.2
+006500     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC1164.2
+006600     02 FILLER                   PIC X      VALUE SPACE.          IC1164.2
+006700     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC1164.2
+006800     02 FILLER                   PIC X      VALUE SPACE.          IC1164.2
+006900     02  PAR-NAME.                                                IC1164.2
+007000       03 FILLER                 PIC X(19)  VALUE SPACE.          IC1164.2
+007100       03  PARDOT-X              PIC X      VALUE SPACE.          IC1164.2
+007200       03 DOTVALUE               PIC 99     VALUE ZERO.           IC1164.2
+007300     02 FILLER                   PIC X(8)   VALUE SPACE.          IC1164.2
+007400     02 RE-MARK                  PIC X(61).                       IC1164.2
+007500 01  TEST-COMPUTED.                                               IC1164.2
+007600     02 FILLER                   PIC X(30)  VALUE SPACE.          IC1164.2
+007700     02 FILLER                   PIC X(17)  VALUE                 IC1164.2
+007800            "       COMPUTED=".                                   IC1164.2
+007900     02 COMPUTED-X.                                               IC1164.2
+008000     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC1164.2
+008100     03 COMPUTED-N               REDEFINES COMPUTED-A             IC1164.2
+008200                                 PIC -9(9).9(9).                  IC1164.2
+008300     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC1164.2
+008400     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC1164.2
+008500     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC1164.2
+008600     03       CM-18V0 REDEFINES COMPUTED-A.                       IC1164.2
+008700         04 COMPUTED-18V0                    PIC -9(18).          IC1164.2
+008800         04 FILLER                           PIC X.               IC1164.2
+008900     03 FILLER PIC X(50) VALUE SPACE.                             IC1164.2
+009000 01  TEST-CORRECT.                                                IC1164.2
+009100     02 FILLER PIC X(30) VALUE SPACE.                             IC1164.2
+009200     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC1164.2
+009300     02 CORRECT-X.                                                IC1164.2
+009400     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC1164.2
+009500     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC1164.2
+009600     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC1164.2
+009700     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC1164.2
+009800     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC1164.2
+009900     03      CR-18V0 REDEFINES CORRECT-A.                         IC1164.2
+010000         04 CORRECT-18V0                     PIC -9(18).          IC1164.2
+010100         04 FILLER                           PIC X.               IC1164.2
+010200     03 FILLER PIC X(2) VALUE SPACE.                              IC1164.2
+010300     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC1164.2
+010400 01  CCVS-C-1.                                                    IC1164.2
+010500     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC1164.2
+010600-    "SS  PARAGRAPH-NAME                                          IC1164.2
+010700-    "       REMARKS".                                            IC1164.2
+010800     02 FILLER                     PIC X(20)    VALUE SPACE.      IC1164.2
+010900 01  CCVS-C-2.                                                    IC1164.2
+011000     02 FILLER                     PIC X        VALUE SPACE.      IC1164.2
+011100     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC1164.2
+011200     02 FILLER                     PIC X(15)    VALUE SPACE.      IC1164.2
+011300     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC1164.2
+011400     02 FILLER                     PIC X(94)    VALUE SPACE.      IC1164.2
+011500 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC1164.2
+011600 01  REC-CT                        PIC 99       VALUE ZERO.       IC1164.2
+011700 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC1164.2
+011800 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC1164.2
+011900 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC1164.2
+012000 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC1164.2
+012100 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC1164.2
+012200 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC1164.2
+012300 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC1164.2
+012400 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC1164.2
+012500 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC1164.2
+012600 01  CCVS-H-1.                                                    IC1164.2
+012700     02  FILLER                    PIC X(39)    VALUE SPACES.     IC1164.2
+012800     02  FILLER                    PIC X(42)    VALUE             IC1164.2
+012900     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC1164.2
+013000     02  FILLER                    PIC X(39)    VALUE SPACES.     IC1164.2
+013100 01  CCVS-H-2A.                                                   IC1164.2
+013200   02  FILLER                        PIC X(40)  VALUE SPACE.      IC1164.2
+013300   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC1164.2
+013400   02  FILLER                        PIC XXXX   VALUE             IC1164.2
+013500     "4.2 ".                                                      IC1164.2
+013600   02  FILLER                        PIC X(28)  VALUE             IC1164.2
+013700            " COPY - NOT FOR DISTRIBUTION".                       IC1164.2
+013800   02  FILLER                        PIC X(41)  VALUE SPACE.      IC1164.2
+013900                                                                  IC1164.2
+014000 01  CCVS-H-2B.                                                   IC1164.2
+014100   02  FILLER                        PIC X(15)  VALUE             IC1164.2
+014200            "TEST RESULT OF ".                                    IC1164.2
+014300   02  TEST-ID                       PIC X(9).                    IC1164.2
+014400   02  FILLER                        PIC X(4)   VALUE             IC1164.2
+014500            " IN ".                                               IC1164.2
+014600   02  FILLER                        PIC X(12)  VALUE             IC1164.2
+014700     " HIGH       ".                                              IC1164.2
+014800   02  FILLER                        PIC X(22)  VALUE             IC1164.2
+014900            " LEVEL VALIDATION FOR ".                             IC1164.2
+015000   02  FILLER                        PIC X(58)  VALUE             IC1164.2
+015100     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1164.2
+015200 01  CCVS-H-3.                                                    IC1164.2
+015300     02  FILLER                      PIC X(34)  VALUE             IC1164.2
+015400            " FOR OFFICIAL USE ONLY    ".                         IC1164.2
+015500     02  FILLER                      PIC X(58)  VALUE             IC1164.2
+015600     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1164.2
+015700     02  FILLER                      PIC X(28)  VALUE             IC1164.2
+015800            "  COPYRIGHT   1985 ".                                IC1164.2
+015900 01  CCVS-E-1.                                                    IC1164.2
+016000     02 FILLER                       PIC X(52)  VALUE SPACE.      IC1164.2
+016100     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC1164.2
+016200     02 ID-AGAIN                     PIC X(9).                    IC1164.2
+016300     02 FILLER                       PIC X(45)  VALUE SPACES.     IC1164.2
+016400 01  CCVS-E-2.                                                    IC1164.2
+016500     02  FILLER                      PIC X(31)  VALUE SPACE.      IC1164.2
+016600     02  FILLER                      PIC X(21)  VALUE SPACE.      IC1164.2
+016700     02 CCVS-E-2-2.                                               IC1164.2
+016800         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC1164.2
+016900         03 FILLER                   PIC X      VALUE SPACE.      IC1164.2
+017000         03 ENDER-DESC               PIC X(44)  VALUE             IC1164.2
+017100            "ERRORS ENCOUNTERED".                                 IC1164.2
+017200 01  CCVS-E-3.                                                    IC1164.2
+017300     02  FILLER                      PIC X(22)  VALUE             IC1164.2
+017400            " FOR OFFICIAL USE ONLY".                             IC1164.2
+017500     02  FILLER                      PIC X(12)  VALUE SPACE.      IC1164.2
+017600     02  FILLER                      PIC X(58)  VALUE             IC1164.2
+017700     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1164.2
+017800     02  FILLER                      PIC X(13)  VALUE SPACE.      IC1164.2
+017900     02 FILLER                       PIC X(15)  VALUE             IC1164.2
+018000             " COPYRIGHT 1985".                                   IC1164.2
+018100 01  CCVS-E-4.                                                    IC1164.2
+018200     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC1164.2
+018300     02 FILLER                       PIC X(4)   VALUE " OF ".     IC1164.2
+018400     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC1164.2
+018500     02 FILLER                       PIC X(40)  VALUE             IC1164.2
+018600      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC1164.2
+018700 01  XXINFO.                                                      IC1164.2
+018800     02 FILLER                       PIC X(19)  VALUE             IC1164.2
+018900            "*** INFORMATION ***".                                IC1164.2
+019000     02 INFO-TEXT.                                                IC1164.2
+019100       04 FILLER                     PIC X(8)   VALUE SPACE.      IC1164.2
+019200       04 XXCOMPUTED                 PIC X(20).                   IC1164.2
+019300       04 FILLER                     PIC X(5)   VALUE SPACE.      IC1164.2
+019400       04 XXCORRECT                  PIC X(20).                   IC1164.2
+019500     02 INF-ANSI-REFERENCE           PIC X(48).                   IC1164.2
+019600 01  HYPHEN-LINE.                                                 IC1164.2
+019700     02 FILLER  PIC IS X VALUE IS SPACE.                          IC1164.2
+019800     02 FILLER  PIC IS X(65)    VALUE IS "************************IC1164.2
+019900-    "*****************************************".                 IC1164.2
+020000     02 FILLER  PIC IS X(54)    VALUE IS "************************IC1164.2
+020100-    "******************************".                            IC1164.2
+020200 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC1164.2
+020300     "IC116M".                                                    IC1164.2
+020400 PROCEDURE DIVISION.                                              IC1164.2
+020500 CCVS1 SECTION.                                                   IC1164.2
+020600 OPEN-FILES.                                                      IC1164.2
+020700     OPEN     OUTPUT PRINT-FILE.                                  IC1164.2
+020800     MOVE CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.   IC1164.2
+020900     MOVE    SPACE TO TEST-RESULTS.                               IC1164.2
+021000     PERFORM  HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.             IC1164.2
+021100     GO TO CCVS1-EXIT.                                            IC1164.2
+021200 CLOSE-FILES.                                                     IC1164.2
+021300     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC1164.2
+021400 TERMINATE-CCVS.                                                  IC1164.2
+021500S    EXIT PROGRAM.                                                IC1164.2
+021600STERMINATE-CALL.                                                  IC1164.2
+021700     STOP     RUN.                                                IC1164.2
+021800 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         IC1164.2
+021900 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           IC1164.2
+022000 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          IC1164.2
+022100 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      IC1164.2
+022200     MOVE "****TEST DELETED****" TO RE-MARK.                      IC1164.2
+022300 PRINT-DETAIL.                                                    IC1164.2
+022400     IF REC-CT NOT EQUAL TO ZERO                                  IC1164.2
+022500             MOVE "." TO PARDOT-X                                 IC1164.2
+022600             MOVE REC-CT TO DOTVALUE.                             IC1164.2
+022700     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      IC1164.2
+022800     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               IC1164.2
+022900        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 IC1164.2
+023000          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 IC1164.2
+023100     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC1164.2
+023200     MOVE SPACE TO CORRECT-X.                                     IC1164.2
+023300     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC1164.2
+023400     MOVE     SPACE TO RE-MARK.                                   IC1164.2
+023500 HEAD-ROUTINE.                                                    IC1164.2
+023600     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC1164.2
+023700     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC1164.2
+023800     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC1164.2
+023900     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC1164.2
+024000 COLUMN-NAMES-ROUTINE.                                            IC1164.2
+024100     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1164.2
+024200     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1164.2
+024300     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC1164.2
+024400 END-ROUTINE.                                                     IC1164.2
+024500     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.IC1164.2
+024600 END-RTN-EXIT.                                                    IC1164.2
+024700     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1164.2
+024800 END-ROUTINE-1.                                                   IC1164.2
+024900      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      IC1164.2
+025000      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               IC1164.2
+025100      ADD PASS-COUNTER TO ERROR-HOLD.                             IC1164.2
+025200*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC1164.2
+025300      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC1164.2
+025400      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC1164.2
+025500      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC1164.2
+025600      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC1164.2
+025700  END-ROUTINE-12.                                                 IC1164.2
+025800      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC1164.2
+025900     IF       ERROR-COUNTER IS EQUAL TO ZERO                      IC1164.2
+026000         MOVE "NO " TO ERROR-TOTAL                                IC1164.2
+026100         ELSE                                                     IC1164.2
+026200         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC1164.2
+026300     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC1164.2
+026400     PERFORM WRITE-LINE.                                          IC1164.2
+026500 END-ROUTINE-13.                                                  IC1164.2
+026600     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC1164.2
+026700         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC1164.2
+026800         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC1164.2
+026900     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC1164.2
+027000     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1164.2
+027100      IF   INSPECT-COUNTER EQUAL TO ZERO                          IC1164.2
+027200          MOVE "NO " TO ERROR-TOTAL                               IC1164.2
+027300      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   IC1164.2
+027400      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            IC1164.2
+027500      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          IC1164.2
+027600     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC1164.2
+027700 WRITE-LINE.                                                      IC1164.2
+027800     ADD 1 TO RECORD-COUNT.                                       IC1164.2
+027900Y    IF RECORD-COUNT GREATER 50                                   IC1164.2
+028000Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC1164.2
+028100Y        MOVE SPACE TO DUMMY-RECORD                               IC1164.2
+028200Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC1164.2
+028300Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC1164.2
+028400Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC1164.2
+028500Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC1164.2
+028600Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC1164.2
+028700Y        MOVE ZERO TO RECORD-COUNT.                               IC1164.2
+028800     PERFORM WRT-LN.                                              IC1164.2
+028900 WRT-LN.                                                          IC1164.2
+029000     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC1164.2
+029100     MOVE SPACE TO DUMMY-RECORD.                                  IC1164.2
+029200 BLANK-LINE-PRINT.                                                IC1164.2
+029300     PERFORM WRT-LN.                                              IC1164.2
+029400 FAIL-ROUTINE.                                                    IC1164.2
+029500     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC1164.2
+029600     IF     CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.IC1164.2
+029700     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC1164.2
+029800     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC1164.2
+029900     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1164.2
+030000     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC1164.2
+030100     GO TO  FAIL-ROUTINE-EX.                                      IC1164.2
+030200 FAIL-ROUTINE-WRITE.                                              IC1164.2
+030300     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC1164.2
+030400     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC1164.2
+030500     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC1164.2
+030600     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC1164.2
+030700 FAIL-ROUTINE-EX. EXIT.                                           IC1164.2
+030800 BAIL-OUT.                                                        IC1164.2
+030900     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC1164.2
+031000     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC1164.2
+031100 BAIL-OUT-WRITE.                                                  IC1164.2
+031200     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC1164.2
+031300     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC1164.2
+031400     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC1164.2
+031500     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC1164.2
+031600 BAIL-OUT-EX. EXIT.                                               IC1164.2
+031700 CCVS1-EXIT.                                                      IC1164.2
+031800     EXIT.                                                        IC1164.2
+031900 SECT-IC116-0001 SECTION.                                         IC1164.2
+032000 USNG-TEST-01.                                                    IC1164.2
+032100     CALL "IC117M".                                               IC1164.2
+032200*                                                                 IC1164.2
+032300*    THIS TEST CONTAINS A CALL STATEMENT WITHOUT THE OPTIONAL     IC1164.2
+032400*    USING PHRASE.                                                IC1164.2
+032500*                                                                 IC1164.2
+032600 USNG-WRITE-01.                                                   IC1164.2
+032700     PERFORM BLANK-LINE-PRINT.                                    IC1164.2
+032800     MOVE "CALL WITHOUT USING" TO FEATURE.                        IC1164.2
+032900     MOVE "USNG-TEST-01" TO PAR-NAME.                             IC1164.2
+033000     PERFORM PASS.                                                IC1164.2
+033100     PERFORM PRINT-DETAIL.                                        IC1164.2
+033200 SUMMARY-REMARKS.                                                 IC1164.2
+033300     PERFORM BLANK-LINE-PRINT.                                    IC1164.2
+033400     MOVE SUMMARY-MESSAGE-1 TO DUMMY-RECORD.                      IC1164.2
+033500     PERFORM WRITE-LINE.                                          IC1164.2
+033600     MOVE SUMMARY-MESSAGE-2 TO DUMMY-RECORD.                      IC1164.2
+033700     PERFORM WRITE-LINE.                                          IC1164.2
+033800     PERFORM BLANK-LINE-PRINT.                                    IC1164.2
+033900 IC116-EXIT.                                                      IC1164.2
+034000     EXIT.                                                        IC1164.2
+034100 CCVS-EXIT SECTION.                                               IC1164.2
+034200 CCVS-999999.                                                     IC1164.2
+034300     GO TO CLOSE-FILES.                                           IC1164.2

--- a/src/IC117M.CBL
+++ b/src/IC117M.CBL
@@ -1,0 +1,71 @@
+000100 IDENTIFICATION DIVISION.                                         IC1174.2
+000200 PROGRAM-ID.                                                      IC1174.2
+000300     IC117M.                                                      IC1174.2
+000400****************************************************************  IC1174.2
+000500*                                                              *  IC1174.2
+000600*    VALIDATION FOR:-                                          *  IC1174.2
+000700*                                                              *  IC1174.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC1174.2
+000900*                                                              *  IC1174.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC1174.2
+001100*                                                              *  IC1174.2
+001200****************************************************************  IC1174.2
+001300*                                                              *  IC1174.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC1174.2
+001500*                                                              *  IC1174.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC1174.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC1174.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC1174.2
+001900*                                                              *  IC1174.2
+002000****************************************************************  IC1174.2
+002100*                                                                 IC1174.2
+002200*        THE SUBPROGRAM IC117 IS CALLED BY THE MAIN PROGRAM IC116.IC1174.2
+002300*    THE SUBPROGRAM IC117 DOES NOT CONTAIN A LINKAGE SECTION OR   IC1174.2
+002400*    AN USING PHRASE IN THE PROCEDURE DIVISION HEADER.  DISPLAY   IC1174.2
+002500*    STATEMENTS ARE USED TO VERIFY THE PROGRAM EXECUTION SEQUENCE.IC1174.2
+002600*    THE SUBPROGRAM IC118 IS CALLED BY THE SUBPROGRAM IC117 AND   IC1174.2
+002700*    THE CALL STATEMENT IN THE SUBPROGRAM ALSO DOES NOT HAVE AN   IC1174.2
+002800*    USING PHRASE.                                                IC1174.2
+002900*                                                                 IC1174.2
+003000*    REFERENCE - AMERICAN NATIONAL STANDARD PROGRAMMING LANGUAGE  IC1174.2
+003100*                    COBOL, X3.23-1974                            IC1174.2
+003200*                SECTION XII, INTER-PROGRAM COMMUNICATION MODULE. IC1174.2
+003300*                                                                 IC1174.2
+003400******************************************************************IC1174.2
+003500 ENVIRONMENT DIVISION.                                            IC1174.2
+003600 CONFIGURATION SECTION.                                           IC1174.2
+003700 SOURCE-COMPUTER.                                                 IC1174.2
+003800     XXXXX082.                                                    IC1174.2
+003900 OBJECT-COMPUTER.                                                 IC1174.2
+004000     XXXXX083.                                                    IC1174.2
+004100 DATA DIVISION.                                                   IC1174.2
+004200 WORKING-STORAGE SECTION.                                         IC1174.2
+004300 01  IC117-TEMP1         PICTURE 9.                               IC1174.2
+004400 01  ONE                 PICTURE 9    VALUE 1.                    IC1174.2
+004500 01  IC117-TEMP2         PICTURE 9     VALUE 0.                   IC1174.2
+004600 PROCEDURE DIVISION.                                              IC1174.2
+004700*USNG-TEST-02.                                                    IC1174.2
+004800*                                                                 IC1174.2
+004900*    THIS TEST VERIFIES THAT A SUBPROGRAM PROCEDURE DIVISION      IC1174.2
+005000*    HEADER IS NOT REQUIRED TO HAVE THE OPTIONAL USING PHRASE.    IC1174.2
+005100*                                                                 IC1174.2
+005200 USNG-VERIFY-02.                                                  IC1174.2
+005300     MOVE 1 TO IC117-TEMP1.                                       IC1174.2
+005400     ADD ONE TO IC117-TEMP2.                                      IC1174.2
+005500*                                                                 IC1174.2
+005600*    THE RESULTS OF THE ABOVE STATEMENTS ARE NOT TESTED.          IC1174.2
+005700*                                                                 IC1174.2
+005800 USNG-DISPLAY-02.                                                 IC1174.2
+005900     DISPLAY "  ".                                                IC1174.2
+006000     DISPLAY "IC117M CALLED".                                     IC1174.2
+006100 USNG-TEST-03.                                                    IC1174.2
+006200     CALL "IC118M".                                               IC1174.2
+006300*                                                                 IC1174.2
+006400*    THIS TEST CONTAINS A CALL STATEMENT WITHOUT THE OPTIONAL     IC1174.2
+006500*    USING PHRASE.                                                IC1174.2
+006600*    REFERENCE - X3.23-1995, PAGE X-27, 5.2, THE CALL STATEMENT.  IC1174.2
+006700*                                                                 IC1174.2
+006800 USNG-DISPLAY-03.                                                 IC1174.2
+006900     DISPLAY "RETURNED TO IC117M".                                IC1174.2
+007000 IC117-EXIT.                                                      IC1174.2
+007100     EXIT PROGRAM.                                                IC1174.2


### PR DESCRIPTION
Fixes #5 

Sources were taken from NIST collections supplied by Don Higgins and James Cray. From those sources I have - to the best of my abilities - reconstructed the original program sources.
