### PR TITLE
Create workaround for nested programs which are not supported by z390

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,63 @@
+# Intellij project files
+.idea/
+*.iml
+
+# VSCode workspace settings
+.vscode/
+
+# doc working areas
+docenv/
+site/
+
+# Assembler/emulator output stuff
+**/*.[bB][aA][lL]
+**/*.[dD][fF]?
+**/*.[dD][iI]?
+**/*.[eE][rR][rR]
+**/*.[hH][lL][aA]
+**/*.[iI][mM][gG]
+**/*.[lL][oO][gG]
+**/*.[lL][sS][tT]
+**/*.[mM][lL][cC]
+**/*.[oO][bB][jJ]
+**/*.[oO][uU][tT]
+**/*.[pP][cC][hH]
+**/*.[pP][rR]1
+**/*.[pP][rR][nN]
+**/*.[rR][pP][tT]
+**/*.[sS][fF][0-9]
+**/*.[sS][tT][aA]
+**/*.[sS][vV]*
+**/*.[tT][fF][0-9]
+!**/*.[tT][fF][1-3]
+**/*.[tT][rR]?
+**/*.[tT][sS][tT]
+# *.XPH / *.XPR / *.XPT
+**/*.[xX][pP][hHrRtT]
+**/*_ZC_LABELS.CPY
+**/*.390
+
+# Other output stuff
+**/[aA][lL][lL]/
+**/[cC][lL][aA][sS][sS][eE][sS]/
+**/[dD][iI][fF]/
+**/[dD][iI][fF][fF]/
+**/[sS][aA][vV][eE]/
+**/*.[bB][mM][kK]
+**/*.[hH][tT][mM]
+**/*.[hH][tT][mM][lL]
+**/*.[oO][tT][1-9]
+# *.RLE / *.RLG / *.RUE / *.RUG
+**/*.[rR][lLuU][eEgG]
+**/*.[uU][lL][dD]
+**/*.[uU][rR][fF]
+**/*.[vV][eE][sS]
+# *.VX0 / *.VXN
+**/*.[vV][xX][0nN]
+
+# redirection files
+**/*.[lL][nN][kK]
+
+# Start ignore rules for docs here
+!doc/**
+!doc_overrides/**

--- a/z390/IC222A.CBL
+++ b/z390/IC222A.CBL
@@ -1,0 +1,1024 @@
+000100 IDENTIFICATION DIVISION.                                         IC2224.2
+      *
+      * This is the z390 version of IC222A
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC222A1
+      * IC222A has been modified to call IC222A1 instead of IC222A-1.
+      *
+000200 PROGRAM-ID.                                                      IC2224.2
+000300     IC222A.                                                      IC2224.2
+000400****************************************************************  IC2224.2
+000500*                                                              *  IC2224.2
+000600*    VALIDATION FOR:-                                          *  IC2224.2
+000700*                                                              *  IC2224.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2224.2
+000900*                                                              *  IC2224.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2224.2
+001100*                                                              *  IC2224.2
+001200****************************************************************  IC2224.2
+001300*                                                              *  IC2224.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2224.2
+001500*                                                              *  IC2224.2
+001600*            X-55   SYSTEM PRINTER                             *  IC2224.2
+001700*            X-82   SOURCE-COMPUTER                            *  IC2224.2
+001800*            X-83   OBJECT-COMPUTER.                           *  IC2224.2
+001900*                                                              *  IC2224.2
+002000****************************************************************  IC2224.2
+002100*                                                              *  IC2224.2
+002200*    THE SOURCE FILE CONTAINS TWO PROGRAMS, IC222A AND         *  IC2224.2
+002300*    IC222A-1, WHICH TEST LANGUAGE ELEMENTS FROM  LEVEL 2 OF   *  IC2224.2
+002400*    THE INTER-PROGRAM COMMUNICATION MODULE.  THE LANGUAGE     *  IC2224.2
+002500*    ELEMENTS TESTED ARE:                                      *  IC2224.2
+002600*          "ON EXCEPTION"     PHRASE                           *  IC2224.2
+002700*          "NOT ON EXCEPTION" PHRASE                           *  IC2224.2
+002800*          "END-CALL"         PHRASE                           *  IC2224.2
+002900*          "ON OVERFLOW"      PHRASE                           *  IC2224.2
+003000*                                                              *  IC2224.2
+003100*    THE TWO PROGRAMS SHOULD BE COMPILED IN THE SAME           *  IC2224.2
+003200*    INVOCATION OF THE COMPILER TO TEST THE BATCH COMPILATION  *  IC2224.2
+003300*    FEATURE AND RECOGNITION OF THE END PROGRAM HEADER.  THE   *  IC2224.2
+003400*    ARRANGEMENT OF THE PROGRAMS IN THE SOURCE FILE IS:        *  IC2224.2
+003500*                                                              *  IC2224.2
+003600*    IDENTIFICATION DIVISION.                                  *  IC2224.2
+003700*    PROGRAM-ID. IC222A.                                       *  IC2224.2
+003800*          .                                                   *  IC2224.2
+003900*          .                                                   *  IC2224.2
+004000*          .                                                   *  IC2224.2
+004100*    END PROGRAM IC222A.                                          IC2224.2
+004200*    IDENTIFICATION DIVISION.                                     IC2224.2
+004300*    PROGRAM-ID. IC222A-1.                                        IC2224.2
+004400*          .                                                   *  IC2224.2
+004500*          .                                                   *  IC2224.2
+004600*          .                                                   *  IC2224.2
+004700*                                                              *  IC2224.2
+004800*    IC222A, THE FIRST PROGRAM IN THE FILE, CONTAINS THE       *  IC2224.2
+004900*    SUBSTANTIVE TESTS.  THE ONLY FUNCTION OF THE OTHER        *  IC2224.2
+005000*    PROGRAM IS TO ENSURE THAT A PROGRAM WITH KNOWN PARAMETER  *  IC2224.2
+005100*    REQUIREMENTS IS AVAILABLE TO BE CALLED.  IC222A TESTS     *  IC2224.2
+005200*    CONTROL FLOW THROUGH VARIANTS OF THE CALL STATEMENT WITH  *  IC2224.2
+005300*    THE "ON EXCEPTION" PHRASE PRESENT OR ABSENT; THE "NOT ON  *  IC2224.2
+005400*    EXCEPTION" PHRASE PRESENT OR ABSENT; AND AVAILABLE OR     *  IC2224.2
+005500*    NON-AVAIABLE TARGET PROGRAMS.  EACH CALL STATEMENT HAS AN *  IC2224.2
+005600*    END-CALL PHRASE, AND THERE ARE SECONDARY TESTS WHICH      *  IC2224.2
+005700*    CHECK THAT STATEMENTS FOLLOWING END-CALL ARE PROPERLY     *  IC2224.2
+005800*    EXECUTED.                                                 *  IC2224.2
+005900*                                                                 IC2224.2
+006000*    THIS TEST SET DOES NOT EXAMINE THE RESULTS RETURNED BY    *  IC2224.2
+006100*    THE CALLED PROGRAM, BUT IS WHOLLY CONCERNED WITH THE FLOW *  IC2224.2
+006200*    OF CONTROL IN THE CALLING PROGRAM DURING EXECUTION OF A   *  IC2224.2
+006300*    CALL STATEMENT.                                           *  IC2224.2
+006400*                                                              *  IC2224.2
+006500*    THERE ARE EIGHT POSIBLE COMBINATIONS OF CALL STATEMENT    *  IC2224.2
+006600*    FORMAT AND CALLED PROGRAM AVAILABILITY THAT COULD BE      *  IC2224.2
+006700*    TESTED.  TWO OF THESE COMBINATIONS, THOSE WHERE A PROGRAM *  IC2224.2
+006800*    WHICH IS NOT AVAILABLE IS CALLED THROUGH  A STATEMENT     *  IC2224.2
+006900*    WHICH DOES NOT CONTAIN AN "ON EXCEPTION" PHRASE, PRODUCE  *  IC2224.2
+007000*    EFFECTS WHICH THE STANDARD LEAVES UNDEFINED.  THUS THERE  *  IC2224.2
+007100*    ARE SIX CASES WHICH CAN BE TESTED.  THIS TEST SUITE TESTS *  IC2224.2
+007200*    ALL SIX.  IN ADDITION, IT TESTS THE TWO CASES WHERE       *  IC2224.2
+007300*    "ON OVERFLOW" CAN BE USED IN PLACE OF "ON EXCEPTION".     *  IC2224.2
+007400*    EACH OF THE EIGHT MAJOR TESTS IS FOLLOWED BY A            *  IC2224.2
+007500*    SUBORDINATE TEST WHICH IS INTENDED TO CHECK THE WAY       *  IC2224.2
+007600*    THAT CONTROL HAS FLOWED THROUGH THE PHRASES OF THE CALL   *  IC2224.2
+007700*    STATEMENT.  EVERY CALL STATEMENT IN IC222A HAS AN         *  IC2224.2
+007800*    "END-CALL" SCOPE DELIMITER.  THIS SCOPE DELIMITER IS      *  IC2224.2
+007900*    FOLLOWED BY ONE MORE STATEMENT IN THE SENTENCE, AND THE   *  IC2224.2
+008000*    SUBORDINATE TESTS CHECK THAT THIS ADDITIONAL STATEMENT    *  IC2224.2
+008100*    HAS BEEN EXECUTED.                                        *  IC2224.2
+008200*                                                              *  IC2224.2
+008300****************************************************************  IC2224.2
+008400*                                                                 IC2224.2
+008500 ENVIRONMENT DIVISION.                                            IC2224.2
+008600 CONFIGURATION SECTION.                                           IC2224.2
+008700 SOURCE-COMPUTER.                                                 IC2224.2
+008800     XXXXX082.                                                    IC2224.2
+008900 OBJECT-COMPUTER.                                                 IC2224.2
+009000     XXXXX083.                                                    IC2224.2
+009100 INPUT-OUTPUT SECTION.                                            IC2224.2
+009200 FILE-CONTROL.                                                    IC2224.2
+009300     SELECT PRINT-FILE ASSIGN TO                                  IC2224.2
+009400     XXXXX055.                                                    IC2224.2
+009500*                                                                 IC2224.2
+009600 DATA DIVISION.                                                   IC2224.2
+009700 FILE SECTION.                                                    IC2224.2
+009800 FD  PRINT-FILE.                                                  IC2224.2
+009900 01  PRINT-REC PICTURE X(120).                                    IC2224.2
+010000 01  DUMMY-RECORD PICTURE X(120).                                 IC2224.2
+010100*                                                                 IC2224.2
+010200 WORKING-STORAGE SECTION.                                         IC2224.2
+010300 77  DN1 PICTURE S99  VALUE ZERO.                                 IC2224.2
+010400 77  DN3 PICTURE S99.                                             IC2224.2
+010500 77  ID1 PICTURE X(8) VALUE "IC222A1".                            IC2224.2
+010600 77  ID2 PICTURE X(8).                                            IC2224.2
+010700 77  DN2 PICTURE S99                                              IC2224.2
+010800         USAGE COMPUTATIONAL, VALUE ZERO.                         IC2224.2
+010900 77  DN4 PICTURE S99                                              IC2224.2
+011000         USAGE IS COMPUTATIONAL.                                  IC2224.2
+011100 77  CALL-FLAG PIC 9.                                             IC2224.2
+011200 01  EXCEPTION-PATH-FLAG PICTURE X.                               IC2224.2
+011300*                                                                 IC2224.2
+011400 01  TEST-RESULTS.                                                IC2224.2
+011500     02 FILLER                   PIC X      VALUE SPACE.          IC2224.2
+011600     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC2224.2
+011700     02 FILLER                   PIC X      VALUE SPACE.          IC2224.2
+011800     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC2224.2
+011900     02 FILLER                   PIC X      VALUE SPACE.          IC2224.2
+012000     02  PAR-NAME.                                                IC2224.2
+012100       03 FILLER                 PIC X(19)  VALUE SPACE.          IC2224.2
+012200       03  PARDOT-X              PIC X      VALUE SPACE.          IC2224.2
+012300       03 DOTVALUE               PIC 99     VALUE ZERO.           IC2224.2
+012400     02 FILLER                   PIC X(8)   VALUE SPACE.          IC2224.2
+012500     02 RE-MARK                  PIC X(61).                       IC2224.2
+012600 01  TEST-COMPUTED.                                               IC2224.2
+012700     02 FILLER                   PIC X(30)  VALUE SPACE.          IC2224.2
+012800     02 FILLER                   PIC X(17)  VALUE                 IC2224.2
+012900            "       COMPUTED=".                                   IC2224.2
+013000     02 COMPUTED-X.                                               IC2224.2
+013100     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC2224.2
+013200     03 COMPUTED-N               REDEFINES COMPUTED-A             IC2224.2
+013300                                 PIC -9(9).9(9).                  IC2224.2
+013400     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC2224.2
+013500     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC2224.2
+013600     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC2224.2
+013700     03       CM-18V0 REDEFINES COMPUTED-A.                       IC2224.2
+013800         04 COMPUTED-18V0                    PIC -9(18).          IC2224.2
+013900         04 FILLER                           PIC X.               IC2224.2
+014000     03 FILLER PIC X(50) VALUE SPACE.                             IC2224.2
+014100 01  TEST-CORRECT.                                                IC2224.2
+014200     02 FILLER PIC X(30) VALUE SPACE.                             IC2224.2
+014300     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC2224.2
+014400     02 CORRECT-X.                                                IC2224.2
+014500     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC2224.2
+014600     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC2224.2
+014700     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC2224.2
+014800     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC2224.2
+014900     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC2224.2
+015000     03      CR-18V0 REDEFINES CORRECT-A.                         IC2224.2
+015100         04 CORRECT-18V0                     PIC -9(18).          IC2224.2
+015200         04 FILLER                           PIC X.               IC2224.2
+015300     03 FILLER PIC X(2) VALUE SPACE.                              IC2224.2
+015400     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC2224.2
+015500 01  CCVS-C-1.                                                    IC2224.2
+015600     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC2224.2
+015700-    "SS  PARAGRAPH-NAME                                          IC2224.2
+015800-    "       REMARKS".                                            IC2224.2
+015900     02 FILLER                     PIC X(20)    VALUE SPACE.      IC2224.2
+016000 01  CCVS-C-2.                                                    IC2224.2
+016100     02 FILLER                     PIC X        VALUE SPACE.      IC2224.2
+016200     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC2224.2
+016300     02 FILLER                     PIC X(15)    VALUE SPACE.      IC2224.2
+016400     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC2224.2
+016500     02 FILLER                     PIC X(94)    VALUE SPACE.      IC2224.2
+016600 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC2224.2
+016700 01  REC-CT                        PIC 99       VALUE ZERO.       IC2224.2
+016800 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC2224.2
+016900 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC2224.2
+017000 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC2224.2
+017100 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC2224.2
+017200 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC2224.2
+017300 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC2224.2
+017400 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC2224.2
+017500 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC2224.2
+017600 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC2224.2
+017700 01  CCVS-H-1.                                                    IC2224.2
+017800     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2224.2
+017900     02  FILLER                    PIC X(42)    VALUE             IC2224.2
+018000     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC2224.2
+018100     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2224.2
+018200 01  CCVS-H-2A.                                                   IC2224.2
+018300   02  FILLER                        PIC X(40)  VALUE SPACE.      IC2224.2
+018400   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC2224.2
+018500   02  FILLER                        PIC XXXX   VALUE             IC2224.2
+018600     "4.2 ".                                                      IC2224.2
+018700   02  FILLER                        PIC X(28)  VALUE             IC2224.2
+018800            " COPY - NOT FOR DISTRIBUTION".                       IC2224.2
+018900   02  FILLER                        PIC X(41)  VALUE SPACE.      IC2224.2
+019000                                                                  IC2224.2
+019100 01  CCVS-H-2B.                                                   IC2224.2
+019200   02  FILLER                        PIC X(15)  VALUE             IC2224.2
+019300            "TEST RESULT OF ".                                    IC2224.2
+019400   02  TEST-ID                       PIC X(9).                    IC2224.2
+019500   02  FILLER                        PIC X(4)   VALUE             IC2224.2
+019600            " IN ".                                               IC2224.2
+019700   02  FILLER                        PIC X(12)  VALUE             IC2224.2
+019800     " HIGH       ".                                              IC2224.2
+019900   02  FILLER                        PIC X(22)  VALUE             IC2224.2
+020000            " LEVEL VALIDATION FOR ".                             IC2224.2
+020100   02  FILLER                        PIC X(58)  VALUE             IC2224.2
+020200     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2224.2
+020300 01  CCVS-H-3.                                                    IC2224.2
+020400     02  FILLER                      PIC X(34)  VALUE             IC2224.2
+020500            " FOR OFFICIAL USE ONLY    ".                         IC2224.2
+020600     02  FILLER                      PIC X(58)  VALUE             IC2224.2
+020700     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2224.2
+020800     02  FILLER                      PIC X(28)  VALUE             IC2224.2
+020900            "  COPYRIGHT   1985,1986 ".                           IC2224.2
+021000 01  CCVS-E-1.                                                    IC2224.2
+021100     02 FILLER                       PIC X(52)  VALUE SPACE.      IC2224.2
+021200     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC2224.2
+021300     02 ID-AGAIN                     PIC X(9).                    IC2224.2
+021400     02 FILLER                       PIC X(45)  VALUE SPACES.     IC2224.2
+021500 01  CCVS-E-2.                                                    IC2224.2
+021600     02  FILLER                      PIC X(31)  VALUE SPACE.      IC2224.2
+021700     02  FILLER                      PIC X(21)  VALUE SPACE.      IC2224.2
+021800     02 CCVS-E-2-2.                                               IC2224.2
+021900         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC2224.2
+022000         03 FILLER                   PIC X      VALUE SPACE.      IC2224.2
+022100         03 ENDER-DESC               PIC X(44)  VALUE             IC2224.2
+022200            "ERRORS ENCOUNTERED".                                 IC2224.2
+022300 01  CCVS-E-3.                                                    IC2224.2
+022400     02  FILLER                      PIC X(22)  VALUE             IC2224.2
+022500            " FOR OFFICIAL USE ONLY".                             IC2224.2
+022600     02  FILLER                      PIC X(12)  VALUE SPACE.      IC2224.2
+022700     02  FILLER                      PIC X(58)  VALUE             IC2224.2
+022800     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2224.2
+022900     02  FILLER                      PIC X(8)   VALUE SPACE.      IC2224.2
+023000     02  FILLER                      PIC X(20)  VALUE             IC2224.2
+023100             " COPYRIGHT 1985,1986".                              IC2224.2
+023200 01  CCVS-E-4.                                                    IC2224.2
+023300     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC2224.2
+023400     02 FILLER                       PIC X(4)   VALUE " OF ".     IC2224.2
+023500     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC2224.2
+023600     02 FILLER                       PIC X(40)  VALUE             IC2224.2
+023700      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC2224.2
+023800 01  XXINFO.                                                      IC2224.2
+023900     02 FILLER                       PIC X(19)  VALUE             IC2224.2
+024000            "*** INFORMATION ***".                                IC2224.2
+024100     02 INFO-TEXT.                                                IC2224.2
+024200       04 FILLER                     PIC X(8)   VALUE SPACE.      IC2224.2
+024300       04 XXCOMPUTED                 PIC X(20).                   IC2224.2
+024400       04 FILLER                     PIC X(5)   VALUE SPACE.      IC2224.2
+024500       04 XXCORRECT                  PIC X(20).                   IC2224.2
+024600     02 INF-ANSI-REFERENCE           PIC X(48).                   IC2224.2
+024700 01  HYPHEN-LINE.                                                 IC2224.2
+024800     02 FILLER  PIC IS X VALUE IS SPACE.                          IC2224.2
+024900     02 FILLER  PIC IS X(65)    VALUE IS "************************IC2224.2
+025000-    "*****************************************".                 IC2224.2
+025100     02 FILLER  PIC IS X(54)    VALUE IS "************************IC2224.2
+025200-    "******************************".                            IC2224.2
+025300 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC2224.2
+025400     "IC222A".                                                    IC2224.2
+025500*                                                                 IC2224.2
+025600 PROCEDURE DIVISION.                                              IC2224.2
+025700 CCVS1 SECTION.                                                   IC2224.2
+025800 OPEN-FILES.                                                      IC2224.2
+025900     OPEN    OUTPUT PRINT-FILE.                                   IC2224.2
+026000     MOVE  CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.  IC2224.2
+026100     MOVE    SPACE TO TEST-RESULTS.                               IC2224.2
+026200     PERFORM HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.              IC2224.2
+026300     GO TO CCVS1-EXIT.                                            IC2224.2
+026400 CLOSE-FILES.                                                     IC2224.2
+026500     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC2224.2
+026600 TERMINATE-CCVS.                                                  IC2224.2
+026700S    EXIT PROGRAM.                                                IC2224.2
+026800STERMINATE-CALL.                                                  IC2224.2
+026900     STOP     RUN.                                                IC2224.2
+027000 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         IC2224.2
+027100 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           IC2224.2
+027200 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          IC2224.2
+027300 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      IC2224.2
+027400     MOVE "****TEST DELETED****" TO RE-MARK.                      IC2224.2
+027500 PRINT-DETAIL.                                                    IC2224.2
+027600     IF REC-CT NOT EQUAL TO ZERO                                  IC2224.2
+027700             MOVE "." TO PARDOT-X                                 IC2224.2
+027800             MOVE REC-CT TO DOTVALUE.                             IC2224.2
+027900     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      IC2224.2
+028000     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               IC2224.2
+028100        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 IC2224.2
+028200          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 IC2224.2
+028300     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC2224.2
+028400     MOVE SPACE TO CORRECT-X.                                     IC2224.2
+028500     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC2224.2
+028600     MOVE     SPACE TO RE-MARK.                                   IC2224.2
+028700 HEAD-ROUTINE.                                                    IC2224.2
+028800     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2224.2
+028900     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2224.2
+029000     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2224.2
+029100     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2224.2
+029200 COLUMN-NAMES-ROUTINE.                                            IC2224.2
+029300     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2224.2
+029400     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2224.2
+029500     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC2224.2
+029600 END-ROUTINE.                                                     IC2224.2
+029700     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.IC2224.2
+029800 END-RTN-EXIT.                                                    IC2224.2
+029900     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2224.2
+030000 END-ROUTINE-1.                                                   IC2224.2
+030100      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      IC2224.2
+030200      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               IC2224.2
+030300      ADD PASS-COUNTER TO ERROR-HOLD.                             IC2224.2
+030400*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC2224.2
+030500      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC2224.2
+030600      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC2224.2
+030700      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC2224.2
+030800      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC2224.2
+030900  END-ROUTINE-12.                                                 IC2224.2
+031000      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC2224.2
+031100     IF       ERROR-COUNTER IS EQUAL TO ZERO                      IC2224.2
+031200         MOVE "NO " TO ERROR-TOTAL                                IC2224.2
+031300         ELSE                                                     IC2224.2
+031400         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC2224.2
+031500     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC2224.2
+031600     PERFORM WRITE-LINE.                                          IC2224.2
+031700 END-ROUTINE-13.                                                  IC2224.2
+031800     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC2224.2
+031900         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC2224.2
+032000         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC2224.2
+032100     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC2224.2
+032200     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2224.2
+032300      IF   INSPECT-COUNTER EQUAL TO ZERO                          IC2224.2
+032400          MOVE "NO " TO ERROR-TOTAL                               IC2224.2
+032500      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   IC2224.2
+032600      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            IC2224.2
+032700      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          IC2224.2
+032800     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2224.2
+032900 WRITE-LINE.                                                      IC2224.2
+033000     ADD 1 TO RECORD-COUNT.                                       IC2224.2
+033100Y    IF RECORD-COUNT GREATER 50                                   IC2224.2
+033200Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC2224.2
+033300Y        MOVE SPACE TO DUMMY-RECORD                               IC2224.2
+033400Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC2224.2
+033500Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC2224.2
+033600Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC2224.2
+033700Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC2224.2
+033800Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC2224.2
+033900Y        MOVE ZERO TO RECORD-COUNT.                               IC2224.2
+034000     PERFORM WRT-LN.                                              IC2224.2
+034100 WRT-LN.                                                          IC2224.2
+034200     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC2224.2
+034300     MOVE SPACE TO DUMMY-RECORD.                                  IC2224.2
+034400 BLANK-LINE-PRINT.                                                IC2224.2
+034500     PERFORM WRT-LN.                                              IC2224.2
+034600 FAIL-ROUTINE.                                                    IC2224.2
+034700     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC2224.2
+034800     IF   CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.  IC2224.2
+034900     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2224.2
+035000     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC2224.2
+035100     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2224.2
+035200     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2224.2
+035300     GO TO  FAIL-ROUTINE-EX.                                      IC2224.2
+035400 FAIL-ROUTINE-WRITE.                                              IC2224.2
+035500     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC2224.2
+035600     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC2224.2
+035700     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC2224.2
+035800     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC2224.2
+035900 FAIL-ROUTINE-EX. EXIT.                                           IC2224.2
+036000 BAIL-OUT.                                                        IC2224.2
+036100     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC2224.2
+036200     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC2224.2
+036300 BAIL-OUT-WRITE.                                                  IC2224.2
+036400     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC2224.2
+036500     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2224.2
+036600     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2224.2
+036700     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2224.2
+036800 BAIL-OUT-EX. EXIT.                                               IC2224.2
+036900 CCVS1-EXIT.                                                      IC2224.2
+037000     EXIT.                                                        IC2224.2
+037100*                                                                 IC2224.2
+037200 SECT-IC222A-001 SECTION.                                         IC2224.2
+037300 CALL-INIT-1.                                                     IC2224.2
+037400****************************************************************  IC2224.2
+037500*                                                              *  IC2224.2
+037600*    CALL A PROGRAM WHICH EXISTS AND FOR WHICH PARAMETERS      *  IC2224.2
+037700*    MATCH IN NUMBER AND TYPE.  EXECUTION SHOULD BE SUCCESSFUL *  IC2224.2
+037800*    AND THE STATEMENTS IN THE "ON EXCEPTION" PATH IGNORED.    *  IC2224.2
+037900*    THE STATEMENT FOLLOWING THE SCOPE TERMINATOR SHOULD BE    *  IC2224.2
+038000*    EXECUTED.                                                 *  IC2224.2
+038100*                                                              *  IC2224.2
+038200****************************************************************  IC2224.2
+038300*                                                                 IC2224.2
+038400     MOVE    1 TO REC-CT.                                         IC2224.2
+038500     MOVE   "CALL-TEST-1" TO PAR-NAME.                            IC2224.2
+038600     MOVE   "AVAILABLE ON " TO FEATURE.                           IC2224.2
+038700     MOVE    0 TO CALL-FLAG.                                      IC2224.2
+038800     MOVE   "P" TO EXCEPTION-PATH-FLAG.                           IC2224.2
+038900     MOVE   "X-27 5.2.4 (2)" TO ANSI-REFERENCE.                   IC2224.2
+039000     MOVE    ZERO TO DN3, DN4.                                    IC2224.2
+039100     GO TO   CALL-TEST-1-1.                                       IC2224.2
+039200 CALL-DELETE-1-1.                                                 IC2224.2
+039300     PERFORM DE-LETE.                                             IC2224.2
+039400     PERFORM PRINT-DETAIL.                                        IC2224.2
+039500     ADD     1 TO REC-CT.                                         IC2224.2
+039600*                                                                 IC2224.2
+039700*    IF THIS TEST IS DELETED THEN ITS SUBORDINATE IS           *  IC2224.2
+039800*    AUTOMATICALLY DELETED.                                    *  IC2224.2
+039900*                                                                 IC2224.2
+040000     GO TO   CALL-DELETE-1-2.                                     IC2224.2
+040100 CALL-TEST-1-1.                                                   IC2224.2
+040200     CALL   "IC222A1" USING DN1, DN2, DN3, DN4                    IC2224.2
+040300             ON EXCEPTION                                         IC2224.2
+040400                  MOVE "F" TO EXCEPTION-PATH-FLAG                 IC2224.2
+040500     END-CALL                                                     IC2224.2
+040600     MOVE    1 TO CALL-FLAG.                                      IC2224.2
+040700     IF EXCEPTION-PATH-FLAG NOT = "P"                             IC2224.2
+040800             MOVE "UNEXPECTED EXECUTION OF EXCEPTION PATH"        IC2224.2
+040900                      TO RE-MARK                                  IC2224.2
+041000             MOVE "P" TO CORRECT-A                                IC2224.2
+041100             MOVE EXCEPTION-PATH-FLAG TO COMPUTED-A               IC2224.2
+041200             PERFORM FAIL                                         IC2224.2
+041300     ELSE                                                         IC2224.2
+041400             PERFORM PASS.                                        IC2224.2
+041500 CALL-WRITE-1-1.                                                  IC2224.2
+041600     PERFORM PRINT-DETAIL.                                        IC2224.2
+041700     ADD 1 TO REC-CT.                                             IC2224.2
+041800*                                                                 IC2224.2
+041900 CALL-INIT-1-2.                                                   IC2224.2
+042000     GO TO    CALL-TEST-1-2.                                      IC2224.2
+042100 CALL-DELETE-1-2.                                                 IC2224.2
+042200     MOVE   "END-CALL OBSERVANCE" TO FEATURE.                     IC2224.2
+042300     PERFORM DE-LETE.                                             IC2224.2
+042400     PERFORM PRINT-DETAIL.                                        IC2224.2
+042500     ADD     1 TO REC-CT.                                         IC2224.2
+042600     GO TO   CALL-EXIT-1.                                         IC2224.2
+042700*                                                                 IC2224.2
+042800 CALL-TEST-1-2.                                                   IC2224.2
+042900****************************************************************  IC2224.2
+043000*                                                              *  IC2224.2
+043100*    CHECKS THAT THE STATEMENT FOLLOWING THE SCOPE TERMINATOR  *  IC2224.2
+043200*    WAS EXECUTED.  IF THE PREVIOUS TEST PASSED, A PASS HERE   *  IC2224.2
+043300*    INDICATES THAT THE SCOPE TERMINATOR HAS BEEN INTERPRETED  *  IC2224.2
+043400*    CORRECTLY.  IF THE PREVIOUS TEST FAILED, A PASS HERE      *  IC2224.2
+043500*    INDICATES THAT THE SCOPE TERMINATOR WAS NOT INTERPRETED   *  IC2224.2
+043600*    AS "NOT ON EXCEPTION" OR "GO TO NEXT-SENTENCE".           *  IC2224.2
+043700*                                                              *  IC2224.2
+043800****************************************************************  IC2224.2
+043900*                                                                 IC2224.2
+044000     MOVE   "END-CALL OBSERVANCE" TO FEATURE.                     IC2224.2
+044100     IF      CALL-FLAG = 1                                        IC2224.2
+044200             PERFORM PASS                                         IC2224.2
+044300     ELSE                                                         IC2224.2
+044400             MOVE   "INCORRECT CONTROL FLOW" TO RE-MARK           IC2224.2
+044500             MOVE    1 TO CORRECT-N                               IC2224.2
+044600             MOVE    CALL-FLAG TO COMPUTED-N                      IC2224.2
+044700             PERFORM FAIL.                                        IC2224.2
+044800     PERFORM PRINT-DETAIL.                                        IC2224.2
+044900*                                                                 IC2224.2
+045000 CALL-EXIT-1.                                                     IC2224.2
+045100*                                                                 IC2224.2
+045200*                                                                 IC2224.2
+045300 CALL-INIT-2.                                                     IC2224.2
+045400****************************************************************  IC2224.2
+045500*                                                              *  IC2224.2
+045600*    CALL A PROGRAM WHICH DOES NOT EXIST.  PAGE X-28, 5.2.4,   *  IC2224.2
+045700*    RULE (3)A STATES THAT IF A PROGRAM CANNOT BE MADE         *  IC2224.2
+045800*    AVAILABLE THEN THE STATEMENTS IN THE "ON EXCEPTION"       *  IC2224.2
+045900*    PHRASE MUST BE EXECUTED.                                  *  IC2224.2
+046000*                                                              *  IC2224.2
+046100****************************************************************  IC2224.2
+046200*                                                                 IC2224.2
+046300     MOVE    1 TO REC-CT.                                         IC2224.2
+046400     MOVE   "CALL-TEST-2" TO PAR-NAME.                            IC2224.2
+046500     MOVE   "NO PROGRAM ON " TO FEATURE.                          IC2224.2
+046600     MOVE    0 TO CALL-FLAG.                                      IC2224.2
+046700     MOVE   "X" TO EXCEPTION-PATH-FLAG.                           IC2224.2
+046800     MOVE   "X-28 5.2.4 (3)A" TO ANSI-REFERENCE.                  IC2224.2
+046900     MOVE    ZERO TO DN3, DN4.                                    IC2224.2
+047000     GO TO   CALL-TEST-2-1.                                       IC2224.2
+047100 CALL-DELETE-2-1.                                                 IC2224.2
+047200     PERFORM DE-LETE.                                             IC2224.2
+047300     PERFORM PRINT-DETAIL.                                        IC2224.2
+047400     ADD     1 TO REC-CT.                                         IC2224.2
+047500*                                                                 IC2224.2
+047600*    IF THIS TEST IS DELETED THEN ITS SUBORDINATE TEST IS      *  IC2224.2
+047700*    AUTOMATICALLY DELETED.                                    *  IC2224.2
+047800*                                                                 IC2224.2
+047900     GO TO   CALL-DELETE-2-2.                                     IC2224.2
+048000 CALL-TEST-2-1.                                                   IC2224.2
+048100*    CALL "NON-EXISTING-PROGRAM"                                  IC2224.2
+048200     CALL   "XXXXXXXX" USING DN1, DN2, DN3, DN4                   IC2224.2
+048300             ON EXCEPTION                                         IC2224.2
+048400                  MOVE "P" TO EXCEPTION-PATH-FLAG                 IC2224.2
+048500     END-CALL                                                     IC2224.2
+048600     MOVE    1 TO CALL-FLAG.                                      IC2224.2
+048700     IF EXCEPTION-PATH-FLAG NOT = "P"                             IC2224.2
+048800             MOVE "EXCEPTION SHOULD HAVE OCCURRED" TO RE-MARK     IC2224.2
+048900             MOVE "P" TO CORRECT-A                                IC2224.2
+049000             MOVE EXCEPTION-PATH-FLAG TO COMPUTED-A               IC2224.2
+049100             PERFORM FAIL                                         IC2224.2
+049200     ELSE                                                         IC2224.2
+049300             PERFORM PASS.                                        IC2224.2
+049400 CALL-WRITE-2-1.                                                  IC2224.2
+049500     PERFORM PRINT-DETAIL.                                        IC2224.2
+049600     ADD 1 TO REC-CT.                                             IC2224.2
+049700*                                                                 IC2224.2
+049800 CALL-INIT-2-2.                                                   IC2224.2
+049900     GO TO    CALL-TEST-2-2.                                      IC2224.2
+050000 CALL-DELETE-2-2.                                                 IC2224.2
+050100     MOVE   "END-CALL OBSERVANCE" TO FEATURE.                     IC2224.2
+050200     PERFORM DE-LETE.                                             IC2224.2
+050300     PERFORM PRINT-DETAIL.                                        IC2224.2
+050400     ADD     1 TO REC-CT.                                         IC2224.2
+050500     GO TO   CALL-EXIT-2.                                         IC2224.2
+050600*                                                                 IC2224.2
+050700 CALL-TEST-2-2.                                                   IC2224.2
+050800****************************************************************  IC2224.2
+050900*                                                              *  IC2224.2
+051000*    CHECKS THAT THE STATEMENT FOLLOWING THE SCOPE TERMINATOR  *  IC2224.2
+051100*    WAS EXECUTED.  IF THE PREVIOUS TEST FAILED, A PASS HERE   *  IC2224.2
+051200*    INDICATES THAT THE SCOPE TERMINATOR HAS BEEN INTERPRETED  *  IC2224.2
+051300*    CORRECTLY.  IF THE PREVIOUS TEST PASSED, A PASS HERE      *  IC2224.2
+051400*    INDICATES THAT THE SCOPE TERMINATOR WAS NOT INTERPRETED   *  IC2224.2
+051500*    AS "NOT ON EXCEPTION" OR "GO TO NEXT-SENTENCE".           *  IC2224.2
+051600*                                                              *  IC2224.2
+051700****************************************************************  IC2224.2
+051800*                                                                 IC2224.2
+051900     MOVE   "END-CALL OBSERVANCE" TO FEATURE.                     IC2224.2
+052000     IF      CALL-FLAG = 1                                        IC2224.2
+052100             PERFORM PASS                                         IC2224.2
+052200     ELSE                                                         IC2224.2
+052300             MOVE   "INCORRECT CONTROL FLOW" TO RE-MARK           IC2224.2
+052400             MOVE    1 TO CORRECT-N                               IC2224.2
+052500             MOVE    CALL-FLAG TO COMPUTED-N                      IC2224.2
+052600             PERFORM FAIL.                                        IC2224.2
+052700     PERFORM PRINT-DETAIL.                                        IC2224.2
+052800*                                                                 IC2224.2
+052900 CALL-EXIT-2.                                                     IC2224.2
+053000*                                                                 IC2224.2
+053100*                                                                 IC2224.2
+053200 CALL-INIT-3.                                                     IC2224.2
+053300****************************************************************  IC2224.2
+053400*                                                              *  IC2224.2
+053500*    CALL A PROGRAM WHICH EXISTS, USING A CALL STATEMENT WITH  *  IC2224.2
+053600*    BOTH AN "ON EXCEPTION" PHRASE AND A "NOT ON EXCEPTION"    *  IC2224.2
+053700*    PHRASE.  EXECUTION SHOULD BE SUCCESSFUL, THE              *  IC2224.2
+053800*    "ON EXCEPTION" PHRASE IGNORED, AND THE STATEMENTS IN THE  *  IC2224.2
+053900*    "NOT ON EXCEPTION" PHRASE EXECUTED.  THE STATEMENT        *  IC2224.2
+054000*    FOLLOWING THE SCOPE TERMINATOR SHOULD BE EXECUTED.        *  IC2224.2
+054100*                                                              *  IC2224.2
+054200****************************************************************  IC2224.2
+054300*                                                                 IC2224.2
+054400     MOVE    1 TO REC-CT.                                         IC2224.2
+054500     MOVE   "CALL-TEST-3" TO PAR-NAME.                            IC2224.2
+054600     MOVE   "AVAILABLE  ON NOT ON" TO FEATURE.                    IC2224.2
+054700     MOVE    0 TO CALL-FLAG.                                      IC2224.2
+054800     MOVE   "X" TO EXCEPTION-PATH-FLAG.                           IC2224.2
+054900     MOVE   "X-28 5.2.4 (2)" TO ANSI-REFERENCE.                   IC2224.2
+055000     MOVE    ZERO TO DN3, DN4.                                    IC2224.2
+055100     GO TO   CALL-TEST-3-1.                                       IC2224.2
+055200 CALL-DELETE-3-1.                                                 IC2224.2
+055300     PERFORM DE-LETE.                                             IC2224.2
+055400     PERFORM PRINT-DETAIL.                                        IC2224.2
+055500     ADD     1 TO REC-CT.                                         IC2224.2
+055600*                                                                 IC2224.2
+055700*    IF THIS TEST IS DELETED THEN ITS SUBORDINATE TEST IS      *  IC2224.2
+055800*    AUTOMATICALLY DELETED.                                    *  IC2224.2
+055900*                                                                 IC2224.2
+056000     GO TO   CALL-DELETE-3-2.                                     IC2224.2
+056100 CALL-TEST-3-1.                                                   IC2224.2
+056200     CALL   "IC222A1" USING DN1, DN2, DN3, DN4                    IC2224.2
+056300             ON EXCEPTION                                         IC2224.2
+056400                  MOVE "F" TO EXCEPTION-PATH-FLAG                 IC2224.2
+056500                  ADD 2 TO CALL-FLAG                              IC2224.2
+056600             NOT ON EXCEPTION                                     IC2224.2
+056700                  MOVE "P" TO EXCEPTION-PATH-FLAG                 IC2224.2
+056800                  ADD 2 TO CALL-FLAG                              IC2224.2
+056900     END-CALL                                                     IC2224.2
+057000     ADD     1 TO CALL-FLAG.                                      IC2224.2
+057100     IF EXCEPTION-PATH-FLAG NOT = "P"                             IC2224.2
+057200             MOVE "NON-EXECUTION OF NOT EXCEPTION PATH"           IC2224.2
+057300                   TO RE-MARK                                     IC2224.2
+057400             MOVE "P" TO CORRECT-A                                IC2224.2
+057500             MOVE EXCEPTION-PATH-FLAG TO COMPUTED-A               IC2224.2
+057600             PERFORM FAIL                                         IC2224.2
+057700     ELSE                                                         IC2224.2
+057800             PERFORM PASS.                                        IC2224.2
+057900 CALL-WRITE-3-1.                                                  IC2224.2
+058000     PERFORM PRINT-DETAIL.                                        IC2224.2
+058100     ADD 1 TO REC-CT.                                             IC2224.2
+058200*                                                                 IC2224.2
+058300 CALL-INIT-3-2.                                                   IC2224.2
+058400     GO TO    CALL-TEST-3-2.                                      IC2224.2
+058500 CALL-DELETE-3-2.                                                 IC2224.2
+058600     MOVE   "END-CALL OBSERVANCE" TO FEATURE.                     IC2224.2
+058700     PERFORM DE-LETE.                                             IC2224.2
+058800     PERFORM PRINT-DETAIL.                                        IC2224.2
+058900     ADD     1 TO REC-CT.                                         IC2224.2
+059000     GO TO   CALL-EXIT-3.                                         IC2224.2
+059100*                                                                 IC2224.2
+059200 CALL-TEST-3-2.                                                   IC2224.2
+059300****************************************************************  IC2224.2
+059400*                                                              *  IC2224.2
+059500*    CHECKS THAT THE STATEMENT FOLLOWING THE SCOPE TERMINATOR  *  IC2224.2
+059600*    WAS EXECUTED.  IF THE PREVIOUS TEST FAILED, A PASS HERE   *  IC2224.2
+059700*    INDICATES THAT THE SCOPE TERMINATOR HAS BEEN INTERPRETED  *  IC2224.2
+059800*    CORRECTLY.  IF THE PREVIOUS TEST PASSED, A PASS HERE      *  IC2224.2
+059900*    INDICATES THAT THE SCOPE TERMINATOR WAS NOT INTERPRETED   *  IC2224.2
+060000*    AS "NOT ON EXCEPTION" OR "GO TO NEXT-SENTENCE".           *  IC2224.2
+060100*                                                              *  IC2224.2
+060200****************************************************************  IC2224.2
+060300*                                                                 IC2224.2
+060400     MOVE   "END-CALL OBSERVANCE" TO FEATURE.                     IC2224.2
+060500     IF      CALL-FLAG = 3                                        IC2224.2
+060600             PERFORM PASS                                         IC2224.2
+060700     ELSE                                                         IC2224.2
+060800             MOVE   "INCORRECT CONTROL FLOW" TO RE-MARK           IC2224.2
+060900             MOVE    3 TO CORRECT-N                               IC2224.2
+061000             MOVE    CALL-FLAG TO COMPUTED-N                      IC2224.2
+061100             PERFORM FAIL.                                        IC2224.2
+061200     PERFORM PRINT-DETAIL.                                        IC2224.2
+061300*                                                                 IC2224.2
+061400 CALL-EXIT-3.                                                     IC2224.2
+061500*                                                                 IC2224.2
+061600*                                                                 IC2224.2
+061700 CALL-INIT-4.                                                     IC2224.2
+061800****************************************************************  IC2224.2
+061900*                                                              *  IC2224.2
+062000*    CALL A PROGRAM WHICH IS NOT AVAILABLE FOR EXECUTION,      *  IC2224.2
+062100*    USING A CALL STATEMENT WITH BOTH AN "ON EXCEPTION" PHRASE *  IC2224.2
+062200*    AND A "NOT ON EXCEPTION" PHRASE.  EXECUTION SHOULD BE     *  IC2224.2
+062300*    UNSUCCESSFUL, THE STATEMENTS IN THE "ON EXCEPTION" PHRASE *  IC2224.2
+062400*    EXECUTED, AND THE STATEMENTS IN THE "NOT ON EXCEPTION"    *  IC2224.2
+062500*    PHRASE IGNORED.  THE STATEMENT FOLLOWING THE SCOPE        *  IC2224.2
+062600*    TERMINATOR SHOULD BE EXECUTED IN EITHER CASE.             *  IC2224.2
+062700*                                                              *  IC2224.2
+062800****************************************************************  IC2224.2
+062900*                                                                 IC2224.2
+063000     MOVE    1 TO REC-CT.                                         IC2224.2
+063100     MOVE   "CALL-TEST-4" TO PAR-NAME.                            IC2224.2
+063200     MOVE   "CALL ON EXCEPTION" TO FEATURE.                       IC2224.2
+063300     MOVE    0 TO CALL-FLAG.                                      IC2224.2
+063400     MOVE   "X" TO EXCEPTION-PATH-FLAG.                           IC2224.2
+063500     MOVE   "X-28 5.2.4 (3)A" TO ANSI-REFERENCE.                  IC2224.2
+063600     MOVE    ZERO TO DN3, DN4.                                    IC2224.2
+063700     GO TO   CALL-TEST-4-1.                                       IC2224.2
+063800 CALL-DELETE-4-1.                                                 IC2224.2
+063900     PERFORM DE-LETE.                                             IC2224.2
+064000     PERFORM PRINT-DETAIL.                                        IC2224.2
+064100     ADD     1 TO REC-CT.                                         IC2224.2
+064200*                                                                 IC2224.2
+064300*    IF THIS TEST IS DELETED THEN ITS SUBORDINATE TEST IS      *  IC2224.2
+064400*    AUTOMATICALLY DELETED.                                    *  IC2224.2
+064500*                                                                 IC2224.2
+064600     GO TO   CALL-DELETE-4-2.                                     IC2224.2
+064700 CALL-TEST-4-1.                                                   IC2224.2
+064800*    CALL   "NON-EXISTENT PROGRAM"                                IC2224.2
+064900     CALL   "XXXXXXXX" USING DN1, DN2, DN3, DN4                   IC2224.2
+065000             ON EXCEPTION                                         IC2224.2
+065100                  MOVE "P" TO EXCEPTION-PATH-FLAG                 IC2224.2
+065200                  ADD 2 TO CALL-FLAG                              IC2224.2
+065300             NOT ON EXCEPTION                                     IC2224.2
+065400                  MOVE "F" TO EXCEPTION-PATH-FLAG                 IC2224.2
+065500                  ADD 2 TO CALL-FLAG                              IC2224.2
+065600     END-CALL                                                     IC2224.2
+065700     ADD     1 TO CALL-FLAG.                                      IC2224.2
+065800     IF EXCEPTION-PATH-FLAG NOT = "P"                             IC2224.2
+065900             MOVE "NON-EXECUTION OF EXCEPTION PATH"               IC2224.2
+066000                   TO RE-MARK                                     IC2224.2
+066100             MOVE "P" TO CORRECT-A                                IC2224.2
+066200             MOVE EXCEPTION-PATH-FLAG TO COMPUTED-A               IC2224.2
+066300             PERFORM FAIL                                         IC2224.2
+066400     ELSE                                                         IC2224.2
+066500             PERFORM PASS.                                        IC2224.2
+066600 CALL-WRITE-4-1.                                                  IC2224.2
+066700     PERFORM PRINT-DETAIL.                                        IC2224.2
+066800     ADD 1 TO REC-CT.                                             IC2224.2
+066900*                                                                 IC2224.2
+067000 CALL-INIT-4-2.                                                   IC2224.2
+067100     GO TO    CALL-TEST-4-2.                                      IC2224.2
+067200 CALL-DELETE-4-2.                                                 IC2224.2
+067300     MOVE   "END-CALL OBSERVANCE" TO FEATURE.                     IC2224.2
+067400     PERFORM DE-LETE.                                             IC2224.2
+067500     PERFORM PRINT-DETAIL.                                        IC2224.2
+067600     ADD     1 TO REC-CT.                                         IC2224.2
+067700     GO TO   CALL-EXIT-4.                                         IC2224.2
+067800*                                                                 IC2224.2
+067900 CALL-TEST-4-2.                                                   IC2224.2
+068000****************************************************************  IC2224.2
+068100*                                                              *  IC2224.2
+068200*    CHECKS THAT THE STATEMENT FOLLOWING THE SCOPE TERMINATOR  *  IC2224.2
+068300*    WAS EXECUTED.  A PASS HERE ALSO INDICATES THAT ONE AND    *  IC2224.2
+068400*    ONLY ONE OF THE "ON EXCEPTION" AND "NOT ON EXCEPTION"     *  IC2224.2
+068500*    PHRASES OF THE PRECEDING CALL STATEMENT WAS EXECUTED.     *  IC2224.2
+068600*                                                              *  IC2224.2
+068700****************************************************************  IC2224.2
+068800*                                                                 IC2224.2
+068900     MOVE   "END-CALL OBSERVANCE" TO FEATURE.                     IC2224.2
+069000     IF      CALL-FLAG = 3                                        IC2224.2
+069100             PERFORM PASS                                         IC2224.2
+069200     ELSE                                                         IC2224.2
+069300             MOVE   "INCORRECT CONTROL FLOW" TO RE-MARK           IC2224.2
+069400             MOVE    3 TO CORRECT-N                               IC2224.2
+069500             MOVE    CALL-FLAG TO COMPUTED-N                      IC2224.2
+069600             PERFORM FAIL.                                        IC2224.2
+069700     PERFORM PRINT-DETAIL.                                        IC2224.2
+069800*                                                                 IC2224.2
+069900 CALL-EXIT-4.                                                     IC2224.2
+070000*                                                                 IC2224.2
+070100*                                                                 IC2224.2
+070200 CALL-INIT-5.                                                     IC2224.2
+070300****************************************************************  IC2224.2
+070400*                                                              *  IC2224.2
+070500*    CALL A PROGRAM WHICH IS AVAILABLE FOR EXECUTION, USING A  *  IC2224.2
+070600*    CALL STATEMENT WITH A "NOT ON EXCEPTION" PHRASE BUT NO    *  IC2224.2
+070700*    "ON EXCEPTION" PHRASE.  EXECUTION SHOULD BE SUCCESSFUL,   *  IC2224.2
+070800*    AND THE STATEMENTS IN THE "NOT ON EXCEPTION" PHRASE       *  IC2224.2
+070900*    EXECUTED.  THE STATEMENT FOLLOWING THE SCOPE TERMINATOR   *  IC2224.2
+071000*    SHOULD ALSO BE EXECUTED.                                  *  IC2224.2
+071100*                                                              *  IC2224.2
+071200****************************************************************  IC2224.2
+071300*                                                                 IC2224.2
+071400     MOVE    1 TO REC-CT.                                         IC2224.2
+071500     MOVE   "CALL-TEST-5" TO PAR-NAME.                            IC2224.2
+071600     MOVE   "AVAILABLE  -- NOT ON" TO FEATURE.                    IC2224.2
+071700     MOVE    0 TO CALL-FLAG.                                      IC2224.2
+071800     MOVE   "X" TO EXCEPTION-PATH-FLAG.                           IC2224.2
+071900     MOVE   "X-28 5.2.4 (3)A" TO ANSI-REFERENCE.                  IC2224.2
+072000     MOVE    ZERO TO DN3, DN4.                                    IC2224.2
+072100     GO TO   CALL-TEST-5-1.                                       IC2224.2
+072200 CALL-DELETE-5-1.                                                 IC2224.2
+072300     PERFORM DE-LETE.                                             IC2224.2
+072400     PERFORM PRINT-DETAIL.                                        IC2224.2
+072500     ADD     1 TO REC-CT.                                         IC2224.2
+072600*                                                                 IC2224.2
+072700*    IF THIS TEST IS DELETED THEN ITS SUBORDINATE TEST IS      *  IC2224.2
+072800*    AUTOMATICALLY DELETED.                                    *  IC2224.2
+072900*                                                                 IC2224.2
+073000     GO TO   CALL-DELETE-5-2.                                     IC2224.2
+073100 CALL-TEST-5-1.                                                   IC2224.2
+073200     CALL   "IC222A1" USING DN1, DN2, DN3, DN4                    IC2224.2
+073300             NOT ON EXCEPTION                                     IC2224.2
+073400                  MOVE "P" TO EXCEPTION-PATH-FLAG                 IC2224.2
+073500                  ADD 2 TO CALL-FLAG                              IC2224.2
+073600     END-CALL                                                     IC2224.2
+073700     ADD     1 TO CALL-FLAG.                                      IC2224.2
+073800     IF EXCEPTION-PATH-FLAG NOT = "P"                             IC2224.2
+073900             MOVE "NON-EXECUTION OF NOT ON EXCEPTION PATH"        IC2224.2
+074000                   TO RE-MARK                                     IC2224.2
+074100             MOVE "P" TO CORRECT-A                                IC2224.2
+074200             MOVE EXCEPTION-PATH-FLAG TO COMPUTED-A               IC2224.2
+074300             PERFORM FAIL                                         IC2224.2
+074400     ELSE                                                         IC2224.2
+074500             PERFORM PASS.                                        IC2224.2
+074600 CALL-WRITE-5-1.                                                  IC2224.2
+074700     PERFORM PRINT-DETAIL.                                        IC2224.2
+074800     ADD 1 TO REC-CT.                                             IC2224.2
+074900*                                                                 IC2224.2
+075000 CALL-INIT-5-2.                                                   IC2224.2
+075100     GO TO    CALL-TEST-5-2.                                      IC2224.2
+075200 CALL-DELETE-5-2.                                                 IC2224.2
+075300     MOVE   "END-CALL OBSERVANCE" TO FEATURE.                     IC2224.2
+075400     PERFORM DE-LETE.                                             IC2224.2
+075500     PERFORM PRINT-DETAIL.                                        IC2224.2
+075600     ADD     1 TO REC-CT.                                         IC2224.2
+075700     GO TO   CALL-EXIT-5.                                         IC2224.2
+075800*                                                                 IC2224.2
+075900 CALL-TEST-5-2.                                                   IC2224.2
+076000****************************************************************  IC2224.2
+076100*                                                              *  IC2224.2
+076200*    CHECKS THAT THE STATEMENT FOLLOWING THE SCOPE TERMINATOR  *  IC2224.2
+076300*    WAS EXECUTED.  A PASS HERE ALSO INDICATES THAT THE        *  IC2224.2
+076400*    "NOT ON EXCEPTION" PHRASE OF THE PRECEDING CALL STATEMENT *  IC2224.2
+076500*    WAS EXECUTED.                                             *  IC2224.2
+076600*                                                              *  IC2224.2
+076700****************************************************************  IC2224.2
+076800*                                                                 IC2224.2
+076900     MOVE   "END-CALL OBSERVANCE" TO FEATURE.                     IC2224.2
+077000     IF      CALL-FLAG = 3                                        IC2224.2
+077100             PERFORM PASS                                         IC2224.2
+077200     ELSE                                                         IC2224.2
+077300             MOVE   "INCORRECT CONTROL FLOW" TO RE-MARK           IC2224.2
+077400             MOVE    3 TO CORRECT-N                               IC2224.2
+077500             MOVE    CALL-FLAG TO COMPUTED-N                      IC2224.2
+077600             PERFORM FAIL.                                        IC2224.2
+077700     PERFORM PRINT-DETAIL.                                        IC2224.2
+077800*                                                                 IC2224.2
+077900 CALL-EXIT-5.                                                     IC2224.2
+078000*                                                                 IC2224.2
+078100*                                                                 IC2224.2
+078200 CALL-INIT-6.                                                     IC2224.2
+078300****************************************************************  IC2224.2
+078400*                                                              *  IC2224.2
+078500*    CALL A PROGRAM WHICH IS AVAILABLE FOR EXECUTION, USING A  *  IC2224.2
+078600*    CALL STATEMENT WITH NEITHER AN "ON EXCEPTION" PHRASE NOR  *  IC2224.2
+078700*    A "NOT ON EXCEPTION" PHRASE.  EXECUTION SHOULD BE         *  IC2224.2
+078800*    SUCCESSFUL. THE STATEMENT FOLLOWING THE SCOPE TERMINATOR  *  IC2224.2
+078900*    SHOULD BE EXECUTED.                                       *  IC2224.2
+079000*                                                              *  IC2224.2
+079100****************************************************************  IC2224.2
+079200*                                                                 IC2224.2
+079300     MOVE    1 TO REC-CT.                                         IC2224.2
+079400     MOVE   "CALL-TEST-6" TO PAR-NAME.                            IC2224.2
+079500     MOVE   "AVAILABLE  -- ---" TO FEATURE.                       IC2224.2
+079600     MOVE    0 TO CALL-FLAG.                                      IC2224.2
+079700     MOVE   "X" TO EXCEPTION-PATH-FLAG.                           IC2224.2
+079800     MOVE   "X-28 5.2.4 (2)" TO ANSI-REFERENCE.                   IC2224.2
+079900     MOVE    ZERO TO DN3, DN4.                                    IC2224.2
+080000     GO TO   CALL-TEST-6-1.                                       IC2224.2
+080100 CALL-DELETE-6-1.                                                 IC2224.2
+080200     PERFORM DE-LETE.                                             IC2224.2
+080300     PERFORM PRINT-DETAIL.                                        IC2224.2
+080400     ADD     1 TO REC-CT.                                         IC2224.2
+080500*                                                                 IC2224.2
+080600*    IF THIS TEST IS DELETED THEN ITS SUBORDINATE TEST IS      *  IC2224.2
+080700*    AUTOMATICALLY DELETED.                                    *  IC2224.2
+080800*                                                                 IC2224.2
+080900     GO TO   CALL-DELETE-6-2.                                     IC2224.2
+081000 CALL-TEST-6-1.                                                   IC2224.2
+081100     CALL   "IC222A1" USING DN1, DN2, DN3, DN4                    IC2224.2
+081200     END-CALL                                                     IC2224.2
+081300     ADD     1 TO CALL-FLAG.                                      IC2224.2
+081400     IF EXCEPTION-PATH-FLAG NOT = "X"                             IC2224.2
+081500             MOVE "EXCEPTION-PATH-FLAG ALTERED" TO RE-MARK        IC2224.2
+081600             MOVE "X" TO CORRECT-A                                IC2224.2
+081700             MOVE EXCEPTION-PATH-FLAG TO COMPUTED-A               IC2224.2
+081800             PERFORM FAIL                                         IC2224.2
+081900     ELSE                                                         IC2224.2
+082000             PERFORM PASS.                                        IC2224.2
+082100 CALL-WRITE-6-1.                                                  IC2224.2
+082200     PERFORM PRINT-DETAIL.                                        IC2224.2
+082300     ADD 1 TO REC-CT.                                             IC2224.2
+082400*                                                                 IC2224.2
+082500 CALL-INIT-6-2.                                                   IC2224.2
+082600     GO TO    CALL-TEST-6-2.                                      IC2224.2
+082700 CALL-DELETE-6-2.                                                 IC2224.2
+082800     MOVE   "END-CALL OBSERVANCE" TO FEATURE.                     IC2224.2
+082900     PERFORM DE-LETE.                                             IC2224.2
+083000     PERFORM PRINT-DETAIL.                                        IC2224.2
+083100     ADD     1 TO REC-CT.                                         IC2224.2
+083200     GO TO   CALL-EXIT-6.                                         IC2224.2
+083300*                                                                 IC2224.2
+083400 CALL-TEST-6-2.                                                   IC2224.2
+083500****************************************************************  IC2224.2
+083600*                                                              *  IC2224.2
+083700*    CHECKS THAT THE STATEMENT FOLLOWING THE SCOPE TERMINATOR  *  IC2224.2
+083800*    WAS EXECUTED.                                             *  IC2224.2
+083900*                                                              *  IC2224.2
+084000****************************************************************  IC2224.2
+084100*                                                                 IC2224.2
+084200     MOVE   "END-CALL OBSERVANCE" TO FEATURE.                     IC2224.2
+084300     IF      CALL-FLAG = 1                                        IC2224.2
+084400             PERFORM PASS                                         IC2224.2
+084500     ELSE                                                         IC2224.2
+084600             MOVE   "INCORRECT CONTROL FLOW" TO RE-MARK           IC2224.2
+084700             MOVE    1 TO CORRECT-N                               IC2224.2
+084800             MOVE    CALL-FLAG TO COMPUTED-N                      IC2224.2
+084900             PERFORM FAIL.                                        IC2224.2
+085000     PERFORM PRINT-DETAIL.                                        IC2224.2
+085100*                                                                 IC2224.2
+085200 CALL-EXIT-6.                                                     IC2224.2
+085300*                                                                 IC2224.2
+085400*                                                                 IC2224.2
+085500 CALL-INIT-7.                                                     IC2224.2
+085600****************************************************************  IC2224.2
+085700*                                                              *  IC2224.2
+085800*    CALL A PROGRAM WHICH EXISTS AND FOR WHICH PARAMETERS      *  IC2224.2
+085900*    MATCH IN NUMBER AND TYPE.  THIS TEST IS A DUPLICATION OF  *  IC2224.2
+086000*    CALL-TEST-1, WITH "ON OVERFLOW" SUBSTITUTED FOR           *  IC2224.2
+086100*    "ON EXCEPTION" IN THE CALL STATEMENT.                     *  IC2224.2
+086200*                                                              *  IC2224.2
+086300****************************************************************  IC2224.2
+086400*                                                                 IC2224.2
+086500     MOVE    1 TO REC-CT.                                         IC2224.2
+086600     MOVE   "CALL-TEST-7" TO PAR-NAME.                            IC2224.2
+086700     MOVE   "AVAILABLE  OV ---" TO FEATURE.                       IC2224.2
+086800     MOVE    0 TO CALL-FLAG.                                      IC2224.2
+086900     MOVE   "P" TO EXCEPTION-PATH-FLAG.                           IC2224.2
+087000     MOVE   "X-27 5.2.4 (2)" TO ANSI-REFERENCE.                   IC2224.2
+087100     MOVE    ZERO TO DN3, DN4.                                    IC2224.2
+087200     GO TO   CALL-TEST-7-1.                                       IC2224.2
+087300 CALL-DELETE-7-1.                                                 IC2224.2
+087400     PERFORM DE-LETE.                                             IC2224.2
+087500     PERFORM PRINT-DETAIL.                                        IC2224.2
+087600     ADD     1 TO REC-CT.                                         IC2224.2
+087700*                                                                 IC2224.2
+087800*    IF THIS TEST IS DELETED THEN ITS SUBORDINATE TEST IS      *  IC2224.2
+087900*    AUTOMATICALLY DELETED.                                    *  IC2224.2
+088000*                                                                 IC2224.2
+088100     GO TO   CALL-DELETE-7-2.                                     IC2224.2
+088200 CALL-TEST-7-1.                                                   IC2224.2
+088300     CALL   "IC222A1" USING DN1, DN2, DN3, DN4                    IC2224.2
+088400             ON OVERFLOW                                          IC2224.2
+088500                  MOVE "F" TO EXCEPTION-PATH-FLAG                 IC2224.2
+088600     END-CALL                                                     IC2224.2
+088700     MOVE    1 TO CALL-FLAG.                                      IC2224.2
+088800     IF EXCEPTION-PATH-FLAG NOT = "P"                             IC2224.2
+088900             MOVE "UNEXPECTED EXECUTION OF EXCEPTION PATH"        IC2224.2
+089000                      TO RE-MARK                                  IC2224.2
+089100             MOVE "P" TO CORRECT-A                                IC2224.2
+089200             MOVE EXCEPTION-PATH-FLAG TO COMPUTED-A               IC2224.2
+089300             PERFORM FAIL                                         IC2224.2
+089400     ELSE                                                         IC2224.2
+089500             PERFORM PASS.                                        IC2224.2
+089600 CALL-WRITE-7-1.                                                  IC2224.2
+089700     PERFORM PRINT-DETAIL.                                        IC2224.2
+089800     ADD 1 TO REC-CT.                                             IC2224.2
+089900*                                                                 IC2224.2
+090000 CALL-INIT-7-2.                                                   IC2224.2
+090100     GO TO    CALL-TEST-7-2.                                      IC2224.2
+090200 CALL-DELETE-7-2.                                                 IC2224.2
+090300     MOVE   "END-CALL OBSERVANCE" TO FEATURE.                     IC2224.2
+090400     PERFORM DE-LETE.                                             IC2224.2
+090500     PERFORM PRINT-DETAIL.                                        IC2224.2
+090600     ADD     1 TO REC-CT.                                         IC2224.2
+090700     GO TO   CALL-EXIT-7.                                         IC2224.2
+090800*                                                                 IC2224.2
+090900 CALL-TEST-7-2.                                                   IC2224.2
+091000****************************************************************  IC2224.2
+091100*                                                              *  IC2224.2
+091200*    CHECKS THAT THE STATEMENT FOLLOWING THE SCOPE TERMINATOR  *  IC2224.2
+091300*    WAS EXECUTED.  IF THE PREVIOUS TEST PASSED, A PASS HERE   *  IC2224.2
+091400*    INDICATES THAT THE SCOPE TERMINATOR HAS BEEN INTERPRETED  *  IC2224.2
+091500*    CORRECTLY.  IF THE PREVIOUS TEST FAILED, A PASS HERE      *  IC2224.2
+091600*    INDICATES THAT THE SCOPE TERMINATOR WAS NOT INTERPRETED   *  IC2224.2
+091700*    AS "NOT ON EXCEPTION" OR "GO TO NEXT-SENTENCE".           *  IC2224.2
+091800*                                                              *  IC2224.2
+091900****************************************************************  IC2224.2
+092000*                                                                 IC2224.2
+092100     MOVE   "END-CALL OBSERVANCE" TO FEATURE.                     IC2224.2
+092200     IF      CALL-FLAG = 1                                        IC2224.2
+092300             PERFORM PASS                                         IC2224.2
+092400     ELSE                                                         IC2224.2
+092500             MOVE   "INCORRECT CONTROL FLOW" TO RE-MARK           IC2224.2
+092600             MOVE    1 TO CORRECT-N                               IC2224.2
+092700             MOVE    CALL-FLAG TO COMPUTED-N                      IC2224.2
+092800             PERFORM FAIL.                                        IC2224.2
+092900     PERFORM PRINT-DETAIL.                                        IC2224.2
+093000*                                                                 IC2224.2
+093100 CALL-EXIT-7.                                                     IC2224.2
+093200*                                                                 IC2224.2
+093300*                                                                 IC2224.2
+093400 CALL-INIT-8.                                                     IC2224.2
+093500****************************************************************  IC2224.2
+093600*                                                              *  IC2224.2
+093700*    CALL A PROGRAM WHICH DOES NOT EXIST.  PAGE X-28, 5.2.4    *  IC2224.2
+093800*    RULE (3)A STATES THAT IF A PROGRAM CANNOT BE MADE        *   IC2224.2
+093900*    AVAILABLE THEN THE STATEMENTS IN THE "ON EXCEPTION" OR    *  IC2224.2
+094000*    "ON OVERFLOW" PHRASE MUST BE EXECUTED.  THIS TEST IS A    *  IC2224.2
+094100*    DUPLICATION OF CALL-TEST-2 WITH "ON OVERFLOW" SUBSTITUTED *  IC2224.2
+094200*    FOR "ON EXCEPTION" IN THE CALL STATEMENT.                 *  IC2224.2
+094300*                                                              *  IC2224.2
+094400****************************************************************  IC2224.2
+094500*                                                                 IC2224.2
+094600     MOVE    1 TO REC-CT.                                         IC2224.2
+094700     MOVE   "CALL-TEST-8" TO PAR-NAME.                            IC2224.2
+094800     MOVE   "NO PROGRAM OV ---" TO FEATURE.                       IC2224.2
+094900     MOVE    0 TO CALL-FLAG.                                      IC2224.2
+095000     MOVE   "X" TO EXCEPTION-PATH-FLAG.                           IC2224.2
+095100     MOVE   "X-28 5.2.4 (3)A" TO ANSI-REFERENCE.                  IC2224.2
+095200     MOVE    ZERO TO DN3, DN4.                                    IC2224.2
+095300     GO TO   CALL-TEST-8-1.                                       IC2224.2
+095400 CALL-DELETE-8-1.                                                 IC2224.2
+095500     PERFORM DE-LETE.                                             IC2224.2
+095600     PERFORM PRINT-DETAIL.                                        IC2224.2
+095700     ADD     1 TO REC-CT.                                         IC2224.2
+095800*                                                                 IC2224.2
+095900*    IF THIS TEST IS DELETED THEN ITS SUBORDINATE TEST IS      *  IC2224.2
+096000*    AUTOMATICALLY DELETED.                                    *  IC2224.2
+096100*                                                                 IC2224.2
+096200     GO TO   CALL-DELETE-8-2.                                     IC2224.2
+096300 CALL-TEST-8-1.                                                   IC2224.2
+096400*    CALL "NON-EXISTING-PROGRAM"                                  IC2224.2
+096500     CALL   "XXXXXXXX" USING DN1, DN2, DN3, DN4                   IC2224.2
+096600             ON OVERFLOW                                          IC2224.2
+096700                  MOVE "P" TO EXCEPTION-PATH-FLAG                 IC2224.2
+096800     END-CALL                                                     IC2224.2
+096900     MOVE    1 TO CALL-FLAG.                                      IC2224.2
+097000     IF EXCEPTION-PATH-FLAG NOT = "P"                             IC2224.2
+097100             MOVE "EXCEPTION SHOULD HAVE OCCURRED" TO RE-MARK     IC2224.2
+097200             MOVE "P" TO CORRECT-A                                IC2224.2
+097300             MOVE EXCEPTION-PATH-FLAG TO COMPUTED-A               IC2224.2
+097400             PERFORM FAIL                                         IC2224.2
+097500     ELSE                                                         IC2224.2
+097600             PERFORM PASS.                                        IC2224.2
+097700 CALL-WRITE-8-1.                                                  IC2224.2
+097800     PERFORM PRINT-DETAIL.                                        IC2224.2
+097900     ADD 1 TO REC-CT.                                             IC2224.2
+098000*                                                                 IC2224.2
+098100 CALL-INIT-8-2.                                                   IC2224.2
+098200     GO TO    CALL-TEST-8-2.                                      IC2224.2
+098300 CALL-DELETE-8-2.                                                 IC2224.2
+098400     MOVE   "END-CALL OBSERVANCE" TO FEATURE.                     IC2224.2
+098500     PERFORM DE-LETE.                                             IC2224.2
+098600     PERFORM PRINT-DETAIL.                                        IC2224.2
+098700     ADD     1 TO REC-CT.                                         IC2224.2
+098800     GO TO   CALL-EXIT-8.                                         IC2224.2
+098900*                                                                 IC2224.2
+099000 CALL-TEST-8-2.                                                   IC2224.2
+099100****************************************************************  IC2224.2
+099200*                                                              *  IC2224.2
+099300*    CHECKS THAT THE STATEMENT FOLLOWING THE SCOPE TERMINATOR  *  IC2224.2
+099400*    WAS EXECUTED.  IF THE PREVIOUS TEST FAILED, A PASS HERE   *  IC2224.2
+099500*    INDICATES THAT THE SCOPE TERMINATOR HAS BEEN INTERPRETED  *  IC2224.2
+099600*    CORRECTLY.  IF THE PREVIOUS TEST PASSED, A PASS HERE      *  IC2224.2
+099700*    INDICATES THAT THE SCOPE TERMINATOR WAS NOT INTERPRETED   *  IC2224.2
+099800*    AS "NOT ON EXCEPTION" OR "GO TO NEXT-SENTENCE".           *  IC2224.2
+099900*                                                              *  IC2224.2
+100000****************************************************************  IC2224.2
+100100*                                                                 IC2224.2
+100200     MOVE   "END-CALL OBSERVANCE" TO FEATURE.                     IC2224.2
+100300     IF      CALL-FLAG = 1                                        IC2224.2
+100400             PERFORM PASS                                         IC2224.2
+100500     ELSE                                                         IC2224.2
+100600             MOVE   "INCORRECT CONTROL FLOW" TO RE-MARK           IC2224.2
+100700             MOVE    1 TO CORRECT-N                               IC2224.2
+100800             MOVE    CALL-FLAG TO COMPUTED-N                      IC2224.2
+100900             PERFORM FAIL.                                        IC2224.2
+101000     PERFORM PRINT-DETAIL.                                        IC2224.2
+101100*                                                                 IC2224.2
+101200 CALL-EXIT-8.                                                     IC2224.2
+101300*                                                                 IC2224.2
+101400*                                                                 IC2224.2
+101500 CCVS-EXIT SECTION.                                               IC2224.2
+101600 CCVS-999999.                                                     IC2224.2
+101700     GO TO CLOSE-FILES.                                           IC2224.2
+101800 END PROGRAM IC222A.                                              IC2224.2

--- a/z390/IC222A1.CBL
+++ b/z390/IC222A1.CBL
@@ -1,0 +1,150 @@
+101900 IDENTIFICATION DIVISION.                                         IC2224.2
+      *
+      * This is the z390 version of IC222A-1
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC222A1
+      * IC222A has been modified to call IC222A1 instead of IC222A-1.
+      *
+102000 PROGRAM-ID.                                                      IC2224.2
+102100     IC222A1.                                                     IC2224.2
+102200****************************************************************  IC2224.2
+102300*                                                              *  IC2224.2
+102400*    THIS PROGRAM FORMS PART OF THE COBOL COMPILER VALIDATION  *  IC2224.2
+102500*    SYSTEM (CCVS) USED TO TEST COBOL COMPILERS FOR            *  IC2224.2
+102600*    CONFORMANCE WITH THE AMERICAN NATIONAL STANDARD           *  IC2224.2
+102700*    (ANSI DOCUMENT REFERENCE: X3.23-1985) AND THE STANDARD OF *  IC2224.2
+102800*    THE INTERNATIONAL ORGANIZATION FOR STANDARDISATION        *  IC2224.2
+102900*    (ISO DOCUMENT REFERENCE: ISO-1989-1985).                  *  IC2224.2
+103000*                                                              *  IC2224.2
+103100*    THIS CCVS INCORPORATES ENHANCEMENTS TO THE CCVS FOR THE   *  IC2224.2
+103200*    1974 STANDARD (ANSI DOCUMENT REFERENCE: X3.23-1974; ISO   *  IC2224.2
+103300*    DOCUMENT REFERENCE: ISO-1989-1978).                       *  IC2224.2
+103400*                                                              *  IC2224.2
+103500*    THESE ENHANCEMENTS WERE SPECIFIED BY A PROJECT TEAM WHICH *  IC2224.2
+103600*    WAS FUNDED BY THE COMMISSION FOR EUROPEAN COMMUNITIES AND *  IC2224.2
+103700*    WHICH WAS RESPONSIBLE FOR TECHNICAL ISSUES TO:            *  IC2224.2
+103800*                                                              *  IC2224.2
+103900*          THE FEDERAL SOFTWARE TESTING CENTER                 *  IC2224.2
+104000*          OFFICE OF SOFTWARE DEVELOPMENT                      *  IC2224.2
+104100*                & INFORMATION TECHNOLOGY                      *  IC2224.2
+104200*          TWO SKYLINE PLACE                                   *  IC2224.2
+104300*          SUITE 1100                                          *  IC2224.2
+104400*          5203 LEESBURG PIKE                                  *  IC2224.2
+104500*          FALLS CHURCH                                        *  IC2224.2
+104600*          VA 22041                                            *  IC2224.2
+104700*          U.S.A.                                              *  IC2224.2
+104800*                                                              *  IC2224.2
+104900*    THE PROJECT TEAM MEMBERS WERE:                            *  IC2224.2
+105000*                                                              *  IC2224.2
+105100*          BIADI (BUREAU INTER ADMINISTRATION                  *  IC2224.2
+105200*                 DE DOCUMENTATION INFORMATIQUE)               *  IC2224.2
+105300*          21 RUE BARA                                         *  IC2224.2
+105400*          F-92132 ISSY                                        *  IC2224.2
+105500*          FRANCE                                              *  IC2224.2
+105600*                                                              *  IC2224.2
+105700*                                                              *  IC2224.2
+105800*          GMD (GESELLSCHAFT FUR MATHEMATIK                    *  IC2224.2
+105900*               UND DATENVERARBEITUNG MBH)                     *  IC2224.2
+106000*          SCHLOSS BIRLINGHOVEN                                *  IC2224.2
+106100*          POSTFACH 12 40                                      *  IC2224.2
+106200*          D-5205 ST. AUGUSTIN 1                               *  IC2224.2
+106300*          GERMANY FR                                          *  IC2224.2
+106400*                                                              *  IC2224.2
+106500*                                                              *  IC2224.2
+106600*          NCC (THE NATIONAL COMPUTING CENTRE LTD)             *  IC2224.2
+106700*          OXFORD ROAD                                         *  IC2224.2
+106800*          MANCHESTER                                          *  IC2224.2
+106900*          M1 7ED                                              *  IC2224.2
+107000*          UNITED KINGDOM                                      *  IC2224.2
+107100*                                                              *  IC2224.2
+107200*                                                              *  IC2224.2
+107300*    THIS TEST SUITE WAS PRODUCED BY THE NATIONAL COMPUTING    *  IC2224.2
+107400*    CENTRE IN ENGLAND AND IS THE OFFICIAL CCVS TEST SUITE     *  IC2224.2
+107500*    USED THROUGHOUT EUROPE AND THE UNITED STATES OF AMERICA.  *  IC2224.2
+107600*                                                              *  IC2224.2
+107700*    REVISED 1986 AUGUST                                       *  IC2224.2
+107800*                                                              *  IC2224.2
+107900****************************************************************  IC2224.2
+108000*                                                              *  IC2224.2
+108100*    VALIDATION FOR:-                                          *  IC2224.2
+108200*                                                              *  IC2224.2
+108300*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2224.2
+108400*                                                              *  IC2224.2
+108500*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2224.2
+108600*                                                              *  IC2224.2
+108700****************************************************************  IC2224.2
+108800*                                                              *  IC2224.2
+108900*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2224.2
+109000*                                                              *  IC2224.2
+109100*            X-82   SOURCE-COMPUTER                            *  IC2224.2
+109200*            X-83   OBJECT-COMPUTER.                           *  IC2224.2
+109300*                                                              *  IC2224.2
+109400****************************************************************  IC2224.2
+109500*                                                              *  IC2224.2
+109600*    THE SOURCE FILE CONTAINS TWO PROGRAMS, IC222A AND         *  IC2224.2
+109700*    IC222A-1, WHICH TEST LANGUAGE ELEMENTS FROM  LEVEL 2 OF   *  IC2224.2
+109800*    THE INTER-PROGRAM COMMUNICATION MODULE.  THE LANGUAGE     *  IC2224.2
+109900*    ELEMENTS TESTED ARE:                                      *  IC2224.2
+110000*          "ON EXCEPTION"     PHRASE                           *  IC2224.2
+110100*          "NOT ON EXCEPTION" PHRASE                           *  IC2224.2
+110200*          "END-CALL"         PHRASE                           *  IC2224.2
+110300*          "ON OVERFLOW"      PHRASE                           *  IC2224.2
+110400*                                                                 IC2224.2
+110500*    THE TWO PROGRAMS SHOULD BE COMPILED IN THE SAME           *  IC2224.2
+110600*    INVOCATION OF THE COMPILER TO TEST THE BATCH COMPILATION  *  IC2224.2
+110700*    FEATURE AND RECOGNITION OF THE END PROGRAM HEADER.  THE   *  IC2224.2
+110800*    ARRANGEMENT OF THE PROGRAMS IN THE SOURCE FILE IS:           IC2224.2
+110900*                                                                 IC2224.2
+111000*    IDENTIFICATION DIVISION.                                     IC2224.2
+111100*    PROGRAM-ID. IC222A.                                          IC2224.2
+111200*          .                                                      IC2224.2
+111300*          .                                                      IC2224.2
+111400*          .                                                      IC2224.2
+111500*    END PROGRAM IC222A.                                          IC2224.2
+111600*    IDENTIFICATION DIVISION.                                     IC2224.2
+111700*    PROGRAM-ID. IC222A-1.                                        IC2224.2
+111800*          .                                                      IC2224.2
+111900*          .                                                      IC2224.2
+112000*          .                                                      IC2224.2
+112100*                                                                 IC2224.2
+112200*    A FULL DESCRIPTION OF THE TWO PROGRAMS IS INCLUDED AS     *  IC2224.2
+112300*    COMMENTS IN PROGRAM IC222A.                               *  IC2224.2
+112400*                                                              *  IC2224.2
+112500****************************************************************  IC2224.2
+112600*                                                                 IC2224.2
+112700 ENVIRONMENT DIVISION.                                            IC2224.2
+112800 CONFIGURATION SECTION.                                           IC2224.2
+112900 SOURCE-COMPUTER.                                                 IC2224.2
+113000     XXXXX082.                                                    IC2224.2
+113100 OBJECT-COMPUTER.                                                 IC2224.2
+113200     XXXXX083.                                                    IC2224.2
+113300 INPUT-OUTPUT SECTION.                                            IC2224.2
+113400 FILE-CONTROL.                                                    IC2224.2
+113500     SELECT PRINT-FILE ASSIGN TO                                  IC2224.2
+113600     XXXXX055.                                                    IC2224.2
+113700*                                                                 IC2224.2
+113800 DATA DIVISION.                                                   IC2224.2
+113900 FILE SECTION.                                                    IC2224.2
+114000 FD  PRINT-FILE.                                                  IC2224.2
+114100 01  PRINT-REC PICTURE X(120).                                    IC2224.2
+114200 01  DUMMY-RECORD PICTURE X(120).                                 IC2224.2
+114300 WORKING-STORAGE SECTION.                                         IC2224.2
+114400 77  WS1 PICTURE S999.                                            IC2224.2
+114500 77  WS2 PICTURE S999                                             IC2224.2
+114600         USAGE COMPUTATIONAL, VALUE ZERO.                         IC2224.2
+114700 LINKAGE SECTION.                                                 IC2224.2
+114800 77  DN1 PICTURE S99.                                             IC2224.2
+114900 77  DN2 PICTURE S99 USAGE COMPUTATIONAL.                         IC2224.2
+115000 77  DN3 PICTURE S99.                                             IC2224.2
+115100 77  DN4 PICTURE S99 USAGE COMPUTATIONAL.                         IC2224.2
+115200*                                                                 IC2224.2
+115300 PROCEDURE DIVISION USING DN1, DN2, DN3, DN4.                     IC2224.2
+115400 SECT-IC222A-1-001 SECTION.                                       IC2224.2
+115500 CALL-TEST-001.                                                   IC2224.2
+115600     MOVE DN1 TO WS1.                                             IC2224.2
+115700     ADD 1 TO WS1.                                                IC2224.2
+115800     ADD 1 TO WS2.                                                IC2224.2
+115900     MOVE WS1 TO DN3.                                             IC2224.2
+116000     MOVE WS2 TO DN4.                                             IC2224.2
+116100 CALL-EXIT-001.                                                   IC2224.2
+116200     EXIT PROGRAM.                                                IC2224.2

--- a/z390/IC223A.CBL
+++ b/z390/IC223A.CBL
@@ -1,0 +1,649 @@
+000100 IDENTIFICATION DIVISION.                                         IC2234.2
+      *
+      * This is the z390 version of IC223A
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC223A1
+      * IC223A has been modified to call IC223A1 instead of IC223A-1.
+      *
+000200 PROGRAM-ID.                                                      IC2234.2
+000300     IC223A.                                                      IC2234.2
+000400****************************************************************  IC2234.2
+000500*                                                              *  IC2234.2
+000600*    VALIDATION FOR:-                                          *  IC2234.2
+000700*                                                              *  IC2234.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2234.2
+000900*                                                              *  IC2234.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2234.2
+001100*                                                              *  IC2234.2
+001200****************************************************************  IC2234.2
+001300*                                                              *  IC2234.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2234.2
+001500*                                                              *  IC2234.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC2234.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC2234.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC2234.2
+001900*                                                              *  IC2234.2
+002000****************************************************************  IC2234.2
+002100*                                                              *  IC2234.2
+002200*    PROGRAM IC223A AND IC223A-1 WILL TEST THE NEW LANGUAGE    *  IC2234.2
+002300*    ELEMENTS FOR THE LEVEL 2 INTER-PROGRAM COMMUNICATION      *  IC2234.2
+002400*    MODULE.                                                   *  IC2234.2
+002500*    THE NEW LANGUAGE ELEMENTS TO BE TESTED WILL BE:           *  IC2234.2
+002600*          "BY REFERENCE"     PHRASE                           *  IC2234.2
+002700*    THE TWO PROGRAMS WILL BE COMPILED IN THE SAME FLOW        *  IC2234.2
+002800*    (TO TEST THE "END PROGRAM" STATEMENT) AS SHOWN BELOW:     *  IC2234.2
+002900*    IDENTIFICATION DIVISION.                                  *  IC2234.2
+003000*    PROGRAM-ID. IC223A.                                       *  IC2234.2
+003100*              .                                               *  IC2234.2
+003200*              .                                               *  IC2234.2
+003300*              .                                               *  IC2234.2
+003400*    END PROGRAM IC223A.                                       *  IC2234.2
+003500*    PROGRAM-ID. IC223A-1.                                     *  IC2234.2
+003600*              .                                               *  IC2234.2
+003700*              .                                               *  IC2234.2
+003800*              .                                               *  IC2234.2
+003900****************************************************************  IC2234.2
+004000 ENVIRONMENT DIVISION.                                            IC2234.2
+004100 CONFIGURATION SECTION.                                           IC2234.2
+004200 SOURCE-COMPUTER.                                                 IC2234.2
+004300     XXXXX082.                                                    IC2234.2
+004400 OBJECT-COMPUTER.                                                 IC2234.2
+004500     XXXXX083.                                                    IC2234.2
+004600 INPUT-OUTPUT SECTION.                                            IC2234.2
+004700 FILE-CONTROL.                                                    IC2234.2
+004800     SELECT PRINT-FILE ASSIGN TO                                  IC2234.2
+004900     XXXXX055.                                                    IC2234.2
+005000 DATA DIVISION.                                                   IC2234.2
+005100 FILE SECTION.                                                    IC2234.2
+005200 FD  PRINT-FILE.                                                  IC2234.2
+005300 01  PRINT-REC PICTURE X(120).                                    IC2234.2
+005400 01  DUMMY-RECORD PICTURE X(120).                                 IC2234.2
+005500 WORKING-STORAGE SECTION.                                         IC2234.2
+005600 77  DN1 PICTURE S99  VALUE ZERO.                                 IC2234.2
+005700 77  DN3 PICTURE S99.                                             IC2234.2
+005800 77  ID1 PICTURE X(8) VALUE "IC223A1".                            IC2234.2
+005900 77  ID2 PICTURE X(8).                                            IC2234.2
+006000 77  DN2 PICTURE S99                                              IC2234.2
+006100         USAGE COMPUTATIONAL, VALUE ZERO.                         IC2234.2
+006200 77  DN4 PICTURE S99                                              IC2234.2
+006300         USAGE IS COMPUTATIONAL.                                  IC2234.2
+006400 77  CALL-COUNT PIC S99.                                          IC2234.2
+006500 77  FAIL-FLAG PIC 9.                                             IC2234.2
+006600 01  TEST-RESULTS.                                                IC2234.2
+006700     02 FILLER                   PIC X      VALUE SPACE.          IC2234.2
+006800     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC2234.2
+006900     02 FILLER                   PIC X      VALUE SPACE.          IC2234.2
+007000     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC2234.2
+007100     02 FILLER                   PIC X      VALUE SPACE.          IC2234.2
+007200     02  PAR-NAME.                                                IC2234.2
+007300       03 FILLER                 PIC X(19)  VALUE SPACE.          IC2234.2
+007400       03  PARDOT-X              PIC X      VALUE SPACE.          IC2234.2
+007500       03 DOTVALUE               PIC 99     VALUE ZERO.           IC2234.2
+007600     02 FILLER                   PIC X(8)   VALUE SPACE.          IC2234.2
+007700     02 RE-MARK                  PIC X(61).                       IC2234.2
+007800 01  TEST-COMPUTED.                                               IC2234.2
+007900     02 FILLER                   PIC X(30)  VALUE SPACE.          IC2234.2
+008000     02 FILLER                   PIC X(17)  VALUE                 IC2234.2
+008100            "       COMPUTED=".                                   IC2234.2
+008200     02 COMPUTED-X.                                               IC2234.2
+008300     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC2234.2
+008400     03 COMPUTED-N               REDEFINES COMPUTED-A             IC2234.2
+008500                                 PIC -9(9).9(9).                  IC2234.2
+008600     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC2234.2
+008700     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC2234.2
+008800     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC2234.2
+008900     03       CM-18V0 REDEFINES COMPUTED-A.                       IC2234.2
+009000         04 COMPUTED-18V0                    PIC -9(18).          IC2234.2
+009100         04 FILLER                           PIC X.               IC2234.2
+009200     03 FILLER PIC X(50) VALUE SPACE.                             IC2234.2
+009300 01  TEST-CORRECT.                                                IC2234.2
+009400     02 FILLER PIC X(30) VALUE SPACE.                             IC2234.2
+009500     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC2234.2
+009600     02 CORRECT-X.                                                IC2234.2
+009700     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC2234.2
+009800     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC2234.2
+009900     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC2234.2
+010000     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC2234.2
+010100     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC2234.2
+010200     03      CR-18V0 REDEFINES CORRECT-A.                         IC2234.2
+010300         04 CORRECT-18V0                     PIC -9(18).          IC2234.2
+010400         04 FILLER                           PIC X.               IC2234.2
+010500     03 FILLER PIC X(2) VALUE SPACE.                              IC2234.2
+010600     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC2234.2
+010700 01  CCVS-C-1.                                                    IC2234.2
+010800     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC2234.2
+010900-    "SS  PARAGRAPH-NAME                                          IC2234.2
+011000-    "       REMARKS".                                            IC2234.2
+011100     02 FILLER                     PIC X(20)    VALUE SPACE.      IC2234.2
+011200 01  CCVS-C-2.                                                    IC2234.2
+011300     02 FILLER                     PIC X        VALUE SPACE.      IC2234.2
+011400     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC2234.2
+011500     02 FILLER                     PIC X(15)    VALUE SPACE.      IC2234.2
+011600     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC2234.2
+011700     02 FILLER                     PIC X(94)    VALUE SPACE.      IC2234.2
+011800 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC2234.2
+011900 01  REC-CT                        PIC 99       VALUE ZERO.       IC2234.2
+012000 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC2234.2
+012100 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC2234.2
+012200 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC2234.2
+012300 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC2234.2
+012400 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC2234.2
+012500 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC2234.2
+012600 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC2234.2
+012700 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC2234.2
+012800 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC2234.2
+012900 01  CCVS-H-1.                                                    IC2234.2
+013000     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2234.2
+013100     02  FILLER                    PIC X(42)    VALUE             IC2234.2
+013200     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC2234.2
+013300     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2234.2
+013400 01  CCVS-H-2A.                                                   IC2234.2
+013500   02  FILLER                        PIC X(40)  VALUE SPACE.      IC2234.2
+013600   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC2234.2
+013700   02  FILLER                        PIC XXXX   VALUE             IC2234.2
+013800     "4.2 ".                                                      IC2234.2
+013900   02  FILLER                        PIC X(28)  VALUE             IC2234.2
+014000            " COPY - NOT FOR DISTRIBUTION".                       IC2234.2
+014100   02  FILLER                        PIC X(41)  VALUE SPACE.      IC2234.2
+014200                                                                  IC2234.2
+014300 01  CCVS-H-2B.                                                   IC2234.2
+014400   02  FILLER                        PIC X(15)  VALUE             IC2234.2
+014500            "TEST RESULT OF ".                                    IC2234.2
+014600   02  TEST-ID                       PIC X(9).                    IC2234.2
+014700   02  FILLER                        PIC X(4)   VALUE             IC2234.2
+014800            " IN ".                                               IC2234.2
+014900   02  FILLER                        PIC X(12)  VALUE             IC2234.2
+015000     " HIGH       ".                                              IC2234.2
+015100   02  FILLER                        PIC X(22)  VALUE             IC2234.2
+015200            " LEVEL VALIDATION FOR ".                             IC2234.2
+015300   02  FILLER                        PIC X(58)  VALUE             IC2234.2
+015400     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2234.2
+015500 01  CCVS-H-3.                                                    IC2234.2
+015600     02  FILLER                      PIC X(34)  VALUE             IC2234.2
+015700            " FOR OFFICIAL USE ONLY    ".                         IC2234.2
+015800     02  FILLER                      PIC X(58)  VALUE             IC2234.2
+015900     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2234.2
+016000     02  FILLER                      PIC X(28)  VALUE             IC2234.2
+016100            "  COPYRIGHT   1985 ".                                IC2234.2
+016200 01  CCVS-E-1.                                                    IC2234.2
+016300     02 FILLER                       PIC X(52)  VALUE SPACE.      IC2234.2
+016400     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC2234.2
+016500     02 ID-AGAIN                     PIC X(9).                    IC2234.2
+016600     02 FILLER                       PIC X(45)  VALUE SPACES.     IC2234.2
+016700 01  CCVS-E-2.                                                    IC2234.2
+016800     02  FILLER                      PIC X(31)  VALUE SPACE.      IC2234.2
+016900     02  FILLER                      PIC X(21)  VALUE SPACE.      IC2234.2
+017000     02 CCVS-E-2-2.                                               IC2234.2
+017100         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC2234.2
+017200         03 FILLER                   PIC X      VALUE SPACE.      IC2234.2
+017300         03 ENDER-DESC               PIC X(44)  VALUE             IC2234.2
+017400            "ERRORS ENCOUNTERED".                                 IC2234.2
+017500 01  CCVS-E-3.                                                    IC2234.2
+017600     02  FILLER                      PIC X(22)  VALUE             IC2234.2
+017700            " FOR OFFICIAL USE ONLY".                             IC2234.2
+017800     02  FILLER                      PIC X(12)  VALUE SPACE.      IC2234.2
+017900     02  FILLER                      PIC X(58)  VALUE             IC2234.2
+018000     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2234.2
+018100     02  FILLER                      PIC X(13)  VALUE SPACE.      IC2234.2
+018200     02 FILLER                       PIC X(15)  VALUE             IC2234.2
+018300             " COPYRIGHT 1985".                                   IC2234.2
+018400 01  CCVS-E-4.                                                    IC2234.2
+018500     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC2234.2
+018600     02 FILLER                       PIC X(4)   VALUE " OF ".     IC2234.2
+018700     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC2234.2
+018800     02 FILLER                       PIC X(40)  VALUE             IC2234.2
+018900      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC2234.2
+019000 01  XXINFO.                                                      IC2234.2
+019100     02 FILLER                       PIC X(19)  VALUE             IC2234.2
+019200            "*** INFORMATION ***".                                IC2234.2
+019300     02 INFO-TEXT.                                                IC2234.2
+019400       04 FILLER                     PIC X(8)   VALUE SPACE.      IC2234.2
+019500       04 XXCOMPUTED                 PIC X(20).                   IC2234.2
+019600       04 FILLER                     PIC X(5)   VALUE SPACE.      IC2234.2
+019700       04 XXCORRECT                  PIC X(20).                   IC2234.2
+019800     02 INF-ANSI-REFERENCE           PIC X(48).                   IC2234.2
+019900 01  HYPHEN-LINE.                                                 IC2234.2
+020000     02 FILLER  PIC IS X VALUE IS SPACE.                          IC2234.2
+020100     02 FILLER  PIC IS X(65)    VALUE IS "************************IC2234.2
+020200-    "*****************************************".                 IC2234.2
+020300     02 FILLER  PIC IS X(54)    VALUE IS "************************IC2234.2
+020400-    "******************************".                            IC2234.2
+020500 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC2234.2
+020600     "IC223A".                                                    IC2234.2
+020700 PROCEDURE DIVISION.                                              IC2234.2
+020800 CCVS1 SECTION.                                                   IC2234.2
+020900 OPEN-FILES.                                                      IC2234.2
+021000     OPEN     OUTPUT PRINT-FILE.                                  IC2234.2
+021100     MOVE CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.   IC2234.2
+021200     MOVE    SPACE TO TEST-RESULTS.                               IC2234.2
+021300     PERFORM  HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.             IC2234.2
+021400     GO TO CCVS1-EXIT.                                            IC2234.2
+021500 CLOSE-FILES.                                                     IC2234.2
+021600     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC2234.2
+021700 TERMINATE-CCVS.                                                  IC2234.2
+021800S    EXIT PROGRAM.                                                IC2234.2
+021900STERMINATE-CALL.                                                  IC2234.2
+022000     STOP     RUN.                                                IC2234.2
+022100 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         IC2234.2
+022200 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           IC2234.2
+022300 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          IC2234.2
+022400 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      IC2234.2
+022500     MOVE "****TEST DELETED****" TO RE-MARK.                      IC2234.2
+022600 PRINT-DETAIL.                                                    IC2234.2
+022700     IF REC-CT NOT EQUAL TO ZERO                                  IC2234.2
+022800             MOVE "." TO PARDOT-X                                 IC2234.2
+022900             MOVE REC-CT TO DOTVALUE.                             IC2234.2
+023000     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      IC2234.2
+023100     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               IC2234.2
+023200        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 IC2234.2
+023300          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 IC2234.2
+023400     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC2234.2
+023500     MOVE SPACE TO CORRECT-X.                                     IC2234.2
+023600     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC2234.2
+023700     MOVE     SPACE TO RE-MARK.                                   IC2234.2
+023800 HEAD-ROUTINE.                                                    IC2234.2
+023900     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2234.2
+024000     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2234.2
+024100     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2234.2
+024200     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2234.2
+024300 COLUMN-NAMES-ROUTINE.                                            IC2234.2
+024400     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2234.2
+024500     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2234.2
+024600     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC2234.2
+024700 END-ROUTINE.                                                     IC2234.2
+024800     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.IC2234.2
+024900 END-RTN-EXIT.                                                    IC2234.2
+025000     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2234.2
+025100 END-ROUTINE-1.                                                   IC2234.2
+025200      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      IC2234.2
+025300      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               IC2234.2
+025400      ADD PASS-COUNTER TO ERROR-HOLD.                             IC2234.2
+025500*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC2234.2
+025600      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC2234.2
+025700      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC2234.2
+025800      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC2234.2
+025900      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC2234.2
+026000  END-ROUTINE-12.                                                 IC2234.2
+026100      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC2234.2
+026200     IF       ERROR-COUNTER IS EQUAL TO ZERO                      IC2234.2
+026300         MOVE "NO " TO ERROR-TOTAL                                IC2234.2
+026400         ELSE                                                     IC2234.2
+026500         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC2234.2
+026600     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC2234.2
+026700     PERFORM WRITE-LINE.                                          IC2234.2
+026800 END-ROUTINE-13.                                                  IC2234.2
+026900     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC2234.2
+027000         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC2234.2
+027100         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC2234.2
+027200     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC2234.2
+027300     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2234.2
+027400      IF   INSPECT-COUNTER EQUAL TO ZERO                          IC2234.2
+027500          MOVE "NO " TO ERROR-TOTAL                               IC2234.2
+027600      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   IC2234.2
+027700      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            IC2234.2
+027800      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          IC2234.2
+027900     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2234.2
+028000 WRITE-LINE.                                                      IC2234.2
+028100     ADD 1 TO RECORD-COUNT.                                       IC2234.2
+028200Y    IF RECORD-COUNT GREATER 50                                   IC2234.2
+028300Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC2234.2
+028400Y        MOVE SPACE TO DUMMY-RECORD                               IC2234.2
+028500Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC2234.2
+028600Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC2234.2
+028700Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC2234.2
+028800Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC2234.2
+028900Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC2234.2
+029000Y        MOVE ZERO TO RECORD-COUNT.                               IC2234.2
+029100     PERFORM WRT-LN.                                              IC2234.2
+029200 WRT-LN.                                                          IC2234.2
+029300     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC2234.2
+029400     MOVE SPACE TO DUMMY-RECORD.                                  IC2234.2
+029500 BLANK-LINE-PRINT.                                                IC2234.2
+029600     PERFORM WRT-LN.                                              IC2234.2
+029700 FAIL-ROUTINE.                                                    IC2234.2
+029800     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC2234.2
+029900     IF     CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.IC2234.2
+030000     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2234.2
+030100     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC2234.2
+030200     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2234.2
+030300     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2234.2
+030400     GO TO  FAIL-ROUTINE-EX.                                      IC2234.2
+030500 FAIL-ROUTINE-WRITE.                                              IC2234.2
+030600     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC2234.2
+030700     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC2234.2
+030800     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC2234.2
+030900     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC2234.2
+031000 FAIL-ROUTINE-EX. EXIT.                                           IC2234.2
+031100 BAIL-OUT.                                                        IC2234.2
+031200     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC2234.2
+031300     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC2234.2
+031400 BAIL-OUT-WRITE.                                                  IC2234.2
+031500     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC2234.2
+031600     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2234.2
+031700     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2234.2
+031800     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2234.2
+031900 BAIL-OUT-EX. EXIT.                                               IC2234.2
+032000 CCVS1-EXIT.                                                      IC2234.2
+032100     EXIT.                                                        IC2234.2
+032200 SECT-IC223A-001 SECTION.                                         IC2234.2
+032300 CALL-TEST-01.                                                    IC2234.2
+032400     MOVE "CALL-TEST-01" TO PAR-NAME.                             IC2234.2
+032500     MOVE     "LEV 2 CALL STATEMENT" TO FEATURE.                  IC2234.2
+032600     MOVE 0 TO CALL-COUNT.                                        IC2234.2
+032700*        THIS TEST HAS CALL STATEMENTS WITH AN IDENTIFIER         IC2234.2
+032800*    CONTAINING THE NAME OF THE SUBPROGRAM TO BE CALLED.          IC2234.2
+032900*        CALL-TEST-01 CONTAINS THE BASIC LEVEL 2 CALL STATEMENT.  IC2234.2
+033000*    IF IT CANNOT BE COMPILED AND EXECUTED CORRECTLY, THERE IS    IC2234.2
+033100*    NO USE IN RUNNING THE LEVEL 2 IPC ROUTINES.                  IC2234.2
+033200 CALL-TEST-01-01.                                                 IC2234.2
+033300     MOVE 1 TO REC-CT.                                            IC2234.2
+033400     MOVE ZERO TO DN3, DN4.                                       IC2234.2
+033500     CALL "IC223A1" USING BY REFERENCE DN1, DN2, DN3, DN4         IC2234.2
+033600     END-CALL                                                     IC2234.2
+033700     PERFORM CHECK-TEST-01.                                       IC2234.2
+033800     IF FAIL-FLAG EQUAL TO ZERO                                   IC2234.2
+033900         PERFORM PASS                                             IC2234.2
+034000         GO TO CALL-WRITE-01-01.                                  IC2234.2
+034100 CALL-FAIL-01-01.                                                 IC2234.2
+034200     PERFORM FAIL.                                                IC2234.2
+034300     MOVE FAIL-FLAG TO COMPUTED-18V0.                             IC2234.2
+034400     MOVE "NO. OF WRONG VALUES RETURNED" TO RE-MARK.              IC2234.2
+034500 CALL-WRITE-01-01.                                                IC2234.2
+034600     PERFORM PRINT-DETAIL.                                        IC2234.2
+034700 CALL-TEST-01-02.                                                 IC2234.2
+034800     ADD 1 TO REC-CT.                                             IC2234.2
+034900     MOVE ZERO TO DN3, DN4.                                       IC2234.2
+035000     CALL ID1 USING BY REFERENCE DN1, DN2, DN3, DN4               IC2234.2
+035100     END-CALL                                                     IC2234.2
+035200     PERFORM CHECK-TEST-01.                                       IC2234.2
+035300     IF FAIL-FLAG EQUAL TO ZERO                                   IC2234.2
+035400         PERFORM PASS                                             IC2234.2
+035500         GO TO CALL-WRITE-01-02.                                  IC2234.2
+035600 CALL-FAIL-01-02.                                                 IC2234.2
+035700     PERFORM FAIL.                                                IC2234.2
+035800     MOVE FAIL-FLAG TO COMPUTED-18V0.                             IC2234.2
+035900     MOVE "NO. OF WRONG VALUES RETURNED" TO RE-MARK.              IC2234.2
+036000 CALL-WRITE-01-02.                                                IC2234.2
+036100     PERFORM PRINT-DETAIL.                                        IC2234.2
+036200 CALL-TEST-01-03.                                                 IC2234.2
+036300     ADD 1 TO REC-CT.                                             IC2234.2
+036400     MOVE ID1 TO ID2.                                             IC2234.2
+036500     MOVE ZERO TO DN3, DN4.                                       IC2234.2
+036600     CALL ID2 USING REFERENCE DN1 DN2 DN3 DN4                     IC2234.2
+036700     END-CALL.                                                    IC2234.2
+036800     PERFORM CHECK-TEST-01.                                       IC2234.2
+036900     IF FAIL-FLAG EQUAL TO ZERO                                   IC2234.2
+037000         PERFORM PASS                                             IC2234.2
+037100         GO TO CALL-WRITE-01-03.                                  IC2234.2
+037200 CALL-FAIL-01-03.                                                 IC2234.2
+037300     PERFORM FAIL.                                                IC2234.2
+037400     MOVE FAIL-FLAG TO COMPUTED-18V0.                             IC2234.2
+037500     MOVE "NO. OF WRONG VALUES RETURNED" TO RE-MARK.              IC2234.2
+037600 CALL-WRITE-01-03.                                                IC2234.2
+037700     PERFORM PRINT-DETAIL.                                        IC2234.2
+037800 CALL-TEST-01-04.                                                 IC2234.2
+037900     ADD 1 TO REC-CT.                                             IC2234.2
+038000     MOVE "IC223A1" TO ID2.                                       IC2234.2
+038100     MOVE ZERO TO DN3, DN4.                                       IC2234.2
+038200     CALL ID2 USING REFERENCE DN1, DN2, DN3, DN4                  IC2234.2
+038300     END-CALL.                                                    IC2234.2
+038400     PERFORM CHECK-TEST-01.                                       IC2234.2
+038500     IF FAIL-FLAG EQUAL TO ZERO                                   IC2234.2
+038600         PERFORM PASS                                             IC2234.2
+038700         GO TO CALL-WRITE-01-04.                                  IC2234.2
+038800 CALL-FAIL-01-04.                                                 IC2234.2
+038900     PERFORM FAIL.                                                IC2234.2
+039000     MOVE FAIL-FLAG TO COMPUTED-18V0.                             IC2234.2
+039100     MOVE "NO. OF WRONG VALUES RETURNED" TO RE-MARK.              IC2234.2
+039200 CALL-WRITE-01-04.                                                IC2234.2
+039300     PERFORM PRINT-DETAIL.                                        IC2234.2
+039400 CALL-TEST-02.                                                    IC2234.2
+039500     MOVE "CALL-TEST-02" TO PAR-NAME.                             IC2234.2
+039600     MOVE "DATA-NAME USED TWICE" TO FEATURE.                      IC2234.2
+039700*        THIS TEST USES A DATA-NAME MORE THAN ONCE IN             IC2234.2
+039800*    A USING PHRASE OF A CALL STATEMENT.                          IC2234.2
+039900 CALL-TEST-02-01.                                                 IC2234.2
+040000     MOVE 1 TO REC-CT.                                            IC2234.2
+040100     MOVE 1 TO DN1.                                               IC2234.2
+040200     MOVE 0 TO DN2, DN3, DN4.                                     IC2234.2
+040300     CALL "IC223A1" USING REFERENCE DN1, DN2, DN1, DN4            IC2234.2
+040400     END-CALL.                                                    IC2234.2
+040500     IF DN1 NOT EQUAL TO 2                                        IC2234.2
+040600         GO TO CALL-FAIL-02-01-1.                                 IC2234.2
+040700     IF DN2 NOT EQUAL TO 0                                        IC2234.2
+040800         GO TO CALL-FAIL-02-01-2.                                 IC2234.2
+040900     IF DN3 NOT EQUAL TO 0                                        IC2234.2
+041000         GO TO CALL-FAIL-02-01-3.                                 IC2234.2
+041100     IF DN4 NOT EQUAL TO 5                                        IC2234.2
+041200         GO TO CALL-FAIL-02-01-4.                                 IC2234.2
+041300     GO TO CALL-PASS-02-01.                                       IC2234.2
+041400 CALL-DELETE-02-01.                                               IC2234.2
+041500     PERFORM DE-LETE.                                             IC2234.2
+041600     GO TO CALL-WRITE-02-01.                                      IC2234.2
+041700 CALL-PASS-02-01.                                                 IC2234.2
+041800     PERFORM PASS.                                                IC2234.2
+041900     GO TO CALL-WRITE-02-01.                                      IC2234.2
+042000 CALL-FAIL-02-01-1.                                               IC2234.2
+042100     MOVE DN1 TO COMPUTED-18V0.                                   IC2234.2
+042200     MOVE 2 TO CORRECT-18V0.                                      IC2234.2
+042300     MOVE "ERROR IN DN1 VALUE RETURNED" TO RE-MARK.               IC2234.2
+042400     GO TO CALL-FAIL-02-01.                                       IC2234.2
+042500 CALL-FAIL-02-01-2.                                               IC2234.2
+042600     MOVE DN2 TO COMPUTED-18V0.                                   IC2234.2
+042700     MOVE 0 TO CORRECT-18V0.                                      IC2234.2
+042800     MOVE "ERROR IN DN2 VALUE RETURNED" TO RE-MARK.               IC2234.2
+042900     GO TO CALL-FAIL-02-01.                                       IC2234.2
+043000 CALL-FAIL-02-01-3.                                               IC2234.2
+043100     MOVE DN3 TO COMPUTED-18V0.                                   IC2234.2
+043200     MOVE ZERO TO CORRECT-18V0.                                   IC2234.2
+043300     MOVE "DN3 VALUE CHANGED BY CALL" TO RE-MARK.                 IC2234.2
+043400     GO TO CALL-FAIL-02-01.                                       IC2234.2
+043500 CALL-FAIL-02-01-4.                                               IC2234.2
+043600     MOVE DN4 TO COMPUTED-18V0.                                   IC2234.2
+043700     MOVE 5 TO CORRECT-18V0.                                      IC2234.2
+043800     MOVE "ERROR IN DN4 VALUE RETURNED" TO RE-MARK.               IC2234.2
+043900 CALL-FAIL-02-01.                                                 IC2234.2
+044000     PERFORM FAIL.                                                IC2234.2
+044100 CALL-WRITE-02-01.                                                IC2234.2
+044200     PERFORM PRINT-DETAIL.                                        IC2234.2
+044300 CALL-TEST-02-02.                                                 IC2234.2
+044400     ADD 1 TO REC-CT.                                             IC2234.2
+044500     MOVE 0 TO DN4, DN3, DN2, DN1.                                IC2234.2
+044600     CALL ID1 USING REFERENCE DN1 DN2 DN3 DN2                     IC2234.2
+044700     END-CALL.                                                    IC2234.2
+044800     IF DN1 NOT EQUAL TO 0                                        IC2234.2
+044900         GO TO CALL-FAIL-02-02-1.                                 IC2234.2
+045000     IF DN2 NOT EQUAL TO 6                                        IC2234.2
+045100         GO TO CALL-FAIL-02-02-2.                                 IC2234.2
+045200     IF DN3 NOT EQUAL TO 1                                        IC2234.2
+045300         GO TO CALL-FAIL-02-02-3.                                 IC2234.2
+045400     IF DN4 NOT EQUAL TO 0                                        IC2234.2
+045500         GO TO CALL-FAIL-02-02-4.                                 IC2234.2
+045600     GO TO CALL-PASS-02-02.                                       IC2234.2
+045700 CALL-DELETE-02-02.                                               IC2234.2
+045800     PERFORM DE-LETE.                                             IC2234.2
+045900     GO TO CALL-WRITE-02-02.                                      IC2234.2
+046000 CALL-PASS-02-02.                                                 IC2234.2
+046100     PERFORM PASS.                                                IC2234.2
+046200     GO TO CALL-WRITE-02-02.                                      IC2234.2
+046300 CALL-FAIL-02-02-1.                                               IC2234.2
+046400     MOVE DN1 TO COMPUTED-18V0.                                   IC2234.2
+046500     MOVE ZERO TO CORRECT-18V0.                                   IC2234.2
+046600     MOVE "ERROR IN DN1 VALUE RETURNED" TO RE-MARK.               IC2234.2
+046700     GO TO CALL-FAIL-02-02.                                       IC2234.2
+046800 CALL-FAIL-02-02-2.                                               IC2234.2
+046900     MOVE DN2 TO COMPUTED-18V0.                                   IC2234.2
+047000     MOVE 6 TO CORRECT-18V0.                                      IC2234.2
+047100     MOVE "ERROR IN DN2 VALUE RETURNED" TO RE-MARK.               IC2234.2
+047200     GO TO CALL-FAIL-02-02.                                       IC2234.2
+047300 CALL-FAIL-02-02-3.                                               IC2234.2
+047400     MOVE DN3 TO COMPUTED-18V0.                                   IC2234.2
+047500     MOVE 1 TO CORRECT-18V0.                                      IC2234.2
+047600     MOVE "ERROR IN DN3 VALUE RETURNED" TO RE-MARK.               IC2234.2
+047700     GO TO CALL-FAIL-02-02.                                       IC2234.2
+047800 CALL-FAIL-02-02-4.                                               IC2234.2
+047900     MOVE DN4 TO COMPUTED-18V0.                                   IC2234.2
+048000     MOVE 0 TO CORRECT-18V0.                                      IC2234.2
+048100     MOVE "DN4 VALUE CHANGED BY CALL" TO RE-MARK.                 IC2234.2
+048200 CALL-FAIL-02-02.                                                 IC2234.2
+048300     PERFORM FAIL.                                                IC2234.2
+048400 CALL-WRITE-02-02.                                                IC2234.2
+048500     PERFORM PRINT-DETAIL.                                        IC2234.2
+048600 CALL-TEST-02-03.                                                 IC2234.2
+048700     ADD 1 TO REC-CT.                                             IC2234.2
+048800     MOVE 0 TO DN4, DN3.                                          IC2234.2
+048900     MOVE 10 TO DN2.                                              IC2234.2
+049000     MOVE 25 TO DN1.                                              IC2234.2
+049100     CALL ID1 USING REFERENCE DN1 DN2 DN1 DN2                     IC2234.2
+049200     END-CALL.                                                    IC2234.2
+049300     IF DN1 EQUAL TO 26                                           IC2234.2
+049400         GO TO CHECK-02-03-2.                                     IC2234.2
+049500     GO TO CALL-FAIL-02-03-1.                                     IC2234.2
+049600 CALL-DELETE-02-03.                                               IC2234.2
+049700     PERFORM DE-LETE.                                             IC2234.2
+049800     GO TO CALL-WRITE-02-03.                                      IC2234.2
+049900 CALL-FAIL-02-03-1.                                               IC2234.2
+050000     MOVE DN1 TO COMPUTED-18V0.                                   IC2234.2
+050100     MOVE 26 TO CORRECT-18V0.                                     IC2234.2
+050200     MOVE "ERROR IN DN1 VALUE RETURNED" TO RE-MARK.               IC2234.2
+050300     GO TO CALL-FAIL-02-03.                                       IC2234.2
+050400 CHECK-02-03-2.                                                   IC2234.2
+050500     IF DN2 EQUAL TO 7                                            IC2234.2
+050600         GO TO CHECK-02-03-3.                                     IC2234.2
+050700 CALL-FAIL-02-03-2.                                               IC2234.2
+050800     MOVE DN2 TO COMPUTED-18V0.                                   IC2234.2
+050900     MOVE 7 TO CORRECT-18V0.                                      IC2234.2
+051000     MOVE "ERROR IN DN2 VALUE RETURNED" TO RE-MARK.               IC2234.2
+051100     GO TO CALL-FAIL-02-03.                                       IC2234.2
+051200 CHECK-02-03-3.                                                   IC2234.2
+051300     IF DN3 EQUAL TO 0                                            IC2234.2
+051400         GO TO CHECK-02-03-4.                                     IC2234.2
+051500 CALL-FAIL-02-03-3.                                               IC2234.2
+051600     MOVE DN3 TO COMPUTED-18V0.                                   IC2234.2
+051700     MOVE 0 TO CORRECT-18V0.                                      IC2234.2
+051800     MOVE "DN3 VALUE CHANGED BY CALL" TO RE-MARK.                 IC2234.2
+051900     GO TO CALL-FAIL-02-03.                                       IC2234.2
+052000 CHECK-02-03-4.                                                   IC2234.2
+052100     IF DN4 EQUAL TO 0                                            IC2234.2
+052200         GO TO CALL-PASS-02-03.                                   IC2234.2
+052300 CALL-FAIL-02-03-4.                                               IC2234.2
+052400     MOVE DN4 TO COMPUTED-18V0.                                   IC2234.2
+052500     MOVE 0 TO CORRECT-18V0.                                      IC2234.2
+052600     MOVE "DN4 VALUE CHANGED BY CALL" TO RE-MARK.                 IC2234.2
+052700 CALL-FAIL-02-03.                                                 IC2234.2
+052800     PERFORM FAIL.                                                IC2234.2
+052900     GO TO CALL-WRITE-02-03.                                      IC2234.2
+053000 CALL-PASS-02-03.                                                 IC2234.2
+053100     PERFORM PASS.                                                IC2234.2
+053200 CALL-WRITE-02-03.                                                IC2234.2
+053300     PERFORM PRINT-DETAIL.                                        IC2234.2
+053400 CALL-TEST-03.                                                    IC2234.2
+053500*        THIS TEST USES THE ON OVERFLOW PHRASE IN THE CALL        IC2234.2
+053600*    STATEMENT.  THIS IS A SYNTACTICAL CHECK ONLY, THE ON         IC2234.2
+053700*    OVERFLOW CONDITION SHOULD NEVER OCCUR.                       IC2234.2
+053800     MOVE "CALL-TEST-03" TO PAR-NAME.                             IC2234.2
+053900     MOVE "ON OVERFLOW PHRASE" TO FEATURE.                        IC2234.2
+054000 CALL-TEST-03-01.                                                 IC2234.2
+054100     MOVE 7 TO CALL-COUNT.                                        IC2234.2
+054200     MOVE 20 TO DN1.                                              IC2234.2
+054300     MOVE 30 TO DN2.                                              IC2234.2
+054400     MOVE ZERO TO DN3, DN4.                                       IC2234.2
+054500     CALL "IC223A1" USING REFERENCE DN1, DN2, DN3, DN4;           IC2234.2
+054600         ON OVERFLOW MOVE "OVERFLOW SHOULD NOT OCCUR" TO RE-MARK  IC2234.2
+054700                     GO TO CALL-FAIL-03-01                        IC2234.2
+054800     END-CALL.                                                    IC2234.2
+054900     PERFORM CHECK-TEST-03.                                       IC2234.2
+055000     IF FAIL-FLAG EQUAL TO ZERO                                   IC2234.2
+055100         PERFORM PASS                                             IC2234.2
+055200         GO TO CALL-WRITE-03-01.                                  IC2234.2
+055300     MOVE FAIL-FLAG TO COMPUTED-18V0.                             IC2234.2
+055400     MOVE "NO. OF WRONG VALUES RETURNED" TO RE-MARK.              IC2234.2
+055500 CALL-FAIL-03-01.                                                 IC2234.2
+055600     PERFORM FAIL.                                                IC2234.2
+055700 CALL-WRITE-03-01.                                                IC2234.2
+055800     PERFORM PRINT-DETAIL.                                        IC2234.2
+055900 CALL-TEST-03-02.                                                 IC2234.2
+056000     MOVE ZERO TO DN3, DN4.                                       IC2234.2
+056100     CALL "IC223A1" USING REFERENCE DN1, DN2, DN3, DN4;           IC2234.2
+056200         OVERFLOW MOVE "OVERFLOW SHOULD NOT OCCUR" TO RE-MARK     IC2234.2
+056300                  GO TO CALL-FAIL-03-02                           IC2234.2
+056400     END-CALL.                                                    IC2234.2
+056500     PERFORM CHECK-TEST-03.                                       IC2234.2
+056600     IF FAIL-FLAG EQUAL TO ZERO                                   IC2234.2
+056700         PERFORM PASS                                             IC2234.2
+056800         GO TO CALL-WRITE-03-02.                                  IC2234.2
+056900     MOVE FAIL-FLAG TO COMPUTED-18V0.                             IC2234.2
+057000     MOVE "NO. OF WRONG VALUES RETURNED" TO RE-MARK.              IC2234.2
+057100 CALL-FAIL-03-02.                                                 IC2234.2
+057200     PERFORM FAIL.                                                IC2234.2
+057300 CALL-WRITE-03-02.                                                IC2234.2
+057400     PERFORM PRINT-DETAIL.                                        IC2234.2
+057500 CALL-TEST-03-03.                                                 IC2234.2
+057600     MOVE ZERO TO DN3, DN4.                                       IC2234.2
+057700     CALL ID1 USING REFERENCE DN1 DN2 DN3 DN4                     IC2234.2
+057800         ON OVERFLOW MOVE "OVERFLOW SHOULD NOT OCCUR" TO RE-MARK  IC2234.2
+057900                     GO TO CALL-FAIL-03-03                        IC2234.2
+058000     END-CALL.                                                    IC2234.2
+058100     PERFORM   CHECK-TEST-03.                                     IC2234.2
+058200     IF FAIL-FLAG EQUAL TO ZERO                                   IC2234.2
+058300         PERFORM PASS                                             IC2234.2
+058400         GO TO CALL-WRITE-03-03.                                  IC2234.2
+058500     MOVE FAIL-FLAG TO COMPUTED-18V0.                             IC2234.2
+058600     MOVE "NO. OF WRONG VALUES RETURNED" TO RE-MARK.              IC2234.2
+058700 CALL-FAIL-03-03.                                                 IC2234.2
+058800     PERFORM FAIL.                                                IC2234.2
+058900 CALL-WRITE-03-03.                                                IC2234.2
+059000     PERFORM PRINT-DETAIL.                                        IC2234.2
+059100 CALL-TEST-03-04.                                                 IC2234.2
+059200     MOVE ZERO TO DN3, DN4.                                       IC2234.2
+059300     CALL ID1 USING REFERENCE DN1 DN2 DN3 DN4;                    IC2234.2
+059400         OVERFLOW MOVE "OVERFLOW SHOULD NOT OCCUR" TO RE-MARK,    IC2234.2
+059500                  GO TO CALL-FAIL-03-04                           IC2234.2
+059600     END-CALL.                                                    IC2234.2
+059700     PERFORM CHECK-TEST-03.                                       IC2234.2
+059800     IF FAIL-FLAG EQUAL TO ZERO                                   IC2234.2
+059900         PERFORM PASS                                             IC2234.2
+060000         GO TO CALL-WRITE-03-04.                                  IC2234.2
+060100     MOVE FAIL-FLAG TO COMPUTED-18V0.                             IC2234.2
+060200     MOVE "NO. OF WRONG VALUES RETURNED" TO RE-MARK.              IC2234.2
+060300 CALL-FAIL-03-04.                                                 IC2234.2
+060400     PERFORM FAIL.                                                IC2234.2
+060500 CALL-WRITE-03-04.                                                IC2234.2
+060600     PERFORM PRINT-DETAIL.                                        IC2234.2
+060700     GO TO EXIT-IC223A.                                           IC2234.2
+060800 CALL-DELETE-03.                                                  IC2234.2
+060900*        IF THE ON OVERFLOW PHRASE IS NOT RECOGNIZED, DELETE ALL  IC2234.2
+061000*    OF THE ABOVE CALL-TEST-03 PARAGRAPHS, STARTING WITH          IC2234.2
+061100*    CALL-TEST-03-01.                                             IC2234.2
+061200     PERFORM DE-LETE.                                             IC2234.2
+061300     PERFORM PRINT-DETAIL.                                        IC2234.2
+061400 EXIT-IC223A.                                                     IC2234.2
+061500     GO TO CCVS-EXIT.                                             IC2234.2
+061600 SECT-IC223A-002 SECTION.                                         IC2234.2
+061700 CHECK-TEST-01.                                                   IC2234.2
+061800     MOVE ZERO TO FAIL-FLAG.                                      IC2234.2
+061900     ADD 1 TO CALL-COUNT.                                         IC2234.2
+062000     IF DN1 EQUAL TO ZERO                                         IC2234.2
+062100             NEXT SENTENCE                                        IC2234.2
+062200         ELSE ADD 1 TO FAIL-FLAG.                                 IC2234.2
+062300     IF DN2 NOT EQUAL TO ZERO                                     IC2234.2
+062400         ADD 1 TO FAIL-FLAG.                                      IC2234.2
+062500     IF DN3 NOT EQUAL TO 1                                        IC2234.2
+062600         ADD 1 TO FAIL-FLAG.                                      IC2234.2
+062700     IF DN4 NOT EQUAL TO CALL-COUNT                               IC2234.2
+062800         ADD 1 TO FAIL-FLAG.                                      IC2234.2
+062900 CHECK-TEST-03.                                                   IC2234.2
+063000     MOVE ZERO TO FAIL-FLAG.                                      IC2234.2
+063100     ADD 1 TO CALL-COUNT.                                         IC2234.2
+063200     IF DN4 NOT EQUAL TO CALL-COUNT                               IC2234.2
+063300         ADD 1 TO FAIL-FLAG.                                      IC2234.2
+063400     IF DN3 NOT EQUAL TO 21                                       IC2234.2
+063500         ADD 1 TO FAIL-FLAG.                                      IC2234.2
+063600     IF DN2 NOT EQUAL TO 30                                       IC2234.2
+063700         ADD 1 TO FAIL-FLAG.                                      IC2234.2
+063800     IF DN1 NOT EQUAL TO 20                                       IC2234.2
+063900         ADD 1 TO FAIL-FLAG.                                      IC2234.2
+064000 CCVS-EXIT SECTION.                                               IC2234.2
+064100 CCVS-999999.                                                     IC2234.2
+064200     GO TO CLOSE-FILES.                                           IC2234.2
+064300 END PROGRAM IC223A.                                              IC2234.2

--- a/z390/IC223A1.CBL
+++ b/z390/IC223A1.CBL
@@ -1,0 +1,134 @@
+064400 IDENTIFICATION DIVISION.                                         IC2234.2
+      *
+      * This is the z390 version of IC223A-1
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC223A1
+      * IC223A has been modified to call IC223A1 instead of IC223A-1.
+      *
+064500 PROGRAM-ID.                                                      IC2234.2
+064600     IC223A1.                                                     IC2234.2
+064700****************************************************************  IC2234.2
+064800*                                                              *  IC2234.2
+064900*    THIS PROGRAM FORMS PART OF THE COBOL COMPILER VALIDATION  *  IC2234.2
+065000*    SYSTEM (CCVS) USED TO TEST COBOL COMPILERS FOR            *  IC2234.2
+065100*    CONFORMANCE WITH THE AMERICAN NATIONAL STANDARD           *  IC2234.2
+065200*    (ANSI DOCUMENT REFERENCE: X3.23-1985) AND THE STANDARD OF *  IC2234.2
+065300*    THE INTERNATIONAL ORGANIZATION FOR STANDARDISATION        *  IC2234.2
+065400*    (ISO DOCUMENT REFERENCE: ISO-1989-1985).                  *  IC2234.2
+065500*                                                              *  IC2234.2
+065600*    THIS CCVS INCORPORATES ENHANCEMENTS TO THE CCVS FOR THE   *  IC2234.2
+065700*    1974 STANDARD (ANSI DOCUMENT REFERENCE: X3.23-1974; ISO   *  IC2234.2
+065800*    DOCUMENT REFERENCE: ISO-1989-1978).                       *  IC2234.2
+065900*                                                              *  IC2234.2
+066000*    THESE ENHANCEMENTS WERE SPECIFIED BY A PROJECT TEAM WHICH *  IC2234.2
+066100*    WAS FUNDED BY THE COMMISSION FOR EUROPEAN COMMUNITIES AND *  IC2234.2
+066200*    WHICH WAS RESPONSIBLE FOR TECHNICAL ISSUES TO:            *  IC2234.2
+066300*                                                              *  IC2234.2
+066400*          THE FEDERAL SOFTWARE TESTING CENTER                 *  IC2234.2
+066500*          OFFICE OF SOFTWARE DEVELOPMENT                      *  IC2234.2
+066600*                & INFORMATION TECHNOLOGY                      *  IC2234.2
+066700*          TWO SKYLINE PLACE                                   *  IC2234.2
+066800*          SUITE 1100                                          *  IC2234.2
+066900*          5203 LEESBURG PIKE                                  *  IC2234.2
+067000*          FALLS CHURCH                                        *  IC2234.2
+067100*          VA 22041                                            *  IC2234.2
+067200*          U.S.A.                                              *  IC2234.2
+067300*                                                              *  IC2234.2
+067400*    THE PROJECT TEAM MEMBERS WERE:                            *  IC2234.2
+067500*                                                              *  IC2234.2
+067600*          BIADI (BUREAU INTER ADMINISTRATION                  *  IC2234.2
+067700*                 DE DOCUMENTATION INFORMATIQUE)               *  IC2234.2
+067800*          21 RUE BARA                                         *  IC2234.2
+067900*          F-92132 ISSY                                        *  IC2234.2
+068000*          FRANCE                                              *  IC2234.2
+068100*                                                              *  IC2234.2
+068200*                                                              *  IC2234.2
+068300*          GMD (GESELLSCHAFT FUR MATHEMATIK                    *  IC2234.2
+068400*               UND DATENVERARBEITUNG MBH)                     *  IC2234.2
+068500*          SCHLOSS BIRLINGHOVEN                                *  IC2234.2
+068600*          POSTFACH 12 40                                      *  IC2234.2
+068700*          D-5205 ST. AUGUSTIN 1                               *  IC2234.2
+068800*          GERMANY FR                                          *  IC2234.2
+068900*                                                              *  IC2234.2
+069000*                                                              *  IC2234.2
+069100*          NCC (THE NATIONAL COMPUTING CENTRE LTD)             *  IC2234.2
+069200*          OXFORD ROAD                                         *  IC2234.2
+069300*          MANCHESTER                                          *  IC2234.2
+069400*          M1 7ED                                              *  IC2234.2
+069500*          UNITED KINGDOM                                      *  IC2234.2
+069600*                                                              *  IC2234.2
+069700*                                                              *  IC2234.2
+069800*    THIS TEST SUITE WAS PRODUCED BY THE NATIONAL COMPUTING    *  IC2234.2
+069900*    CENTRE IN ENGLAND AND IS THE OFFICIAL CCVS TEST SUITE     *  IC2234.2
+070000*    USED THROUGHOUT EUROPE AND THE UNITED STATES OF AMERICA.  *  IC2234.2
+070100*                                                              *  IC2234.2
+070200****************************************************************  IC2234.2
+070300*                                                              *  IC2234.2
+070400*    VALIDATION FOR:-                                          *  IC2234.2
+070500*                                                              *  IC2234.2
+070600*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2234.2
+070700*                                                              *  IC2234.2
+070800*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2234.2
+070900*                                                              *  IC2234.2
+071000****************************************************************  IC2234.2
+071100*                                                              *  IC2234.2
+071200*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2234.2
+071300*                                                              *  IC2234.2
+071400*        X-55  - SYSTEM PRINTER NAME.                          *  IC2234.2
+071500*        X-82  - SOURCE COMPUTER NAME.                         *  IC2234.2
+071600*        X-83  - OBJECT COMPUTER NAME.                         *  IC2234.2
+071700*                                                              *  IC2234.2
+071800****************************************************************  IC2234.2
+071900*                                                              *  IC2234.2
+072000*    PROGRAM IC223A AND IC223A-1 WILL TEST THE NEW LANGUAGE    *  IC2234.2
+072100*    ELEMENTS FOR THE LEVEL 2 INTER-PROGRAM COMMUNICATION      *  IC2234.2
+072200*    MODULE.                                                   *  IC2234.2
+072300*    THE NEW LANGUAGE ELEMENTS TO BE TESTED WILL BE:           *  IC2234.2
+072400*          "BY REFERENCE"     PHRASE                           *  IC2234.2
+072500*    THE TWO PROGRAMS WILL BE COMPILED IN THE SAME FLOW        *  IC2234.2
+072600*    (TO TEST THE "END PROGRAM" STATEMENT) AS SHOWN BELOW:     *  IC2234.2
+072700*    IDENTIFICATION DIVISION.                                  *  IC2234.2
+072800*    PROGRAM-ID. IC223A.                                       *  IC2234.2
+072900*              .                                               *  IC2234.2
+073000*              .                                               *  IC2234.2
+073100*              .                                               *  IC2234.2
+073200*    END PROGRAM IC223A.                                       *  IC2234.2
+073300*    PROGRAM-ID. IC223A-1.                                     *  IC2234.2
+073400*              .                                               *  IC2234.2
+073500*              .                                               *  IC2234.2
+073600*              .                                               *  IC2234.2
+073700****************************************************************  IC2234.2
+073800 ENVIRONMENT DIVISION.                                            IC2234.2
+073900 CONFIGURATION SECTION.                                           IC2234.2
+074000 SOURCE-COMPUTER.                                                 IC2234.2
+074100     XXXXX082.                                                    IC2234.2
+074200 OBJECT-COMPUTER.                                                 IC2234.2
+074300     XXXXX083.                                                    IC2234.2
+074400 INPUT-OUTPUT SECTION.                                            IC2234.2
+074500 FILE-CONTROL.                                                    IC2234.2
+074600     SELECT PRINT-FILE ASSIGN TO                                  IC2234.2
+074700     XXXXX055.                                                    IC2234.2
+074800 DATA DIVISION.                                                   IC2234.2
+074900 FILE SECTION.                                                    IC2234.2
+075000 FD  PRINT-FILE.                                                  IC2234.2
+075100 01  PRINT-REC PICTURE X(120).                                    IC2234.2
+075200 01  DUMMY-RECORD PICTURE X(120).                                 IC2234.2
+075300 WORKING-STORAGE SECTION.                                         IC2234.2
+075400 77  WS1 PICTURE S999.                                            IC2234.2
+075500 77  WS2 PICTURE S999                                             IC2234.2
+075600         USAGE COMPUTATIONAL, VALUE ZERO.                         IC2234.2
+075700 LINKAGE SECTION.                                                 IC2234.2
+075800 77  DN1 PICTURE S99.                                             IC2234.2
+075900 77  DN2 PICTURE S99 USAGE COMPUTATIONAL.                         IC2234.2
+076000 77  DN3 PICTURE S99.                                             IC2234.2
+076100 77  DN4 PICTURE S99 USAGE COMPUTATIONAL.                         IC2234.2
+076200 PROCEDURE DIVISION USING DN1, DN2, DN3, DN4.                     IC2234.2
+076300 SECT-IC223A-1-001 SECTION.                                       IC2234.2
+076400 CALL-TEST-001.                                                   IC2234.2
+076500     MOVE DN1 TO WS1.                                             IC2234.2
+076600     ADD 1 TO WS1.                                                IC2234.2
+076700     ADD 1 TO WS2.                                                IC2234.2
+076800     MOVE WS1 TO DN3.                                             IC2234.2
+076900     MOVE WS2 TO DN4.                                             IC2234.2
+077000 CALL-EXIT-001.                                                   IC2234.2
+077100     EXIT PROGRAM.                                                IC2234.2

--- a/z390/IC224A.CBL
+++ b/z390/IC224A.CBL
@@ -1,0 +1,581 @@
+000100 IDENTIFICATION DIVISION.                                         IC2244.2
+      *
+      * This is the z390 version of IC224A
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC224A1
+      * IC224A has been modified to call IC224A1 instead of IC224A-1.
+      *
+000200 PROGRAM-ID.                                                      IC2244.2
+000300     IC224A.                                                      IC2244.2
+000400****************************************************************  IC2244.2
+000500*                                                              *  IC2244.2
+000600*    VALIDATION FOR:-                                          *  IC2244.2
+000700*                                                              *  IC2244.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2244.2
+000900*                                                              *  IC2244.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2244.2
+001100*                                                              *  IC2244.2
+001200****************************************************************  IC2244.2
+001300*                                                              *  IC2244.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2244.2
+001500*                                                              *  IC2244.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC2244.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC2244.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC2244.2
+001900*                                                              *  IC2244.2
+002000****************************************************************  IC2244.2
+002100*                                                              *  IC2244.2
+002200*    PROGRAM IC224A AND IC224A-1 WILL TEST THE NEW LANGUAGE    *  IC2244.2
+002300*    ELEMENTS FOR THE LEVEL 2 INTER-PROGRAM COMMUNICATION      *  IC2244.2
+002400*    MODULE.                                                   *  IC2244.2
+002500*    THE NEW LANGUAGE ELEMENTS TO BE TESTED WILL BE:           *  IC2244.2
+002600*          "BY CONTENT"       PHRASE                           *  IC2244.2
+002700*    THE TWO PROGRAMS WILL BE COMPILED IN THE SAME FLOW        *  IC2244.2
+002800*    (TO TEST THE "END PROGRAM" STATEMENT) AS SHOWN BELOW:     *  IC2244.2
+002900*    IDENTIFICATION DIVISION.                                  *  IC2244.2
+003000*    PROGRAM-ID. IC224A.                                       *  IC2244.2
+003100*              .                                               *  IC2244.2
+003200*              .                                               *  IC2244.2
+003300*              .                                               *  IC2244.2
+003400*    END PROGRAM IC224A.                                       *  IC2244.2
+003500*    PROGRAM-ID. IC224A-1.                                     *  IC2244.2
+003600*              .                                               *  IC2244.2
+003700*              .                                               *  IC2244.2
+003800*              .                                               *  IC2244.2
+003900****************************************************************  IC2244.2
+004000 ENVIRONMENT DIVISION.                                            IC2244.2
+004100 CONFIGURATION SECTION.                                           IC2244.2
+004200 SOURCE-COMPUTER.                                                 IC2244.2
+004300     XXXXX082.                                                    IC2244.2
+004400 OBJECT-COMPUTER.                                                 IC2244.2
+004500     XXXXX083.                                                    IC2244.2
+004600 INPUT-OUTPUT SECTION.                                            IC2244.2
+004700 FILE-CONTROL.                                                    IC2244.2
+004800     SELECT PRINT-FILE ASSIGN TO                                  IC2244.2
+004900     XXXXX055.                                                    IC2244.2
+005000 DATA DIVISION.                                                   IC2244.2
+005100 FILE SECTION.                                                    IC2244.2
+005200 FD  PRINT-FILE.                                                  IC2244.2
+005300 01  PRINT-REC PICTURE X(120).                                    IC2244.2
+005400 01  DUMMY-RECORD PICTURE X(120).                                 IC2244.2
+005500 WORKING-STORAGE SECTION.                                         IC2244.2
+005600 77  DN1 PICTURE S99  VALUE ZERO.                                 IC2244.2
+005700 77  DN3 PICTURE S99.                                             IC2244.2
+005800 77  ID1 PICTURE X(8) VALUE "IC224A-1".                           IC2244.2
+005900 77  ID2 PICTURE X(8).                                            IC2244.2
+006000 77  DN2 PICTURE S99                                              IC2244.2
+006100         USAGE COMPUTATIONAL, VALUE ZERO.                         IC2244.2
+006200 77  DN4 PICTURE S99                                              IC2244.2
+006300         USAGE IS COMPUTATIONAL.                                  IC2244.2
+006400 77  SAVE-DN1 PICTURE S99.                                        IC2244.2
+006500 77  SAVE-DN3 PICTURE S99.                                        IC2244.2
+006600 77  SAVE-DN2 PICTURE S99                                         IC2244.2
+006700         USAGE COMPUTATIONAL.                                     IC2244.2
+006800 77  SAVE-DN4 PICTURE S99                                         IC2244.2
+006900         USAGE IS COMPUTATIONAL.                                  IC2244.2
+007000 77  CALL-COUNT PIC S99.                                          IC2244.2
+007100 77  FAIL-FLAG PIC 9.                                             IC2244.2
+007200 01  TEST-RESULTS.                                                IC2244.2
+007300     02 FILLER                   PIC X      VALUE SPACE.          IC2244.2
+007400     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC2244.2
+007500     02 FILLER                   PIC X      VALUE SPACE.          IC2244.2
+007600     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC2244.2
+007700     02 FILLER                   PIC X      VALUE SPACE.          IC2244.2
+007800     02  PAR-NAME.                                                IC2244.2
+007900       03 FILLER                 PIC X(19)  VALUE SPACE.          IC2244.2
+008000       03  PARDOT-X              PIC X      VALUE SPACE.          IC2244.2
+008100       03 DOTVALUE               PIC 99     VALUE ZERO.           IC2244.2
+008200     02 FILLER                   PIC X(8)   VALUE SPACE.          IC2244.2
+008300     02 RE-MARK                  PIC X(61).                       IC2244.2
+008400 01  TEST-COMPUTED.                                               IC2244.2
+008500     02 FILLER                   PIC X(30)  VALUE SPACE.          IC2244.2
+008600     02 FILLER                   PIC X(17)  VALUE                 IC2244.2
+008700            "       COMPUTED=".                                   IC2244.2
+008800     02 COMPUTED-X.                                               IC2244.2
+008900     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC2244.2
+009000     03 COMPUTED-N               REDEFINES COMPUTED-A             IC2244.2
+009100                                 PIC -9(9).9(9).                  IC2244.2
+009200     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC2244.2
+009300     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC2244.2
+009400     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC2244.2
+009500     03       CM-18V0 REDEFINES COMPUTED-A.                       IC2244.2
+009600         04 COMPUTED-18V0                    PIC -9(18).          IC2244.2
+009700         04 FILLER                           PIC X.               IC2244.2
+009800     03 FILLER PIC X(50) VALUE SPACE.                             IC2244.2
+009900 01  TEST-CORRECT.                                                IC2244.2
+010000     02 FILLER PIC X(30) VALUE SPACE.                             IC2244.2
+010100     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC2244.2
+010200     02 CORRECT-X.                                                IC2244.2
+010300     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC2244.2
+010400     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC2244.2
+010500     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC2244.2
+010600     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC2244.2
+010700     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC2244.2
+010800     03      CR-18V0 REDEFINES CORRECT-A.                         IC2244.2
+010900         04 CORRECT-18V0                     PIC -9(18).          IC2244.2
+011000         04 FILLER                           PIC X.               IC2244.2
+011100     03 FILLER PIC X(2) VALUE SPACE.                              IC2244.2
+011200     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC2244.2
+011300 01  CCVS-C-1.                                                    IC2244.2
+011400     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC2244.2
+011500-    "SS  PARAGRAPH-NAME                                          IC2244.2
+011600-    "       REMARKS".                                            IC2244.2
+011700     02 FILLER                     PIC X(20)    VALUE SPACE.      IC2244.2
+011800 01  CCVS-C-2.                                                    IC2244.2
+011900     02 FILLER                     PIC X        VALUE SPACE.      IC2244.2
+012000     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC2244.2
+012100     02 FILLER                     PIC X(15)    VALUE SPACE.      IC2244.2
+012200     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC2244.2
+012300     02 FILLER                     PIC X(94)    VALUE SPACE.      IC2244.2
+012400 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC2244.2
+012500 01  REC-CT                        PIC 99       VALUE ZERO.       IC2244.2
+012600 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC2244.2
+012700 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC2244.2
+012800 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC2244.2
+012900 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC2244.2
+013000 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC2244.2
+013100 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC2244.2
+013200 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC2244.2
+013300 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC2244.2
+013400 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC2244.2
+013500 01  CCVS-H-1.                                                    IC2244.2
+013600     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2244.2
+013700     02  FILLER                    PIC X(42)    VALUE             IC2244.2
+013800     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC2244.2
+013900     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2244.2
+014000 01  CCVS-H-2A.                                                   IC2244.2
+014100   02  FILLER                        PIC X(40)  VALUE SPACE.      IC2244.2
+014200   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC2244.2
+014300   02  FILLER                        PIC XXXX   VALUE             IC2244.2
+014400     "4.2 ".                                                      IC2244.2
+014500   02  FILLER                        PIC X(28)  VALUE             IC2244.2
+014600            " COPY - NOT FOR DISTRIBUTION".                       IC2244.2
+014700   02  FILLER                        PIC X(41)  VALUE SPACE.      IC2244.2
+014800                                                                  IC2244.2
+014900 01  CCVS-H-2B.                                                   IC2244.2
+015000   02  FILLER                        PIC X(15)  VALUE             IC2244.2
+015100            "TEST RESULT OF ".                                    IC2244.2
+015200   02  TEST-ID                       PIC X(9).                    IC2244.2
+015300   02  FILLER                        PIC X(4)   VALUE             IC2244.2
+015400            " IN ".                                               IC2244.2
+015500   02  FILLER                        PIC X(12)  VALUE             IC2244.2
+015600     " HIGH       ".                                              IC2244.2
+015700   02  FILLER                        PIC X(22)  VALUE             IC2244.2
+015800            " LEVEL VALIDATION FOR ".                             IC2244.2
+015900   02  FILLER                        PIC X(58)  VALUE             IC2244.2
+016000     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2244.2
+016100 01  CCVS-H-3.                                                    IC2244.2
+016200     02  FILLER                      PIC X(34)  VALUE             IC2244.2
+016300            " FOR OFFICIAL USE ONLY    ".                         IC2244.2
+016400     02  FILLER                      PIC X(58)  VALUE             IC2244.2
+016500     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2244.2
+016600     02  FILLER                      PIC X(28)  VALUE             IC2244.2
+016700            "  COPYRIGHT   1985 ".                                IC2244.2
+016800 01  CCVS-E-1.                                                    IC2244.2
+016900     02 FILLER                       PIC X(52)  VALUE SPACE.      IC2244.2
+017000     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC2244.2
+017100     02 ID-AGAIN                     PIC X(9).                    IC2244.2
+017200     02 FILLER                       PIC X(45)  VALUE SPACES.     IC2244.2
+017300 01  CCVS-E-2.                                                    IC2244.2
+017400     02  FILLER                      PIC X(31)  VALUE SPACE.      IC2244.2
+017500     02  FILLER                      PIC X(21)  VALUE SPACE.      IC2244.2
+017600     02 CCVS-E-2-2.                                               IC2244.2
+017700         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC2244.2
+017800         03 FILLER                   PIC X      VALUE SPACE.      IC2244.2
+017900         03 ENDER-DESC               PIC X(44)  VALUE             IC2244.2
+018000            "ERRORS ENCOUNTERED".                                 IC2244.2
+018100 01  CCVS-E-3.                                                    IC2244.2
+018200     02  FILLER                      PIC X(22)  VALUE             IC2244.2
+018300            " FOR OFFICIAL USE ONLY".                             IC2244.2
+018400     02  FILLER                      PIC X(12)  VALUE SPACE.      IC2244.2
+018500     02  FILLER                      PIC X(58)  VALUE             IC2244.2
+018600     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2244.2
+018700     02  FILLER                      PIC X(13)  VALUE SPACE.      IC2244.2
+018800     02 FILLER                       PIC X(15)  VALUE             IC2244.2
+018900             " COPYRIGHT 1985".                                   IC2244.2
+019000 01  CCVS-E-4.                                                    IC2244.2
+019100     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC2244.2
+019200     02 FILLER                       PIC X(4)   VALUE " OF ".     IC2244.2
+019300     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC2244.2
+019400     02 FILLER                       PIC X(40)  VALUE             IC2244.2
+019500      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC2244.2
+019600 01  XXINFO.                                                      IC2244.2
+019700     02 FILLER                       PIC X(19)  VALUE             IC2244.2
+019800            "*** INFORMATION ***".                                IC2244.2
+019900     02 INFO-TEXT.                                                IC2244.2
+020000       04 FILLER                     PIC X(8)   VALUE SPACE.      IC2244.2
+020100       04 XXCOMPUTED                 PIC X(20).                   IC2244.2
+020200       04 FILLER                     PIC X(5)   VALUE SPACE.      IC2244.2
+020300       04 XXCORRECT                  PIC X(20).                   IC2244.2
+020400     02 INF-ANSI-REFERENCE           PIC X(48).                   IC2244.2
+020500 01  HYPHEN-LINE.                                                 IC2244.2
+020600     02 FILLER  PIC IS X VALUE IS SPACE.                          IC2244.2
+020700     02 FILLER  PIC IS X(65)    VALUE IS "************************IC2244.2
+020800-    "*****************************************".                 IC2244.2
+020900     02 FILLER  PIC IS X(54)    VALUE IS "************************IC2244.2
+021000-    "******************************".                            IC2244.2
+021100 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC2244.2
+021200     "IC224A".                                                    IC2244.2
+021300 PROCEDURE DIVISION.                                              IC2244.2
+021400 CCVS1 SECTION.                                                   IC2244.2
+021500 OPEN-FILES.                                                      IC2244.2
+021600     OPEN     OUTPUT PRINT-FILE.                                  IC2244.2
+021700     MOVE CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.   IC2244.2
+021800     MOVE    SPACE TO TEST-RESULTS.                               IC2244.2
+021900     PERFORM  HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.             IC2244.2
+022000     GO TO CCVS1-EXIT.                                            IC2244.2
+022100 CLOSE-FILES.                                                     IC2244.2
+022200     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC2244.2
+022300 TERMINATE-CCVS.                                                  IC2244.2
+022400S    EXIT PROGRAM.                                                IC2244.2
+022500STERMINATE-CALL.                                                  IC2244.2
+022600     STOP     RUN.                                                IC2244.2
+022700 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         IC2244.2
+022800 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           IC2244.2
+022900 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          IC2244.2
+023000 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      IC2244.2
+023100     MOVE "****TEST DELETED****" TO RE-MARK.                      IC2244.2
+023200 PRINT-DETAIL.                                                    IC2244.2
+023300     IF REC-CT NOT EQUAL TO ZERO                                  IC2244.2
+023400             MOVE "." TO PARDOT-X                                 IC2244.2
+023500             MOVE REC-CT TO DOTVALUE.                             IC2244.2
+023600     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      IC2244.2
+023700     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               IC2244.2
+023800        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 IC2244.2
+023900          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 IC2244.2
+024000     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC2244.2
+024100     MOVE SPACE TO CORRECT-X.                                     IC2244.2
+024200     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC2244.2
+024300     MOVE     SPACE TO RE-MARK.                                   IC2244.2
+024400 HEAD-ROUTINE.                                                    IC2244.2
+024500     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2244.2
+024600     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2244.2
+024700     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2244.2
+024800     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2244.2
+024900 COLUMN-NAMES-ROUTINE.                                            IC2244.2
+025000     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2244.2
+025100     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2244.2
+025200     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC2244.2
+025300 END-ROUTINE.                                                     IC2244.2
+025400     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.IC2244.2
+025500 END-RTN-EXIT.                                                    IC2244.2
+025600     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2244.2
+025700 END-ROUTINE-1.                                                   IC2244.2
+025800      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      IC2244.2
+025900      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               IC2244.2
+026000      ADD PASS-COUNTER TO ERROR-HOLD.                             IC2244.2
+026100*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC2244.2
+026200      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC2244.2
+026300      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC2244.2
+026400      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC2244.2
+026500      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC2244.2
+026600  END-ROUTINE-12.                                                 IC2244.2
+026700      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC2244.2
+026800     IF       ERROR-COUNTER IS EQUAL TO ZERO                      IC2244.2
+026900         MOVE "NO " TO ERROR-TOTAL                                IC2244.2
+027000         ELSE                                                     IC2244.2
+027100         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC2244.2
+027200     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC2244.2
+027300     PERFORM WRITE-LINE.                                          IC2244.2
+027400 END-ROUTINE-13.                                                  IC2244.2
+027500     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC2244.2
+027600         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC2244.2
+027700         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC2244.2
+027800     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC2244.2
+027900     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2244.2
+028000      IF   INSPECT-COUNTER EQUAL TO ZERO                          IC2244.2
+028100          MOVE "NO " TO ERROR-TOTAL                               IC2244.2
+028200      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   IC2244.2
+028300      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            IC2244.2
+028400      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          IC2244.2
+028500     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2244.2
+028600 WRITE-LINE.                                                      IC2244.2
+028700     ADD 1 TO RECORD-COUNT.                                       IC2244.2
+028800Y    IF RECORD-COUNT GREATER 50                                   IC2244.2
+028900Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC2244.2
+029000Y        MOVE SPACE TO DUMMY-RECORD                               IC2244.2
+029100Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC2244.2
+029200Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC2244.2
+029300Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC2244.2
+029400Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC2244.2
+029500Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC2244.2
+029600Y        MOVE ZERO TO RECORD-COUNT.                               IC2244.2
+029700     PERFORM WRT-LN.                                              IC2244.2
+029800 WRT-LN.                                                          IC2244.2
+029900     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC2244.2
+030000     MOVE SPACE TO DUMMY-RECORD.                                  IC2244.2
+030100 BLANK-LINE-PRINT.                                                IC2244.2
+030200     PERFORM WRT-LN.                                              IC2244.2
+030300 FAIL-ROUTINE.                                                    IC2244.2
+030400     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC2244.2
+030500     IF     CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.IC2244.2
+030600     MOVE ANSI-REFERENCE TO INF-ANSI-REFERENCE.                   IC2244.2
+030700     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC2244.2
+030800     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2244.2
+030900     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2244.2
+031000     GO TO  FAIL-ROUTINE-EX.                                      IC2244.2
+031100 FAIL-ROUTINE-WRITE.                                              IC2244.2
+031200     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC2244.2
+031300     MOVE ANSI-REFERENCE TO COR-ANSI-REFERENCE.                   IC2244.2
+031400     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC2244.2
+031500     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC2244.2
+031600 FAIL-ROUTINE-EX. EXIT.                                           IC2244.2
+031700 BAIL-OUT.                                                        IC2244.2
+031800     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC2244.2
+031900     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC2244.2
+032000 BAIL-OUT-WRITE.                                                  IC2244.2
+032100     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC2244.2
+032200     MOVE ANSI-REFERENCE TO INF-ANSI-REFERENCE.                   IC2244.2
+032300     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2244.2
+032400     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2244.2
+032500 BAIL-OUT-EX. EXIT.                                               IC2244.2
+032600 CCVS1-EXIT.                                                      IC2244.2
+032700     EXIT.                                                        IC2244.2
+032800 SECT-IC224A-001 SECTION.                                         IC2244.2
+032900 CALL-TEST-01.                                                    IC2244.2
+033000     MOVE "CALL-TEST-01" TO PAR-NAME.                             IC2244.2
+033100     MOVE     "LEV 2 CALL STATEMENT" TO FEATURE.                  IC2244.2
+033200     MOVE 0 TO CALL-COUNT.                                        IC2244.2
+033300*        THIS TEST HAS CALL STATEMENTS WITH AN IDENTIFIER         IC2244.2
+033400*    CONTAINING THE NAME OF THE SUBPROGRAM TO BE CALLED.          IC2244.2
+033500*        CALL-TEST-01 CONTAINS THE BASIC LEVEL 2 CALL STATEMENT.  IC2244.2
+033600*    IF IT CANNOT BE COMPILED AND EXECUTED CORRECTLY, THERE IS    IC2244.2
+033700*    NO USE IN RUNNING THE LEVEL 2 IPC ROUTINES.                  IC2244.2
+033800 CALL-TEST-01-01.                                                 IC2244.2
+033900     MOVE ZERO TO DN3, DN4.                                       IC2244.2
+034000     MOVE  "CALL-TEST-01-01" TO PAR-NAME.                         IC2244.2
+034100     MOVE  DN1 TO SAVE-DN1.                                       IC2244.2
+034200     MOVE  DN2 TO SAVE-DN2.                                       IC2244.2
+034300     MOVE  DN3 TO SAVE-DN3.                                       IC2244.2
+034400     MOVE  DN4 TO SAVE-DN4.                                       IC2244.2
+034500     CALL "IC224A-1" USING BY CONTENT DN1, DN2, DN3, DN4          IC2244.2
+034600     END-CALL.                                                    IC2244.2
+034700     PERFORM CHECK-TEST-01.                                       IC2244.2
+034800 CALL-TEST-01-02.                                                 IC2244.2
+034900     ADD 1 TO REC-CT.                                             IC2244.2
+035000     MOVE ZERO TO DN3, DN4.                                       IC2244.2
+035100     MOVE  "CALL-TEST-01-02" TO PAR-NAME.                         IC2244.2
+035200     MOVE  DN1 TO SAVE-DN1.                                       IC2244.2
+035300     MOVE  DN2 TO SAVE-DN2.                                       IC2244.2
+035400     MOVE  DN3 TO SAVE-DN3.                                       IC2244.2
+035500     MOVE  DN4 TO SAVE-DN4.                                       IC2244.2
+035600     CALL ID1 USING CONTENT DN1, DN2, DN3, DN4                    IC2244.2
+035700     END-CALL.                                                    IC2244.2
+035800     PERFORM CHECK-TEST-01.                                       IC2244.2
+035900 CALL-TEST-01-03.                                                 IC2244.2
+036000     MOVE ID1 TO ID2.                                             IC2244.2
+036100     MOVE ZERO TO DN3, DN4.                                       IC2244.2
+036200     MOVE  "CALL-TEST-01-03" TO PAR-NAME.                         IC2244.2
+036300     MOVE  DN1 TO SAVE-DN1.                                       IC2244.2
+036400     MOVE  DN2 TO SAVE-DN2.                                       IC2244.2
+036500     MOVE  DN3 TO SAVE-DN3.                                       IC2244.2
+036600     MOVE  DN4 TO SAVE-DN4.                                       IC2244.2
+036700     CALL ID2 USING CONTENT DN1 DN2 DN3 DN4                       IC2244.2
+036800     END-CALL.                                                    IC2244.2
+036900     PERFORM CHECK-TEST-01.                                       IC2244.2
+037000 CALL-TEST-01-04.                                                 IC2244.2
+037100     MOVE "IC224A-1" TO ID2.                                      IC2244.2
+037200     MOVE ZERO TO DN3, DN4.                                       IC2244.2
+037300     MOVE  "CALL-TEST-01-03" TO PAR-NAME.                         IC2244.2
+037400     MOVE  DN1 TO SAVE-DN1.                                       IC2244.2
+037500     MOVE  DN2 TO SAVE-DN2.                                       IC2244.2
+037600     MOVE  DN3 TO SAVE-DN3.                                       IC2244.2
+037700     MOVE  DN4 TO SAVE-DN4.                                       IC2244.2
+037800     CALL ID2 USING CONTENT DN1, DN2, DN3, DN4                    IC2244.2
+037900     END-CALL.                                                    IC2244.2
+038000     PERFORM CHECK-TEST-01.                                       IC2244.2
+038100 CALL-TEST-02.                                                    IC2244.2
+038200     MOVE "CALL-TEST-02" TO PAR-NAME.                             IC2244.2
+038300     MOVE "DATA-NAME USED TWICE" TO FEATURE.                      IC2244.2
+038400*        THIS TEST USES A DATA-NAME MORE THAN ONCE IN             IC2244.2
+038500*    A USING PHRASE OF A CALL STATEMENT.                          IC2244.2
+038600 CALL-INIT-02-01.                                                 IC2244.2
+038700     MOVE    1 TO DN1.                                            IC2244.2
+038800     MOVE    0 TO DN2, DN3, DN4.                                  IC2244.2
+038900     MOVE   "CALL-TEST-02-01" TO PAR-NAME.                        IC2244.2
+039000     MOVE    DN1 TO SAVE-DN1.                                     IC2244.2
+039100     MOVE    DN2 TO SAVE-DN2.                                     IC2244.2
+039200     MOVE    DN3 TO SAVE-DN3.                                     IC2244.2
+039300     MOVE    DN4 TO SAVE-DN4.                                     IC2244.2
+039400     GO TO   CALL-TEST-02-01.                                     IC2244.2
+039500 CALL-DELETE-02-01.                                               IC2244.2
+039600     PERFORM DE-LETE.                                             IC2244.2
+039700     PERFORM PRINT-DETAIL.                                        IC2244.2
+039800     GO TO   CALL-INIT-02-02.                                     IC2244.2
+039900 CALL-TEST-02-01.                                                 IC2244.2
+040000     CALL   "IC224A-1" USING CONTENT DN1, DN2, DN1, DN4           IC2244.2
+040100     END-CALL.                                                    IC2244.2
+040200     PERFORM CHECK-TEST-01.                                       IC2244.2
+040300 CALL-INIT-02-02.                                                 IC2244.2
+040400     MOVE    0 TO DN1, DN2, DN3, DN4.                             IC2244.2
+040500     MOVE   "CALL-TEST-02-02" TO PAR-NAME.                        IC2244.2
+040600     MOVE    DN1 TO SAVE-DN1.                                     IC2244.2
+040700     MOVE    DN2 TO SAVE-DN2.                                     IC2244.2
+040800     MOVE    DN3 TO SAVE-DN3.                                     IC2244.2
+040900     MOVE    DN4 TO SAVE-DN4.                                     IC2244.2
+041000     GO TO   CALL-TEST-02-02.                                     IC2244.2
+041100 CALL-DELETE-02-02.                                               IC2244.2
+041200     PERFORM DE-LETE.                                             IC2244.2
+041300     PERFORM PRINT-DETAIL.                                        IC2244.2
+041400     GO TO   CALL-INIT-02-03.                                     IC2244.2
+041500 CALL-TEST-02-02.                                                 IC2244.2
+041600     CALL   "IC224A-1" USING CONTENT DN1, DN2, DN3, DN2           IC2244.2
+041700     END-CALL.                                                    IC2244.2
+041800     PERFORM CHECK-TEST-01.                                       IC2244.2
+041900 CALL-INIT-02-03.                                                 IC2244.2
+042000     MOVE    0 TO DN4, DN3.                                       IC2244.2
+042100     MOVE    10 TO DN2.                                           IC2244.2
+042200     MOVE    25 TO DN1.                                           IC2244.2
+042300     MOVE   "CALL-TEST-02-03" TO PAR-NAME.                        IC2244.2
+042400     MOVE    DN1 TO SAVE-DN1.                                     IC2244.2
+042500     MOVE    DN2 TO SAVE-DN2.                                     IC2244.2
+042600     MOVE    DN3 TO SAVE-DN3.                                     IC2244.2
+042700     MOVE    DN4 TO SAVE-DN4.                                     IC2244.2
+042800     GO TO   CALL-TEST-02-03.                                     IC2244.2
+042900 CALL-DELETE-02-03.                                               IC2244.2
+043000     PERFORM DE-LETE.                                             IC2244.2
+043100     PERFORM PRINT-DETAIL.                                        IC2244.2
+043200     GO TO   CALL-TEST-03.                                        IC2244.2
+043300 CALL-TEST-02-03.                                                 IC2244.2
+043400     CALL ID1 USING CONTENT DN1 DN2 DN1 DN2                       IC2244.2
+043500     END-CALL.                                                    IC2244.2
+043600     PERFORM CHECK-TEST-01.                                       IC2244.2
+043700 CALL-TEST-03.                                                    IC2244.2
+043800*        THIS TEST USES THE ON OVERFLOW PHRASE IN THE CALL        IC2244.2
+043900*    STATEMENT.  THIS IS A SYNTACTICAL CHECK ONLY, THE ON         IC2244.2
+044000*    OVERFLOW CONDITION SHOULD NEVER OCCUR.                       IC2244.2
+044100     MOVE "ON OVERFLOW PHRASE" TO FEATURE.                        IC2244.2
+044200 CALL-INIT-03-01.                                                 IC2244.2
+044300     MOVE    20 TO DN1.                                           IC2244.2
+044400     MOVE    30 TO DN2.                                           IC2244.2
+044500     MOVE    ZERO TO DN3, DN4.                                    IC2244.2
+044600     MOVE   "CALL-TEST-03-01" TO PAR-NAME.                        IC2244.2
+044700     MOVE    DN1 TO SAVE-DN1.                                     IC2244.2
+044800     MOVE    DN2 TO SAVE-DN2.                                     IC2244.2
+044900     MOVE    DN3 TO SAVE-DN3.                                     IC2244.2
+045000     MOVE    DN4 TO SAVE-DN4.                                     IC2244.2
+045100     GO TO   CALL-TEST-03-01.                                     IC2244.2
+045200 CALL-DELETE-03-01.                                               IC2244.2
+045300     PERFORM DE-LETE.                                             IC2244.2
+045400     PERFORM PRINT-DETAIL.                                        IC2244.2
+045500     GO TO   CALL-INIT-03-02.                                     IC2244.2
+045600 CALL-TEST-03-01.                                                 IC2244.2
+045700     CALL "IC224A-1" USING CONTENT DN1, DN2, DN3, DN4;            IC2244.2
+045800         ON OVERFLOW MOVE "OVERFLOW SHOULD NOT OCCUR" TO RE-MARK  IC2244.2
+045900                     PERFORM FAIL PERFORM PRINT-DETAIL            IC2244.2
+046000     END-CALL.                                                    IC2244.2
+046100     MOVE   "CALL-TEST-03-01" TO PAR-NAME.                        IC2244.2
+046200     PERFORM CHECK-TEST-01.                                       IC2244.2
+046300 CALL-INIT-03-02.                                                 IC2244.2
+046400     MOVE    ZERO TO DN3, DN4.                                    IC2244.2
+046500     MOVE   "CALL-TEST-03-02" TO PAR-NAME.                        IC2244.2
+046600     MOVE    DN1 TO SAVE-DN1.                                     IC2244.2
+046700     MOVE    DN2 TO SAVE-DN2.                                     IC2244.2
+046800     MOVE    DN3 TO SAVE-DN3.                                     IC2244.2
+046900     MOVE    DN4 TO SAVE-DN4.                                     IC2244.2
+047000     GO TO   CALL-TEST-03-02.                                     IC2244.2
+047100 CALL-DELETE-03-02.                                               IC2244.2
+047200     PERFORM DE-LETE.                                             IC2244.2
+047300     PERFORM PRINT-DETAIL.                                        IC2244.2
+047400     GO TO   CALL-INIT-03-03.                                     IC2244.2
+047500 CALL-TEST-03-02.                                                 IC2244.2
+047600     CALL "IC224A-1" USING CONTENT DN1, DN2, DN3, DN4;            IC2244.2
+047700         OVERFLOW MOVE "OVERFLOW SHOULD NOT OCCUR" TO RE-MARK     IC2244.2
+047800                   PERFORM FAIL PERFORM PRINT-DETAIL              IC2244.2
+047900     END-CALL.                                                    IC2244.2
+048000     PERFORM CHECK-TEST-01.                                       IC2244.2
+048100 CALL-INIT-03-03.                                                 IC2244.2
+048200     MOVE    ZERO TO DN3, DN4.                                    IC2244.2
+048300     MOVE   "CALL-TEST-03-03" TO PAR-NAME.                        IC2244.2
+048400     MOVE    DN1 TO SAVE-DN1.                                     IC2244.2
+048500     MOVE    DN2 TO SAVE-DN2.                                     IC2244.2
+048600     MOVE    DN3 TO SAVE-DN3.                                     IC2244.2
+048700     MOVE    DN4 TO SAVE-DN4.                                     IC2244.2
+048800     GO TO   CALL-TEST-03-03.                                     IC2244.2
+048900 CALL-DELETE-03-03.                                               IC2244.2
+049000     PERFORM DE-LETE.                                             IC2244.2
+049100     PERFORM PRINT-DETAIL.                                        IC2244.2
+049200     GO TO   CALL-INIT-03-04.                                     IC2244.2
+049300 CALL-TEST-03-03.                                                 IC2244.2
+049400     CALL ID1 USING CONTENT DN1 DN2 DN3 DN4                       IC2244.2
+049500         ON OVERFLOW MOVE "OVERFLOW SHOULD NOT OCCUR" TO RE-MARK  IC2244.2
+049600                     PERFORM FAIL  PERFORM PRINT-DETAIL           IC2244.2
+049700     END-CALL.                                                    IC2244.2
+049800     PERFORM CHECK-TEST-01.                                       IC2244.2
+049900 CALL-INIT-03-04.                                                 IC2244.2
+050000     MOVE ZERO TO DN3, DN4.                                       IC2244.2
+050100     MOVE   "CALL-TEST-03-04" TO PAR-NAME.                        IC2244.2
+050200     MOVE    DN1 TO SAVE-DN1.                                     IC2244.2
+050300     MOVE    DN2 TO SAVE-DN2.                                     IC2244.2
+050400     MOVE    DN3 TO SAVE-DN3.                                     IC2244.2
+050500     MOVE    DN4 TO SAVE-DN4.                                     IC2244.2
+050600     GO TO   CALL-TEST-03-04.                                     IC2244.2
+050700 CALL-DELETE-03-04.                                               IC2244.2
+050800     PERFORM DE-LETE.                                             IC2244.2
+050900     PERFORM PRINT-DETAIL.                                        IC2244.2
+051000     GO TO   EXIT-IC224A.                                         IC2244.2
+051100 CALL-TEST-03-04.                                                 IC2244.2
+051200     CALL ID1 USING CONTENT DN1 DN2 DN3 DN4;                      IC2244.2
+051300         OVERFLOW MOVE "OVERFLOW SHOULD NOT OCCUR" TO RE-MARK,    IC2244.2
+051400                  PERFORM FAIL  PERFORM PRINT-DETAIL              IC2244.2
+051500     END-CALL.                                                    IC2244.2
+051600     PERFORM CHECK-TEST-01.                                       IC2244.2
+051700     GO TO   EXIT-IC224A.                                         IC2244.2
+051800 CALL-DELETE-03.                                                  IC2244.2
+051900*        IF THE ON OVERFLOW PHRASE IS NOT RECOGNIZED, DELETE ALL  IC2244.2
+052000*    OF THE ABOVE CALL-TEST-03 PARAGRAPHS, STARTING WITH          IC2244.2
+052100*    CALL-TEST-03-01.                                             IC2244.2
+052200     PERFORM DE-LETE.                                             IC2244.2
+052300     PERFORM PRINT-DETAIL.                                        IC2244.2
+052400 EXIT-IC224A.                                                     IC2244.2
+052500     GO TO   CCVS-EXIT.                                           IC2244.2
+052600*                                                                 IC2244.2
+052700 SECT-IC224A-CHECK-01.                                            IC2244.2
+052800*=====================                                            IC2244.2
+052900 CHECK-TEST-01.                                                   IC2244.2
+053000     MOVE    1 TO REC-CT.                                         IC2244.2
+053100     IF      DN1 = SAVE-DN1                                       IC2244.2
+053200             PERFORM PASS                                         IC2244.2
+053300             PERFORM PRINT-DETAIL                                 IC2244.2
+053400     ELSE                                                         IC2244.2
+053500             MOVE    SAVE-DN1 TO CORRECT-N                        IC2244.2
+053600             MOVE    DN1      TO COMPUTED-N                       IC2244.2
+053700             MOVE   "VALUE OF DN1 HAS CHANGED" TO RE-MARK         IC2244.2
+053800             PERFORM FAIL                                         IC2244.2
+053900             PERFORM PRINT-DETAIL.                                IC2244.2
+054000     ADD     1 TO REC-CT.                                         IC2244.2
+054100     IF      DN2 = SAVE-DN2                                       IC2244.2
+054200             PERFORM PASS                                         IC2244.2
+054300             PERFORM PRINT-DETAIL                                 IC2244.2
+054400     ELSE                                                         IC2244.2
+054500             MOVE    SAVE-DN2 TO CORRECT-N                        IC2244.2
+054600             MOVE    DN2      TO COMPUTED-N                       IC2244.2
+054700             MOVE   "VALUE OF DN2 HAS CHANGED" TO RE-MARK         IC2244.2
+054800             PERFORM FAIL                                         IC2244.2
+054900             PERFORM PRINT-DETAIL.                                IC2244.2
+055000     ADD     1 TO REC-CT.                                         IC2244.2
+055100     IF      DN3 = SAVE-DN3                                       IC2244.2
+055200             PERFORM PASS                                         IC2244.2
+055300             PERFORM PRINT-DETAIL                                 IC2244.2
+055400     ELSE                                                         IC2244.2
+055500             MOVE    SAVE-DN3 TO CORRECT-N                        IC2244.2
+055600             MOVE    DN3      TO COMPUTED-N                       IC2244.2
+055700             MOVE   "VALUE OF DN3 HAS CHANGED" TO RE-MARK         IC2244.2
+055800             PERFORM FAIL                                         IC2244.2
+055900             PERFORM PRINT-DETAIL.                                IC2244.2
+056000     ADD     1 TO REC-CT.                                         IC2244.2
+056100     IF      DN4 = SAVE-DN4                                       IC2244.2
+056200             PERFORM PASS                                         IC2244.2
+056300             PERFORM PRINT-DETAIL                                 IC2244.2
+056400     ELSE                                                         IC2244.2
+056500             MOVE    SAVE-DN4 TO CORRECT-N                        IC2244.2
+056600             MOVE    DN4      TO COMPUTED-N                       IC2244.2
+056700             MOVE   "VALUE OF DN4 HAS CHANGED" TO RE-MARK         IC2244.2
+056800             PERFORM FAIL                                         IC2244.2
+056900             PERFORM PRINT-DETAIL.                                IC2244.2
+057000*                                                                 IC2244.2
+057100*                                                                 IC2244.2
+057200 CCVS-EXIT SECTION.                                               IC2244.2
+057300 CCVS-999999.                                                     IC2244.2
+057400     GO TO CLOSE-FILES.                                           IC2244.2
+057500 END PROGRAM IC224A.                                              IC2244.2

--- a/z390/IC224A1.CBL
+++ b/z390/IC224A1.CBL
@@ -1,0 +1,134 @@
+057600 IDENTIFICATION DIVISION.                                         IC2244.2
+      *
+      * This is the z390 version of IC224A-1
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC224A1
+      * IC224A has been modified to call IC224A1 instead of IC224A-1.
+      *
+057700 PROGRAM-ID.                                                      IC2244.2
+057800     IC224A1.                                                     IC2244.2
+057900****************************************************************  IC2244.2
+058000*                                                              *  IC2244.2
+058100*    THIS PROGRAM FORMS PART OF THE COBOL COMPILER VALIDATION  *  IC2244.2
+058200*    SYSTEM (CCVS) USED TO TEST COBOL COMPILERS FOR            *  IC2244.2
+058300*    CONFORMANCE WITH THE AMERICAN NATIONAL STANDARD           *  IC2244.2
+058400*    (ANSI DOCUMENT REFERENCE: X3.23-1985) AND THE STANDARD OF *  IC2244.2
+058500*    THE INTERNATIONAL ORGANIZATION FOR STANDARDISATION        *  IC2244.2
+058600*    (ISO DOCUMENT REFERENCE: ISO-1989-1985).                  *  IC2244.2
+058700*                                                              *  IC2244.2
+058800*    THIS CCVS INCORPORATES ENHANCEMENTS TO THE CCVS FOR THE   *  IC2244.2
+058900*    1974 STANDARD (ANSI DOCUMENT REFERENCE: X3.23-1974; ISO   *  IC2244.2
+059000*    DOCUMENT REFERENCE: ISO-1989-1978).                       *  IC2244.2
+059100*                                                              *  IC2244.2
+059200*    THESE ENHANCEMENTS WERE SPECIFIED BY A PROJECT TEAM WHICH *  IC2244.2
+059300*    WAS FUNDED BY THE COMMISSION FOR EUROPEAN COMMUNITIES AND *  IC2244.2
+059400*    WHICH WAS RESPONSIBLE FOR TECHNICAL ISSUES TO:            *  IC2244.2
+059500*                                                              *  IC2244.2
+059600*          THE FEDERAL SOFTWARE TESTING CENTER                 *  IC2244.2
+059700*          OFFICE OF SOFTWARE DEVELOPMENT                      *  IC2244.2
+059800*                & INFORMATION TECHNOLOGY                      *  IC2244.2
+059900*          TWO SKYLINE PLACE                                   *  IC2244.2
+060000*          SUITE 1100                                          *  IC2244.2
+060100*          5203 LEESBURG PIKE                                  *  IC2244.2
+060200*          FALLS CHURCH                                        *  IC2244.2
+060300*          VA 22041                                            *  IC2244.2
+060400*          U.S.A.                                              *  IC2244.2
+060500*                                                              *  IC2244.2
+060600*    THE PROJECT TEAM MEMBERS WERE:                            *  IC2244.2
+060700*                                                              *  IC2244.2
+060800*          BIADI (BUREAU INTER ADMINISTRATION                  *  IC2244.2
+060900*                 DE DOCUMENTATION INFORMATIQUE)               *  IC2244.2
+061000*          21 RUE BARA                                         *  IC2244.2
+061100*          F-92132 ISSY                                        *  IC2244.2
+061200*          FRANCE                                              *  IC2244.2
+061300*                                                              *  IC2244.2
+061400*                                                              *  IC2244.2
+061500*          GMD (GESELLSCHAFT FUR MATHEMATIK                    *  IC2244.2
+061600*               UND DATENVERARBEITUNG MBH)                     *  IC2244.2
+061700*          SCHLOSS BIRLINGHOVEN                                *  IC2244.2
+061800*          POSTFACH 12 40                                      *  IC2244.2
+061900*          D-5205 ST. AUGUSTIN 1                               *  IC2244.2
+062000*          GERMANY FR                                          *  IC2244.2
+062100*                                                              *  IC2244.2
+062200*                                                              *  IC2244.2
+062300*          NCC (THE NATIONAL COMPUTING CENTRE LTD)             *  IC2244.2
+062400*          OXFORD ROAD                                         *  IC2244.2
+062500*          MANCHESTER                                          *  IC2244.2
+062600*          M1 7ED                                              *  IC2244.2
+062700*          UNITED KINGDOM                                      *  IC2244.2
+062800*                                                              *  IC2244.2
+062900*                                                              *  IC2244.2
+063000*    THIS TEST SUITE WAS PRODUCED BY THE NATIONAL COMPUTING    *  IC2244.2
+063100*    CENTRE IN ENGLAND AND IS THE OFFICIAL CCVS TEST SUITE     *  IC2244.2
+063200*    USED THROUGHOUT EUROPE AND THE UNITED STATES OF AMERICA.  *  IC2244.2
+063300*                                                              *  IC2244.2
+063400****************************************************************  IC2244.2
+063500*                                                              *  IC2244.2
+063600*    VALIDATION FOR:-                                          *  IC2244.2
+063700*                                                              *  IC2244.2
+063800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2244.2
+063900*                                                              *  IC2244.2
+064000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2244.2
+064100*                                                              *  IC2244.2
+064200****************************************************************  IC2244.2
+064300*                                                              *  IC2244.2
+064400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2244.2
+064500*                                                              *  IC2244.2
+064600*        X-55  - SYSTEM PRINTER NAME.                          *  IC2244.2
+064700*        X-82  - SOURCE COMPUTER NAME.                         *  IC2244.2
+064800*        X-83  - OBJECT COMPUTER NAME.                         *  IC2244.2
+064900*                                                              *  IC2244.2
+065000****************************************************************  IC2244.2
+065100*                                                              *  IC2244.2
+065200*    PROGRAM IC224A AND IC224A-1 WILL TEST THE NEW LANGUAGE    *  IC2244.2
+065300*    ELEMENTS FOR THE LEVEL 2 INTER-PROGRAM COMMUNICATION      *  IC2244.2
+065400*    MODULE.                                                   *  IC2244.2
+065500*    THE NEW LANGUAGE ELEMENTS TO BE TESTED WILL BE:           *  IC2244.2
+065600*          "BY CONTENT"       PHRASE                           *  IC2244.2
+065700*    THE TWO PROGRAMS WILL BE COMPILED IN THE SAME FLOW        *  IC2244.2
+065800*    (TO TEST THE "END PROGRAM" STATEMENT) AS SHOWN BELOW:     *  IC2244.2
+065900*    IDENTIFICATION DIVISION.                                  *  IC2244.2
+066000*    PROGRAM-ID. IC224A.                                       *  IC2244.2
+066100*              .                                               *  IC2244.2
+066200*              .                                               *  IC2244.2
+066300*              .                                               *  IC2244.2
+066400*    END PROGRAM IC224A.                                       *  IC2244.2
+066500*    PROGRAM-ID. IC224A-1.                                     *  IC2244.2
+066600*              .                                               *  IC2244.2
+066700*              .                                               *  IC2244.2
+066800*              .                                               *  IC2244.2
+066900****************************************************************  IC2244.2
+067000 ENVIRONMENT DIVISION.                                            IC2244.2
+067100 CONFIGURATION SECTION.                                           IC2244.2
+067200 SOURCE-COMPUTER.                                                 IC2244.2
+067300     XXXXX082.                                                    IC2244.2
+067400 OBJECT-COMPUTER.                                                 IC2244.2
+067500     XXXXX083.                                                    IC2244.2
+067600 INPUT-OUTPUT SECTION.                                            IC2244.2
+067700 FILE-CONTROL.                                                    IC2244.2
+067800     SELECT PRINT-FILE ASSIGN TO                                  IC2244.2
+067900     XXXXX055.                                                    IC2244.2
+068000 DATA DIVISION.                                                   IC2244.2
+068100 FILE SECTION.                                                    IC2244.2
+068200 FD  PRINT-FILE.                                                  IC2244.2
+068300 01  PRINT-REC PICTURE X(120).                                    IC2244.2
+068400 01  DUMMY-RECORD PICTURE X(120).                                 IC2244.2
+068500 WORKING-STORAGE SECTION.                                         IC2244.2
+068600 77  WS1 PICTURE S999.                                            IC2244.2
+068700 77  WS2 PICTURE S999                                             IC2244.2
+068800         USAGE COMPUTATIONAL, VALUE ZERO.                         IC2244.2
+068900 LINKAGE SECTION.                                                 IC2244.2
+069000 77  DN1 PICTURE S99.                                             IC2244.2
+069100 77  DN2 PICTURE S99 USAGE COMPUTATIONAL.                         IC2244.2
+069200 77  DN3 PICTURE S99.                                             IC2244.2
+069300 77  DN4 PICTURE S99 USAGE COMPUTATIONAL.                         IC2244.2
+069400 PROCEDURE DIVISION USING DN1, DN2, DN3, DN4.                     IC2244.2
+069500 SECT-IC224A-1-001 SECTION.                                       IC2244.2
+069600 CALL-TEST-001.                                                   IC2244.2
+069700     MOVE DN1 TO WS1.                                             IC2244.2
+069800     ADD 1 TO WS1.                                                IC2244.2
+069900     ADD 1 TO WS2.                                                IC2244.2
+070000     MOVE WS1 TO DN3.                                             IC2244.2
+070100     MOVE WS2 TO DN4.                                             IC2244.2
+070200 CALL-EXIT-001.                                                   IC2244.2
+070300     EXIT PROGRAM.                                                IC2244.2

--- a/z390/IC225A.CBL
+++ b/z390/IC225A.CBL
@@ -1,0 +1,938 @@
+000100 IDENTIFICATION DIVISION.                                         IC2254.2
+      *
+      * This is the z390 version of IC225A
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC225A1
+      * IC225A has been modified to call IC225A1 instead of IC225A-1.
+      *
+000200 PROGRAM-ID.                                                      IC2254.2
+000300     IC225A.                                                      IC2254.2
+000400****************************************************************  IC2254.2
+000500*                                                              *  IC2254.2
+000600*    VALIDATION FOR:-                                          *  IC2254.2
+000700*                                                              *  IC2254.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2254.2
+000900*                                                              *  IC2254.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2254.2
+001100*                                                              *  IC2254.2
+001200****************************************************************  IC2254.2
+001300*                                                              *  IC2254.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2254.2
+001500*                                                              *  IC2254.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC2254.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC2254.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC2254.2
+001900*                                                              *  IC2254.2
+002000****************************************************************  IC2254.2
+002100*                                                              *  IC2254.2
+002200*    PROGRAM IC225A AND IC225A-1 WILL TEST THE NEW LANGUAGE    *  IC2254.2
+002300*    ELEMENTS FOR THE LEVEL 2 INTER-PROGRAM COMMUNICATION      *  IC2254.2
+002400*    MODULE.                                                   *  IC2254.2
+002500*    THE NEW LANGUAGE ELEMENTS TO BE TESTED WILL BE:           *  IC2254.2
+002600*          "BY REFERENCE"     PHRASE                           *  IC2254.2
+002700*    THE TWO PROGRAMS WILL BE COMPILED IN THE SAME FLOW        *  IC2254.2
+002800*    (TO TEST THE "END PROGRAM" STATEMENT) AS SHOWN BELOW:     *  IC2254.2
+002900*    IDENTIFICATION DIVISION.                                  *  IC2254.2
+003000*    PROGRAM-ID. IC225A.                                       *  IC2254.2
+003100*              .                                               *  IC2254.2
+003200*              .                                               *  IC2254.2
+003300*              .                                               *  IC2254.2
+003400*    END PROGRAM IC225A.                                       *  IC2254.2
+003500*    PROGRAM-ID. IC225A-1.                                     *  IC2254.2
+003600*              .                                               *  IC2254.2
+003700*              .                                               *  IC2254.2
+003800*              .                                               *  IC2254.2
+003900****************************************************************  IC2254.2
+004000 ENVIRONMENT DIVISION.                                            IC2254.2
+004100 CONFIGURATION SECTION.                                           IC2254.2
+004200 SOURCE-COMPUTER.                                                 IC2254.2
+004300     XXXXX082.                                                    IC2254.2
+004400 OBJECT-COMPUTER.                                                 IC2254.2
+004500     XXXXX083.                                                    IC2254.2
+004600 INPUT-OUTPUT SECTION.                                            IC2254.2
+004700 FILE-CONTROL.                                                    IC2254.2
+004800     SELECT PRINT-FILE ASSIGN TO                                  IC2254.2
+004900     XXXXX055.                                                    IC2254.2
+005000 DATA DIVISION.                                                   IC2254.2
+005100 FILE SECTION.                                                    IC2254.2
+005200 FD  PRINT-FILE.                                                  IC2254.2
+005300 01  PRINT-REC PICTURE X(120).                                    IC2254.2
+005400 01  DUMMY-RECORD PICTURE X(120).                                 IC2254.2
+005500 WORKING-STORAGE SECTION.                                         IC2254.2
+005600 77  DN1 PICTURE S99  VALUE ZERO.                                 IC2254.2
+005700 77  DN3 PICTURE S99.                                             IC2254.2
+005800 77  ID1 PICTURE X(8) VALUE "IC225A1".                            IC2254.2
+005900 77  ID2 PICTURE X(8).                                            IC2254.2
+006000 77  DN2 PICTURE S99                                              IC2254.2
+006100         USAGE COMPUTATIONAL, VALUE ZERO.                         IC2254.2
+006200 77  DN4 PICTURE S99                                              IC2254.2
+006300         USAGE IS COMPUTATIONAL.                                  IC2254.2
+006400 77  CALL-COUNT PIC S99.                                          IC2254.2
+006500 77  FAIL-FLAG PIC 9.                                             IC2254.2
+006600 01  TEST-RESULTS.                                                IC2254.2
+006700     02 FILLER                   PIC X      VALUE SPACE.          IC2254.2
+006800     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC2254.2
+006900     02 FILLER                   PIC X      VALUE SPACE.          IC2254.2
+007000     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC2254.2
+007100     02 FILLER                   PIC X      VALUE SPACE.          IC2254.2
+007200     02  PAR-NAME.                                                IC2254.2
+007300       03 FILLER                 PIC X(19)  VALUE SPACE.          IC2254.2
+007400       03  PARDOT-X              PIC X      VALUE SPACE.          IC2254.2
+007500       03 DOTVALUE               PIC 99     VALUE ZERO.           IC2254.2
+007600     02 FILLER                   PIC X(8)   VALUE SPACE.          IC2254.2
+007700     02 RE-MARK                  PIC X(61).                       IC2254.2
+007800 01  TEST-COMPUTED.                                               IC2254.2
+007900     02 FILLER                   PIC X(30)  VALUE SPACE.          IC2254.2
+008000     02 FILLER                   PIC X(17)  VALUE                 IC2254.2
+008100            "       COMPUTED=".                                   IC2254.2
+008200     02 COMPUTED-X.                                               IC2254.2
+008300     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC2254.2
+008400     03 COMPUTED-N               REDEFINES COMPUTED-A             IC2254.2
+008500                                 PIC -9(9).9(9).                  IC2254.2
+008600     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC2254.2
+008700     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC2254.2
+008800     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC2254.2
+008900     03       CM-18V0 REDEFINES COMPUTED-A.                       IC2254.2
+009000         04 COMPUTED-18V0                    PIC -9(18).          IC2254.2
+009100         04 FILLER                           PIC X.               IC2254.2
+009200     03 FILLER PIC X(50) VALUE SPACE.                             IC2254.2
+009300 01  TEST-CORRECT.                                                IC2254.2
+009400     02 FILLER PIC X(30) VALUE SPACE.                             IC2254.2
+009500     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC2254.2
+009600     02 CORRECT-X.                                                IC2254.2
+009700     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC2254.2
+009800     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC2254.2
+009900     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC2254.2
+010000     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC2254.2
+010100     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC2254.2
+010200     03      CR-18V0 REDEFINES CORRECT-A.                         IC2254.2
+010300         04 CORRECT-18V0                     PIC -9(18).          IC2254.2
+010400         04 FILLER                           PIC X.               IC2254.2
+010500     03 FILLER PIC X(2) VALUE SPACE.                              IC2254.2
+010600     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC2254.2
+010700 01  CCVS-C-1.                                                    IC2254.2
+010800     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC2254.2
+010900-    "SS  PARAGRAPH-NAME                                          IC2254.2
+011000-    "       REMARKS".                                            IC2254.2
+011100     02 FILLER                     PIC X(20)    VALUE SPACE.      IC2254.2
+011200 01  CCVS-C-2.                                                    IC2254.2
+011300     02 FILLER                     PIC X        VALUE SPACE.      IC2254.2
+011400     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC2254.2
+011500     02 FILLER                     PIC X(15)    VALUE SPACE.      IC2254.2
+011600     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC2254.2
+011700     02 FILLER                     PIC X(94)    VALUE SPACE.      IC2254.2
+011800 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC2254.2
+011900 01  REC-CT                        PIC 99       VALUE ZERO.       IC2254.2
+012000 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC2254.2
+012100 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC2254.2
+012200 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC2254.2
+012300 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC2254.2
+012400 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC2254.2
+012500 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC2254.2
+012600 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC2254.2
+012700 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC2254.2
+012800 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC2254.2
+012900 01  CCVS-H-1.                                                    IC2254.2
+013000     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2254.2
+013100     02  FILLER                    PIC X(42)    VALUE             IC2254.2
+013200     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC2254.2
+013300     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2254.2
+013400 01  CCVS-H-2A.                                                   IC2254.2
+013500   02  FILLER                        PIC X(40)  VALUE SPACE.      IC2254.2
+013600   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC2254.2
+013700   02  FILLER                        PIC XXXX   VALUE             IC2254.2
+013800     "4.2 ".                                                      IC2254.2
+013900   02  FILLER                        PIC X(28)  VALUE             IC2254.2
+014000            " COPY - NOT FOR DISTRIBUTION".                       IC2254.2
+014100   02  FILLER                        PIC X(41)  VALUE SPACE.      IC2254.2
+014200                                                                  IC2254.2
+014300 01  CCVS-H-2B.                                                   IC2254.2
+014400   02  FILLER                        PIC X(15)  VALUE             IC2254.2
+014500            "TEST RESULT OF ".                                    IC2254.2
+014600   02  TEST-ID                       PIC X(9).                    IC2254.2
+014700   02  FILLER                        PIC X(4)   VALUE             IC2254.2
+014800            " IN ".                                               IC2254.2
+014900   02  FILLER                        PIC X(12)  VALUE             IC2254.2
+015000     " HIGH       ".                                              IC2254.2
+015100   02  FILLER                        PIC X(22)  VALUE             IC2254.2
+015200            " LEVEL VALIDATION FOR ".                             IC2254.2
+015300   02  FILLER                        PIC X(58)  VALUE             IC2254.2
+015400     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2254.2
+015500 01  CCVS-H-3.                                                    IC2254.2
+015600     02  FILLER                      PIC X(34)  VALUE             IC2254.2
+015700            " FOR OFFICIAL USE ONLY    ".                         IC2254.2
+015800     02  FILLER                      PIC X(58)  VALUE             IC2254.2
+015900     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2254.2
+016000     02  FILLER                      PIC X(28)  VALUE             IC2254.2
+016100            "  COPYRIGHT   1985 ".                                IC2254.2
+016200 01  CCVS-E-1.                                                    IC2254.2
+016300     02 FILLER                       PIC X(52)  VALUE SPACE.      IC2254.2
+016400     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC2254.2
+016500     02 ID-AGAIN                     PIC X(9).                    IC2254.2
+016600     02 FILLER                       PIC X(45)  VALUE SPACES.     IC2254.2
+016700 01  CCVS-E-2.                                                    IC2254.2
+016800     02  FILLER                      PIC X(31)  VALUE SPACE.      IC2254.2
+016900     02  FILLER                      PIC X(21)  VALUE SPACE.      IC2254.2
+017000     02 CCVS-E-2-2.                                               IC2254.2
+017100         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC2254.2
+017200         03 FILLER                   PIC X      VALUE SPACE.      IC2254.2
+017300         03 ENDER-DESC               PIC X(44)  VALUE             IC2254.2
+017400            "ERRORS ENCOUNTERED".                                 IC2254.2
+017500 01  CCVS-E-3.                                                    IC2254.2
+017600     02  FILLER                      PIC X(22)  VALUE             IC2254.2
+017700            " FOR OFFICIAL USE ONLY".                             IC2254.2
+017800     02  FILLER                      PIC X(12)  VALUE SPACE.      IC2254.2
+017900     02  FILLER                      PIC X(58)  VALUE             IC2254.2
+018000     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2254.2
+018100     02  FILLER                      PIC X(13)  VALUE SPACE.      IC2254.2
+018200     02 FILLER                       PIC X(15)  VALUE             IC2254.2
+018300             " COPYRIGHT 1985".                                   IC2254.2
+018400 01  CCVS-E-4.                                                    IC2254.2
+018500     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC2254.2
+018600     02 FILLER                       PIC X(4)   VALUE " OF ".     IC2254.2
+018700     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC2254.2
+018800     02 FILLER                       PIC X(40)  VALUE             IC2254.2
+018900      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC2254.2
+019000 01  XXINFO.                                                      IC2254.2
+019100     02 FILLER                       PIC X(19)  VALUE             IC2254.2
+019200            "*** INFORMATION ***".                                IC2254.2
+019300     02 INFO-TEXT.                                                IC2254.2
+019400       04 FILLER                     PIC X(8)   VALUE SPACE.      IC2254.2
+019500       04 XXCOMPUTED                 PIC X(20).                   IC2254.2
+019600       04 FILLER                     PIC X(5)   VALUE SPACE.      IC2254.2
+019700       04 XXCORRECT                  PIC X(20).                   IC2254.2
+019800     02 INF-ANSI-REFERENCE           PIC X(48).                   IC2254.2
+019900 01  HYPHEN-LINE.                                                 IC2254.2
+020000     02 FILLER  PIC IS X VALUE IS SPACE.                          IC2254.2
+020100     02 FILLER  PIC IS X(65)    VALUE IS "************************IC2254.2
+020200-    "*****************************************".                 IC2254.2
+020300     02 FILLER  PIC IS X(54)    VALUE IS "************************IC2254.2
+020400-    "******************************".                            IC2254.2
+020500 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC2254.2
+020600     "IC225A".                                                    IC2254.2
+020700 PROCEDURE DIVISION.                                              IC2254.2
+020800 CCVS1 SECTION.                                                   IC2254.2
+020900 OPEN-FILES.                                                      IC2254.2
+021000     OPEN     OUTPUT PRINT-FILE.                                  IC2254.2
+021100     MOVE CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.   IC2254.2
+021200     MOVE    SPACE TO TEST-RESULTS.                               IC2254.2
+021300     PERFORM  HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.             IC2254.2
+021400     GO TO CCVS1-EXIT.                                            IC2254.2
+021500 CLOSE-FILES.                                                     IC2254.2
+021600     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC2254.2
+021700 TERMINATE-CCVS.                                                  IC2254.2
+021800S    EXIT PROGRAM.                                                IC2254.2
+021900STERMINATE-CALL.                                                  IC2254.2
+022000     STOP     RUN.                                                IC2254.2
+022100 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         IC2254.2
+022200 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           IC2254.2
+022300 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          IC2254.2
+022400 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      IC2254.2
+022500     MOVE "****TEST DELETED****" TO RE-MARK.                      IC2254.2
+022600 PRINT-DETAIL.                                                    IC2254.2
+022700     IF REC-CT NOT EQUAL TO ZERO                                  IC2254.2
+022800             MOVE "." TO PARDOT-X                                 IC2254.2
+022900             MOVE REC-CT TO DOTVALUE.                             IC2254.2
+023000     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      IC2254.2
+023100     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               IC2254.2
+023200        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 IC2254.2
+023300          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 IC2254.2
+023400     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC2254.2
+023500     MOVE SPACE TO CORRECT-X.                                     IC2254.2
+023600     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC2254.2
+023700     MOVE     SPACE TO RE-MARK.                                   IC2254.2
+023800 HEAD-ROUTINE.                                                    IC2254.2
+023900     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2254.2
+024000     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2254.2
+024100     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2254.2
+024200     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2254.2
+024300 COLUMN-NAMES-ROUTINE.                                            IC2254.2
+024400     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2254.2
+024500     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2254.2
+024600     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC2254.2
+024700 END-ROUTINE.                                                     IC2254.2
+024800     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.IC2254.2
+024900 END-RTN-EXIT.                                                    IC2254.2
+025000     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2254.2
+025100 END-ROUTINE-1.                                                   IC2254.2
+025200      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      IC2254.2
+025300      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               IC2254.2
+025400      ADD PASS-COUNTER TO ERROR-HOLD.                             IC2254.2
+025500*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC2254.2
+025600      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC2254.2
+025700      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC2254.2
+025800      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC2254.2
+025900      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC2254.2
+026000  END-ROUTINE-12.                                                 IC2254.2
+026100      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC2254.2
+026200     IF       ERROR-COUNTER IS EQUAL TO ZERO                      IC2254.2
+026300         MOVE "NO " TO ERROR-TOTAL                                IC2254.2
+026400         ELSE                                                     IC2254.2
+026500         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC2254.2
+026600     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC2254.2
+026700     PERFORM WRITE-LINE.                                          IC2254.2
+026800 END-ROUTINE-13.                                                  IC2254.2
+026900     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC2254.2
+027000         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC2254.2
+027100         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC2254.2
+027200     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC2254.2
+027300     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2254.2
+027400      IF   INSPECT-COUNTER EQUAL TO ZERO                          IC2254.2
+027500          MOVE "NO " TO ERROR-TOTAL                               IC2254.2
+027600      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   IC2254.2
+027700      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            IC2254.2
+027800      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          IC2254.2
+027900     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2254.2
+028000 WRITE-LINE.                                                      IC2254.2
+028100     ADD 1 TO RECORD-COUNT.                                       IC2254.2
+028200Y    IF RECORD-COUNT GREATER 50                                   IC2254.2
+028300Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC2254.2
+028400Y        MOVE SPACE TO DUMMY-RECORD                               IC2254.2
+028500Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC2254.2
+028600Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC2254.2
+028700Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC2254.2
+028800Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC2254.2
+028900Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC2254.2
+029000Y        MOVE ZERO TO RECORD-COUNT.                               IC2254.2
+029100     PERFORM WRT-LN.                                              IC2254.2
+029200 WRT-LN.                                                          IC2254.2
+029300     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC2254.2
+029400     MOVE SPACE TO DUMMY-RECORD.                                  IC2254.2
+029500 BLANK-LINE-PRINT.                                                IC2254.2
+029600     PERFORM WRT-LN.                                              IC2254.2
+029700 FAIL-ROUTINE.                                                    IC2254.2
+029800     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC2254.2
+029900     IF     CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.IC2254.2
+030000     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2254.2
+030100     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC2254.2
+030200     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2254.2
+030300     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2254.2
+030400     GO TO  FAIL-ROUTINE-EX.                                      IC2254.2
+030500 FAIL-ROUTINE-WRITE.                                              IC2254.2
+030600     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC2254.2
+030700     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC2254.2
+030800     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC2254.2
+030900     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC2254.2
+031000 FAIL-ROUTINE-EX. EXIT.                                           IC2254.2
+031100 BAIL-OUT.                                                        IC2254.2
+031200     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC2254.2
+031300     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC2254.2
+031400 BAIL-OUT-WRITE.                                                  IC2254.2
+031500     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC2254.2
+031600     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2254.2
+031700     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2254.2
+031800     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2254.2
+031900 BAIL-OUT-EX. EXIT.                                               IC2254.2
+032000 CCVS1-EXIT.                                                      IC2254.2
+032100     EXIT.                                                        IC2254.2
+032200 SECT-IC225A-001 SECTION.                                         IC2254.2
+032300 CALL-TEST-01.                                                    IC2254.2
+032400     MOVE   "X-27 5.2.2" TO ANSI-REFERENCE.                       IC2254.2
+032500     MOVE   "CALL-TEST-01" TO PAR-NAME.                           IC2254.2
+032600     MOVE     "LEV 2 CALL STATEMENT" TO FEATURE.                  IC2254.2
+032700     MOVE 0 TO CALL-COUNT.                                        IC2254.2
+032800*        THIS TEST HAS CALL STATEMENTS WITH AN IDENTIFIER         IC2254.2
+032900*    CONTAINING THE NAME OF THE SUBPROGRAM TO BE CALLED.          IC2254.2
+033000*        CALL-TEST-01 CONTAINS THE BASIC LEVEL 2 CALL STATEMENT.  IC2254.2
+033100*    IF IT CANNOT BE COMPILED AND EXECUTED CORRECTLY, THERE IS    IC2254.2
+033200*    NO USE IN RUNNING THE LEVEL 2 IPC ROUTINES.                  IC2254.2
+033300 CALL-INIT-01-01.                                                 IC2254.2
+033400     MOVE    1    TO REC-CT.                                      IC2254.2
+033500     MOVE    ZERO TO DN3, DN4.                                    IC2254.2
+033600 CALL-TEST-01-01-0.                                               IC2254.2
+033700     CALL   "IC225A1" USING BY REFERENCE DN1, DN2,                IC2254.2
+033800                                CONTENT   DN3, DN4                IC2254.2
+033900     END-CALL.                                                    IC2254.2
+034000     GO TO   CALL-TEST-01-01-1.                                   IC2254.2
+034100 CALL-DELETE-01-01.                                               IC2254.2
+034200     PERFORM DE-LETE.                                             IC2254.2
+034300     PERFORM PRINT-DETAIL.                                        IC2254.2
+034400     GO TO   CALL-INIT-01-02.                                     IC2254.2
+034500 CALL-TEST-01-01-1.                                               IC2254.2
+034600     MOVE   "CALL-TEST-01-01-1" TO PAR-NAME.                      IC2254.2
+034700     IF      DN1 = ZERO                                           IC2254.2
+034800             PERFORM PASS                                         IC2254.2
+034900             PERFORM PRINT-DETAIL                                 IC2254.2
+035000     ELSE                                                         IC2254.2
+035100             MOVE    DN1  TO COMPUTED-N                           IC2254.2
+035200             MOVE    ZERO TO CORRECT-N                            IC2254.2
+035300             MOVE   "INCORRECT DN1 VALUE RETURNED" TO RE-MARK     IC2254.2
+035400             PERFORM FAIL                                         IC2254.2
+035500             PERFORM PRINT-DETAIL.                                IC2254.2
+035600     ADD     1 TO REC-CT.                                         IC2254.2
+035700 CALL-TEST-01-01-2.                                               IC2254.2
+035800     MOVE   "CALL-TEST-01-01-2" TO PAR-NAME.                      IC2254.2
+035900     IF      DN2 = ZERO                                           IC2254.2
+036000             PERFORM PASS                                         IC2254.2
+036100             PERFORM PRINT-DETAIL                                 IC2254.2
+036200     ELSE                                                         IC2254.2
+036300             MOVE    DN2  TO COMPUTED-N                           IC2254.2
+036400             MOVE    ZERO TO CORRECT-N                            IC2254.2
+036500             MOVE   "VALUE OF DN2 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+036600             PERFORM FAIL                                         IC2254.2
+036700             PERFORM PRINT-DETAIL.                                IC2254.2
+036800     ADD     1 TO REC-CT.                                         IC2254.2
+036900 CALL-TEST-01-01-3.                                               IC2254.2
+037000     MOVE   "CALL-TEST-01-01-3" TO PAR-NAME.                      IC2254.2
+037100     IF      DN3 = ZERO                                           IC2254.2
+037200             PERFORM PASS                                         IC2254.2
+037300             PERFORM PRINT-DETAIL                                 IC2254.2
+037400     ELSE                                                         IC2254.2
+037500             MOVE    DN3  TO COMPUTED-N                           IC2254.2
+037600             MOVE    ZERO TO CORRECT-N                            IC2254.2
+037700             MOVE   "INCORRECT DN3 VALUE RETURNED" TO RE-MARK     IC2254.2
+037800             PERFORM FAIL                                         IC2254.2
+037900             PERFORM PRINT-DETAIL.                                IC2254.2
+038000     ADD     1 TO REC-CT.                                         IC2254.2
+038100 CALL-TEST-01-01-4.                                               IC2254.2
+038200     MOVE   "CALL-TEST-01-01-4" TO PAR-NAME.                      IC2254.2
+038300     IF      DN4 = ZERO                                           IC2254.2
+038400             PERFORM PASS                                         IC2254.2
+038500             PERFORM PRINT-DETAIL                                 IC2254.2
+038600     ELSE                                                         IC2254.2
+038700             MOVE    DN4  TO COMPUTED-N                           IC2254.2
+038800             MOVE    ZERO TO CORRECT-N                            IC2254.2
+038900             MOVE   "VALUE OF DN4 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+039000             PERFORM FAIL                                         IC2254.2
+039100             PERFORM PRINT-DETAIL.                                IC2254.2
+039200*                                                                 IC2254.2
+039300 CALL-INIT-01-02.                                                 IC2254.2
+039400     MOVE    1    TO REC-CT.                                      IC2254.2
+039500     MOVE    2    TO DN1, DN2, DN3                                IC2254.2
+039600     MOVE   42    TO DN4.                                         IC2254.2
+039700 CALL-TEST-01-02-0.                                               IC2254.2
+039800     CALL   "IC225A1" USING BY CONTENT   DN1 DN2                  IC2254.2
+039900                                REFERENCE DN3                     IC2254.2
+040000                                CONTENT   DN4                     IC2254.2
+040100     END-CALL.                                                    IC2254.2
+040200     GO TO   CALL-TEST-01-02-1.                                   IC2254.2
+040300 CALL-DELETE-01-02.                                               IC2254.2
+040400     PERFORM DE-LETE.                                             IC2254.2
+040500     PERFORM PRINT-DETAIL.                                        IC2254.2
+040600     GO TO   CALL-INIT-01-03.                                     IC2254.2
+040700 CALL-TEST-01-02-1.                                               IC2254.2
+040800     MOVE   "CALL-TEST-01-02-1" TO PAR-NAME.                      IC2254.2
+040900     IF      DN1 = 2                                              IC2254.2
+041000             PERFORM PASS                                         IC2254.2
+041100             PERFORM PRINT-DETAIL                                 IC2254.2
+041200     ELSE                                                         IC2254.2
+041300             MOVE    DN1  TO COMPUTED-N                           IC2254.2
+041400             MOVE    2    TO CORRECT-N                            IC2254.2
+041500             MOVE   "INCORRECT DN1 VALUE RETURNED" TO RE-MARK     IC2254.2
+041600             PERFORM FAIL                                         IC2254.2
+041700             PERFORM PRINT-DETAIL.                                IC2254.2
+041800     ADD     1 TO REC-CT.                                         IC2254.2
+041900 CALL-TEST-01-02-2.                                               IC2254.2
+042000     MOVE   "CALL-TEST-01-02-2" TO PAR-NAME.                      IC2254.2
+042100     IF      DN2 = 2                                              IC2254.2
+042200             PERFORM PASS                                         IC2254.2
+042300             PERFORM PRINT-DETAIL                                 IC2254.2
+042400     ELSE                                                         IC2254.2
+042500             MOVE    DN2  TO COMPUTED-N                           IC2254.2
+042600             MOVE    2    TO CORRECT-N                            IC2254.2
+042700             MOVE   "VALUE OF DN2 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+042800             PERFORM FAIL                                         IC2254.2
+042900             PERFORM PRINT-DETAIL.                                IC2254.2
+043000     ADD     1 TO REC-CT.                                         IC2254.2
+043100 CALL-TEST-01-02-3.                                               IC2254.2
+043200     MOVE   "CALL-TEST-01-02-3" TO PAR-NAME.                      IC2254.2
+043300     IF      DN3 = 3                                              IC2254.2
+043400             PERFORM PASS                                         IC2254.2
+043500             PERFORM PRINT-DETAIL                                 IC2254.2
+043600     ELSE                                                         IC2254.2
+043700             MOVE    DN3  TO COMPUTED-N                           IC2254.2
+043800             MOVE    3    TO CORRECT-N                            IC2254.2
+043900             MOVE   "INCORRECT DN3 VALUE RETURNED" TO RE-MARK     IC2254.2
+044000             PERFORM FAIL                                         IC2254.2
+044100             PERFORM PRINT-DETAIL.                                IC2254.2
+044200     ADD     1 TO REC-CT.                                         IC2254.2
+044300 CALL-TEST-01-02-4.                                               IC2254.2
+044400     MOVE   "CALL-TEST-01-02-4" TO PAR-NAME.                      IC2254.2
+044500     IF      DN4 = 42                                             IC2254.2
+044600             PERFORM PASS                                         IC2254.2
+044700             PERFORM PRINT-DETAIL                                 IC2254.2
+044800     ELSE                                                         IC2254.2
+044900             MOVE    DN4  TO COMPUTED-N                           IC2254.2
+045000             MOVE    42   TO CORRECT-N                            IC2254.2
+045100             MOVE   "VALUE OF DN4 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+045200             PERFORM FAIL                                         IC2254.2
+045300             PERFORM PRINT-DETAIL.                                IC2254.2
+045400*                                                                 IC2254.2
+045500 CALL-INIT-01-03.                                                 IC2254.2
+045600     MOVE    1    TO REC-CT.                                      IC2254.2
+045700     MOVE    3    TO DN1, DN2, DN3                                IC2254.2
+045800     MOVE   71    TO DN4.                                         IC2254.2
+045900 CALL-TEST-01-03-0.                                               IC2254.2
+046000     CALL   "IC225A1" USING BY CONTENT   DN1                      IC2254.2
+046100                                REFERENCE DN2                     IC2254.2
+046200                                CONTENT   DN3                     IC2254.2
+046300                                REFERENCE DN4                     IC2254.2
+046400     END-CALL.                                                    IC2254.2
+046500     GO TO   CALL-TEST-01-03-1.                                   IC2254.2
+046600 CALL-DELETE-01-03.                                               IC2254.2
+046700     PERFORM DE-LETE.                                             IC2254.2
+046800     PERFORM PRINT-DETAIL.                                        IC2254.2
+046900     GO TO   CALL-TEST-02.                                        IC2254.2
+047000 CALL-TEST-01-03-1.                                               IC2254.2
+047100     MOVE   "CALL-TEST-01-03-1" TO PAR-NAME.                      IC2254.2
+047200     IF      DN1 = 3                                              IC2254.2
+047300             PERFORM PASS                                         IC2254.2
+047400             PERFORM PRINT-DETAIL                                 IC2254.2
+047500     ELSE                                                         IC2254.2
+047600             MOVE    DN1  TO COMPUTED-N                           IC2254.2
+047700             MOVE    3    TO CORRECT-N                            IC2254.2
+047800             MOVE   "VALUE OF DN1 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+047900             PERFORM FAIL                                         IC2254.2
+048000             PERFORM PRINT-DETAIL.                                IC2254.2
+048100     ADD     1 TO REC-CT.                                         IC2254.2
+048200 CALL-TEST-01-03-2.                                               IC2254.2
+048300     MOVE   "CALL-TEST-01-03-2" TO PAR-NAME.                      IC2254.2
+048400     IF      DN2 = 3                                              IC2254.2
+048500             PERFORM PASS                                         IC2254.2
+048600             PERFORM PRINT-DETAIL                                 IC2254.2
+048700     ELSE                                                         IC2254.2
+048800             MOVE    DN2  TO COMPUTED-N                           IC2254.2
+048900             MOVE    3    TO CORRECT-N                            IC2254.2
+049000             MOVE   "INCORRECT DN2 VALUE RETURNED" TO RE-MARK     IC2254.2
+049100             PERFORM FAIL                                         IC2254.2
+049200             PERFORM PRINT-DETAIL.                                IC2254.2
+049300     ADD     1 TO REC-CT.                                         IC2254.2
+049400 CALL-TEST-01-03-3.                                               IC2254.2
+049500     MOVE   "CALL-TEST-01-03-3" TO PAR-NAME.                      IC2254.2
+049600     IF      DN3 = 3                                              IC2254.2
+049700             PERFORM PASS                                         IC2254.2
+049800             PERFORM PRINT-DETAIL                                 IC2254.2
+049900     ELSE                                                         IC2254.2
+050000             MOVE    DN3  TO COMPUTED-N                           IC2254.2
+050100             MOVE    3    TO CORRECT-N                            IC2254.2
+050200             MOVE   "VALUE OF DN3 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+050300             PERFORM FAIL                                         IC2254.2
+050400             PERFORM PRINT-DETAIL.                                IC2254.2
+050500     ADD     1 TO REC-CT.                                         IC2254.2
+050600 CALL-TEST-01-03-4.                                               IC2254.2
+050700     MOVE   "CALL-TEST-01-03-4" TO PAR-NAME.                      IC2254.2
+050800     IF      DN4 = 3                                              IC2254.2
+050900             PERFORM PASS                                         IC2254.2
+051000             PERFORM PRINT-DETAIL                                 IC2254.2
+051100     ELSE                                                         IC2254.2
+051200             MOVE    DN4  TO COMPUTED-N                           IC2254.2
+051300             MOVE    3    TO CORRECT-N                            IC2254.2
+051400             MOVE   "INCORRECT DN4 VALUE RETURNED" TO RE-MARK     IC2254.2
+051500             PERFORM FAIL                                         IC2254.2
+051600             PERFORM PRINT-DETAIL.                                IC2254.2
+051700*                                                                 IC2254.2
+051800 CALL-TEST-02.                                                    IC2254.2
+051900     MOVE   "DATA-NAME USED TWICE" TO FEATURE.                    IC2254.2
+052000*            THIS TEST USES A DATA-NAME MORE THAN ONCE IN         IC2254.2
+052100*            A USING PHRASE OF A CALL STATEMENT.                  IC2254.2
+052200 CALL-INIT-02-01.                                                 IC2254.2
+052300     MOVE    1 TO REC-CT.                                         IC2254.2
+052400     MOVE    1 TO DN1.                                            IC2254.2
+052500     MOVE    0 TO DN2, DN3, DN4.                                  IC2254.2
+052600 CALL-TEST-02-01-0.                                               IC2254.2
+052700     CALL   "IC225A1" USING REFERENCE DN1,                        IC2254.2
+052800                             CONTENT   DN2,                       IC2254.2
+052900                             REFERENCE DN1, DN4,                  IC2254.2
+053000     END-CALL.                                                    IC2254.2
+053100     GO TO   CALL-TEST-02-01-1.                                   IC2254.2
+053200 CALL-DELETE-02-01.                                               IC2254.2
+053300     PERFORM DE-LETE.                                             IC2254.2
+053400     PERFORM PRINT-DETAIL.                                        IC2254.2
+053500     GO TO   CALL-INIT-02-02.                                     IC2254.2
+053600 CALL-TEST-02-01-1.                                               IC2254.2
+053700     MOVE   "CALL-TEST-02-01-1" TO PAR-NAME.                      IC2254.2
+053800     IF      DN1 = 2                                              IC2254.2
+053900             PERFORM PASS                                         IC2254.2
+054000             PERFORM PRINT-DETAIL                                 IC2254.2
+054100     ELSE                                                         IC2254.2
+054200             MOVE    DN1  TO COMPUTED-N                           IC2254.2
+054300             MOVE    2    TO CORRECT-N                            IC2254.2
+054400             MOVE   "INCORRECT DN1 VALUE RETURNED" TO RE-MARK     IC2254.2
+054500             PERFORM FAIL                                         IC2254.2
+054600             PERFORM PRINT-DETAIL.                                IC2254.2
+054700     ADD     1 TO REC-CT.                                         IC2254.2
+054800 CALL-TEST-02-01-2.                                               IC2254.2
+054900     MOVE   "CALL-TEST-02-01-2" TO PAR-NAME.                      IC2254.2
+055000     IF      DN2 = 0                                              IC2254.2
+055100             PERFORM PASS                                         IC2254.2
+055200             PERFORM PRINT-DETAIL                                 IC2254.2
+055300     ELSE                                                         IC2254.2
+055400             MOVE    DN2  TO COMPUTED-N                           IC2254.2
+055500             MOVE    ZERO TO CORRECT-N                            IC2254.2
+055600             MOVE   "VALUE OF DN2 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+055700             PERFORM FAIL                                         IC2254.2
+055800             PERFORM PRINT-DETAIL.                                IC2254.2
+055900     ADD     1 TO REC-CT.                                         IC2254.2
+056000 CALL-TEST-02-01-3.                                               IC2254.2
+056100     MOVE   "CALL-TEST-02-01-3" TO PAR-NAME.                      IC2254.2
+056200     IF      DN3 = 0                                              IC2254.2
+056300             PERFORM PASS                                         IC2254.2
+056400             PERFORM PRINT-DETAIL                                 IC2254.2
+056500     ELSE                                                         IC2254.2
+056600             MOVE    DN3  TO COMPUTED-N                           IC2254.2
+056700             MOVE    ZERO TO CORRECT-N                            IC2254.2
+056800             MOVE   "VALUE OF DN3 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+056900             PERFORM FAIL                                         IC2254.2
+057000             PERFORM PRINT-DETAIL.                                IC2254.2
+057100     ADD     1 TO REC-CT.                                         IC2254.2
+057200 CALL-TEST-02-01-4.                                               IC2254.2
+057300     MOVE   "CALL-TEST-02-01-4" TO PAR-NAME.                      IC2254.2
+057400     IF      DN4 = 4                                              IC2254.2
+057500             PERFORM PASS                                         IC2254.2
+057600             PERFORM PRINT-DETAIL                                 IC2254.2
+057700     ELSE                                                         IC2254.2
+057800             MOVE    DN4  TO COMPUTED-N                           IC2254.2
+057900             MOVE    4    TO CORRECT-N                            IC2254.2
+058000             MOVE   "INCORRECT DN4 VALUE RETURNED" TO RE-MARK     IC2254.2
+058100             PERFORM FAIL                                         IC2254.2
+058200             PERFORM PRINT-DETAIL.                                IC2254.2
+058300*                                                                 IC2254.2
+058400 CALL-INIT-02-02.                                                 IC2254.2
+058500     MOVE 1 TO REC-CT.                                            IC2254.2
+058600     MOVE 0 TO DN4, DN3, DN2, DN1.                                IC2254.2
+058700 CALL-TEST-02-02-0.                                               IC2254.2
+058800     CALL ID1 USING BY REFERENCE DN1                              IC2254.2
+058900                       CONTENT   DN2 DN3 DN2                      IC2254.2
+059000     END-CALL.                                                    IC2254.2
+059100     GO TO   CALL-TEST-02-02-1.                                   IC2254.2
+059200 CALL-DELETE-02-02.                                               IC2254.2
+059300     PERFORM DE-LETE.                                             IC2254.2
+059400     PERFORM PRINT-DETAIL.                                        IC2254.2
+059500     GO TO   CALL-INIT-02-03.                                     IC2254.2
+059600 CALL-TEST-02-02-1.                                               IC2254.2
+059700     MOVE   "CALL-TEST-02-02-1" TO PAR-NAME.                      IC2254.2
+059800     IF      DN1 = 0                                              IC2254.2
+059900             PERFORM PASS                                         IC2254.2
+060000             PERFORM PRINT-DETAIL                                 IC2254.2
+060100     ELSE                                                         IC2254.2
+060200             MOVE    DN1  TO COMPUTED-N                           IC2254.2
+060300             MOVE    ZERO TO CORRECT-N                            IC2254.2
+060400             MOVE   "INCORRECT DN1 VALUE RETURNED" TO RE-MARK     IC2254.2
+060500             PERFORM FAIL                                         IC2254.2
+060600             PERFORM PRINT-DETAIL.                                IC2254.2
+060700     ADD     1 TO REC-CT.                                         IC2254.2
+060800 CALL-TEST-02-02-2.                                               IC2254.2
+060900     MOVE   "CALL-TEST-02-02-2" TO PAR-NAME.                      IC2254.2
+061000     IF      DN2 = 0                                              IC2254.2
+061100             PERFORM PASS                                         IC2254.2
+061200             PERFORM PRINT-DETAIL                                 IC2254.2
+061300     ELSE                                                         IC2254.2
+061400             MOVE    DN2  TO COMPUTED-N                           IC2254.2
+061500             MOVE    ZERO TO CORRECT-N                            IC2254.2
+061600             MOVE   "VALUE OF DN2 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+061700             PERFORM FAIL                                         IC2254.2
+061800             PERFORM PRINT-DETAIL.                                IC2254.2
+061900     ADD     1 TO REC-CT.                                         IC2254.2
+062000 CALL-TEST-02-02-3.                                               IC2254.2
+062100     MOVE   "CALL-TEST-02-02-3" TO PAR-NAME.                      IC2254.2
+062200     IF      DN3 = 0                                              IC2254.2
+062300             PERFORM PASS                                         IC2254.2
+062400             PERFORM PRINT-DETAIL                                 IC2254.2
+062500     ELSE                                                         IC2254.2
+062600             MOVE    DN3  TO COMPUTED-N                           IC2254.2
+062700             MOVE    ZERO TO CORRECT-N                            IC2254.2
+062800             MOVE   "VALUE OF DN3 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+062900             PERFORM FAIL                                         IC2254.2
+063000             PERFORM PRINT-DETAIL.                                IC2254.2
+063100     ADD     1 TO REC-CT.                                         IC2254.2
+063200 CALL-TEST-02-02-4.                                               IC2254.2
+063300     MOVE   "CALL-TEST-02-02-4" TO PAR-NAME.                      IC2254.2
+063400     IF      DN4 = ZERO                                           IC2254.2
+063500             PERFORM PASS                                         IC2254.2
+063600             PERFORM PRINT-DETAIL                                 IC2254.2
+063700     ELSE                                                         IC2254.2
+063800             MOVE    DN4  TO COMPUTED-N                           IC2254.2
+063900             MOVE    ZERO TO CORRECT-N                            IC2254.2
+064000             MOVE   "VALUE OF DN4 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+064100             PERFORM FAIL                                         IC2254.2
+064200             PERFORM PRINT-DETAIL.                                IC2254.2
+064300*                                                                 IC2254.2
+064400 CALL-INIT-02-03.                                                 IC2254.2
+064500     MOVE 1 TO REC-CT.                                            IC2254.2
+064600     MOVE 0 TO DN4, DN3.                                          IC2254.2
+064700     MOVE 10 TO DN2.                                              IC2254.2
+064800     MOVE 25 TO DN1.                                              IC2254.2
+064900 CALL-TEST-02-03-0.                                               IC2254.2
+065000     CALL ID1 USING CONTENT   DN1                                 IC2254.2
+065100                    REFERENCE DN2 DN1                             IC2254.2
+065200                    REFERENCE DN2                                 IC2254.2
+065300     END-CALL.                                                    IC2254.2
+065400     GO TO   CALL-TEST-02-03-1.                                   IC2254.2
+065500 CALL-DELETE-02-03.                                               IC2254.2
+065600     PERFORM DE-LETE.                                             IC2254.2
+065700     PERFORM PRINT-DETAIL.                                        IC2254.2
+065800     GO TO   CALL-INIT-03-01.                                     IC2254.2
+065900 CALL-TEST-02-03-1.                                               IC2254.2
+066000     MOVE   "CALL-TEST-02-03-1" TO PAR-NAME.                      IC2254.2
+066100     IF      DN1 = 26                                             IC2254.2
+066200             PERFORM PASS                                         IC2254.2
+066300             PERFORM PRINT-DETAIL                                 IC2254.2
+066400     ELSE                                                         IC2254.2
+066500             MOVE    DN1  TO COMPUTED-N                           IC2254.2
+066600             MOVE    26   TO CORRECT-N                            IC2254.2
+066700             MOVE   "INCORRECT VALUE RETURNED     " TO RE-MARK    IC2254.2
+066800             PERFORM FAIL                                         IC2254.2
+066900             PERFORM PRINT-DETAIL.                                IC2254.2
+067000     ADD     1 TO REC-CT.                                         IC2254.2
+067100 CALL-TEST-02-03-2.                                               IC2254.2
+067200     MOVE   "CALL-TEST-02-03-2" TO PAR-NAME.                      IC2254.2
+067300     IF      DN2 = 6                                              IC2254.2
+067400             PERFORM PASS                                         IC2254.2
+067500             PERFORM PRINT-DETAIL                                 IC2254.2
+067600     ELSE                                                         IC2254.2
+067700             MOVE    DN2  TO COMPUTED-N                           IC2254.2
+067800             MOVE    6    TO CORRECT-N                            IC2254.2
+067900             MOVE   "INCORRECT DN2 VALUE RETURNED" TO RE-MARK     IC2254.2
+068000             PERFORM FAIL                                         IC2254.2
+068100             PERFORM PRINT-DETAIL.                                IC2254.2
+068200     ADD     1 TO REC-CT.                                         IC2254.2
+068300 CALL-TEST-02-03-3.                                               IC2254.2
+068400     MOVE   "CALL-TEST-02-03-3" TO PAR-NAME.                      IC2254.2
+068500     IF      DN3 = 0                                              IC2254.2
+068600             PERFORM PASS                                         IC2254.2
+068700             PERFORM PRINT-DETAIL                                 IC2254.2
+068800     ELSE                                                         IC2254.2
+068900             MOVE    DN3  TO COMPUTED-N                           IC2254.2
+069000             MOVE    ZERO TO CORRECT-N                            IC2254.2
+069100             MOVE   "VALUE OF DN3 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+069200             PERFORM FAIL                                         IC2254.2
+069300             PERFORM PRINT-DETAIL.                                IC2254.2
+069400     ADD     1 TO REC-CT.                                         IC2254.2
+069500 CALL-TEST-02-03-4.                                               IC2254.2
+069600     MOVE   "CALL-TEST-02-03-4" TO PAR-NAME.                      IC2254.2
+069700     IF      DN4 = ZERO                                           IC2254.2
+069800             PERFORM PASS                                         IC2254.2
+069900             PERFORM PRINT-DETAIL                                 IC2254.2
+070000     ELSE                                                         IC2254.2
+070100             MOVE    DN4  TO COMPUTED-N                           IC2254.2
+070200             MOVE    ZERO TO CORRECT-N                            IC2254.2
+070300             MOVE   "VALUE OF DN4 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+070400             PERFORM FAIL                                         IC2254.2
+070500             PERFORM PRINT-DETAIL.                                IC2254.2
+070600*                                                                 IC2254.2
+070700 CALL-TEST-03.                                                    IC2254.2
+070800*    THIS TEST USES THE ON OVERFLOW PHRASE IN THE CALL            IC2254.2
+070900*    STATEMENT.  THIS IS A SYNTACTICAL CHECK ONLY, THE            IC2254.2
+071000*    ON OVERFLOW CONDITION SHOULD NEVER OCCUR.                    IC2254.2
+071100     MOVE "CALL-TEST-03" TO PAR-NAME.                             IC2254.2
+071200     MOVE "ON OVERFLOW PHRASE" TO FEATURE.                        IC2254.2
+071300 CALL-INIT-03-01.                                                 IC2254.2
+071400     MOVE    1  TO REC-CT.                                        IC2254.2
+071500     MOVE    6  TO CALL-COUNT.                                    IC2254.2
+071600     MOVE    20 TO DN1.                                           IC2254.2
+071700     MOVE 30 TO DN2.                                              IC2254.2
+071800     MOVE ZERO TO DN3, DN4.                                       IC2254.2
+071900 CALL-TEST-03-01-0.                                               IC2254.2
+072000     MOVE   "CALL-TEST-03-01-0" TO PAR-NAME.                      IC2254.2
+072100     CALL "IC225A1" USING BY CONTENT   DN1, DN2,                  IC2254.2
+072200                              REFERENCE DN3, DN4;                 IC2254.2
+072300         ON OVERFLOW MOVE "OVERFLOW SHOULD NOT OCCUR" TO RE-MARK  IC2254.2
+072400                     PERFORM FAIL                                 IC2254.2
+072500                     PERFORM PRINT-DETAIL.                        IC2254.2
+072600     GO TO   CALL-TEST-03-01-1.                                   IC2254.2
+072700 CALL-DELETE-03-01.                                               IC2254.2
+072800     PERFORM DE-LETE.                                             IC2254.2
+072900     PERFORM PRINT-DETAIL.                                        IC2254.2
+073000     GO TO   CALL-INIT-03-02.                                     IC2254.2
+073100 CALL-TEST-03-01-1.                                               IC2254.2
+073200     MOVE   "CALL-TEST-03-01-1" TO PAR-NAME.                      IC2254.2
+073300     IF      DN1 = 20                                             IC2254.2
+073400             PERFORM PASS                                         IC2254.2
+073500             PERFORM PRINT-DETAIL                                 IC2254.2
+073600     ELSE                                                         IC2254.2
+073700             MOVE    DN1  TO COMPUTED-N                           IC2254.2
+073800             MOVE    20   TO CORRECT-N                            IC2254.2
+073900             MOVE   "VALUE OF DN1 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+074000             PERFORM FAIL                                         IC2254.2
+074100             PERFORM PRINT-DETAIL.                                IC2254.2
+074200     ADD     1 TO REC-CT.                                         IC2254.2
+074300 CALL-TEST-03-01-2.                                               IC2254.2
+074400     MOVE   "CALL-TEST-03-01-2" TO PAR-NAME.                      IC2254.2
+074500     IF      DN2 = 30                                             IC2254.2
+074600             PERFORM PASS                                         IC2254.2
+074700             PERFORM PRINT-DETAIL                                 IC2254.2
+074800     ELSE                                                         IC2254.2
+074900             MOVE    DN2  TO COMPUTED-N                           IC2254.2
+075000             MOVE    30   TO CORRECT-N                            IC2254.2
+075100             MOVE   "VALUE OF DN2 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+075200             PERFORM FAIL                                         IC2254.2
+075300             PERFORM PRINT-DETAIL.                                IC2254.2
+075400     ADD     1 TO REC-CT.                                         IC2254.2
+075500 CALL-TEST-03-01-3.                                               IC2254.2
+075600     MOVE   "CALL-TEST-03-01-3" TO PAR-NAME.                      IC2254.2
+075700     IF      DN3 = 21                                             IC2254.2
+075800             PERFORM PASS                                         IC2254.2
+075900             PERFORM PRINT-DETAIL                                 IC2254.2
+076000     ELSE                                                         IC2254.2
+076100             MOVE    DN3  TO COMPUTED-N                           IC2254.2
+076200             MOVE    21   TO CORRECT-N                            IC2254.2
+076300             MOVE   "INCORRECT DN3 VALUE RETURNED" TO RE-MARK     IC2254.2
+076400             PERFORM FAIL                                         IC2254.2
+076500             PERFORM PRINT-DETAIL.                                IC2254.2
+076600     ADD     1 TO REC-CT.                                         IC2254.2
+076700 CALL-TEST-03-01-4.                                               IC2254.2
+076800     MOVE   "CALL-TEST-03-01-4" TO PAR-NAME.                      IC2254.2
+076900     IF      DN4 = 7                                              IC2254.2
+077000             PERFORM PASS                                         IC2254.2
+077100             PERFORM PRINT-DETAIL                                 IC2254.2
+077200     ELSE                                                         IC2254.2
+077300             MOVE    DN4  TO COMPUTED-N                           IC2254.2
+077400             MOVE    7    TO CORRECT-N                            IC2254.2
+077500             MOVE   "INCORRECT DN4 VALUE RETURNED" TO RE-MARK     IC2254.2
+077600             PERFORM FAIL                                         IC2254.2
+077700             PERFORM PRINT-DETAIL.                                IC2254.2
+077800*                                                                 IC2254.2
+077900 CALL-INIT-03-02.                                                 IC2254.2
+078000     MOVE   "CALL-TEST-03-02-0" TO PAR-NAME.                      IC2254.2
+078100     MOVE    0 TO DN3, DN4.                                       IC2254.2
+078200     MOVE    1 TO REC-CT.                                         IC2254.2
+078300 CALL-TEST-03-02-0.                                               IC2254.2
+078400     CALL "IC225A1" USING REFERENCE DN1,                          IC2254.2
+078500                           CONTENT   DN2,                         IC2254.2
+078600                           REFERENCE DN3,                         IC2254.2
+078700                           CONTENT   DN4,                         IC2254.2
+078800         OVERFLOW MOVE "OVERFLOW SHOULD NOT OCCUR" TO RE-MARK     IC2254.2
+078900                     PERFORM FAIL                                 IC2254.2
+079000                     PERFORM PRINT-DETAIL.                        IC2254.2
+079100     GO TO   CALL-TEST-03-02-1.                                   IC2254.2
+079200 CALL-DELETE-03-02.                                               IC2254.2
+079300     PERFORM DE-LETE.                                             IC2254.2
+079400     PERFORM PRINT-DETAIL.                                        IC2254.2
+079500     GO TO   CALL-INIT-03-03.                                     IC2254.2
+079600 CALL-TEST-03-02-1.                                               IC2254.2
+079700     MOVE   "CALL-TEST-03-02-1" TO PAR-NAME.                      IC2254.2
+079800     IF      DN1 = 20                                             IC2254.2
+079900             PERFORM PASS                                         IC2254.2
+080000             PERFORM PRINT-DETAIL                                 IC2254.2
+080100     ELSE                                                         IC2254.2
+080200             MOVE    DN1  TO COMPUTED-N                           IC2254.2
+080300             MOVE    20   TO CORRECT-N                            IC2254.2
+080400             MOVE   "VALUE OF DN1 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+080500             PERFORM FAIL                                         IC2254.2
+080600             PERFORM PRINT-DETAIL.                                IC2254.2
+080700     ADD     1 TO REC-CT.                                         IC2254.2
+080800 CALL-TEST-03-02-2.                                               IC2254.2
+080900     MOVE   "CALL-TEST-03-02-2" TO PAR-NAME.                      IC2254.2
+081000     IF      DN2 = 30                                             IC2254.2
+081100             PERFORM PASS                                         IC2254.2
+081200             PERFORM PRINT-DETAIL                                 IC2254.2
+081300     ELSE                                                         IC2254.2
+081400             MOVE    DN2  TO COMPUTED-N                           IC2254.2
+081500             MOVE    30   TO CORRECT-N                            IC2254.2
+081600             MOVE   "VALUE OF DN2 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+081700             PERFORM FAIL                                         IC2254.2
+081800             PERFORM PRINT-DETAIL.                                IC2254.2
+081900     ADD     1 TO REC-CT.                                         IC2254.2
+082000 CALL-TEST-03-02-3.                                               IC2254.2
+082100     MOVE   "CALL-TEST-03-02-3" TO PAR-NAME.                      IC2254.2
+082200     IF      DN3 = 21                                             IC2254.2
+082300             PERFORM PASS                                         IC2254.2
+082400             PERFORM PRINT-DETAIL                                 IC2254.2
+082500     ELSE                                                         IC2254.2
+082600             MOVE    DN3  TO COMPUTED-N                           IC2254.2
+082700             MOVE    21   TO CORRECT-N                            IC2254.2
+082800             MOVE   "INCORRECT DN3 VALUE RETURNED" TO RE-MARK     IC2254.2
+082900             PERFORM FAIL                                         IC2254.2
+083000             PERFORM PRINT-DETAIL.                                IC2254.2
+083100     ADD     1 TO REC-CT.                                         IC2254.2
+083200 CALL-TEST-03-02-4.                                               IC2254.2
+083300     MOVE   "CALL-TEST-03-02-4" TO PAR-NAME.                      IC2254.2
+083400     IF      DN4 = 0                                              IC2254.2
+083500             PERFORM PASS                                         IC2254.2
+083600             PERFORM PRINT-DETAIL                                 IC2254.2
+083700     ELSE                                                         IC2254.2
+083800             MOVE    DN4  TO COMPUTED-N                           IC2254.2
+083900             MOVE    ZERO TO CORRECT-N                            IC2254.2
+084000             MOVE   "VALUE OF DN4 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+084100             PERFORM FAIL                                         IC2254.2
+084200             PERFORM PRINT-DETAIL.                                IC2254.2
+084300*                                                                 IC2254.2
+084400 CALL-INIT-03-03.                                                 IC2254.2
+084500     MOVE   "CALL-TEST-03-03-0" TO PAR-NAME.                      IC2254.2
+084600     MOVE    0 TO DN3, DN4.                                       IC2254.2
+084700     MOVE    1 TO REC-CT.                                         IC2254.2
+084800 CALL-TEST-03-03-0.                                               IC2254.2
+084900     CALL ID1 USING BY CONTENT DN1                                IC2254.2
+085000                       REFERENCE DN2 DN3 DN4                      IC2254.2
+085100         ON OVERFLOW MOVE "OVERFLOW SHOULD NOT OCCUR" TO RE-MARK  IC2254.2
+085200             PERFORM FAIL                                         IC2254.2
+085300             PERFORM PRINT-DETAIL.                                IC2254.2
+085400     GO TO   CALL-TEST-03-03-1.                                   IC2254.2
+085500 CALL-DELETE-03-03.                                               IC2254.2
+085600     PERFORM DE-LETE.                                             IC2254.2
+085700     PERFORM PRINT-DETAIL.                                        IC2254.2
+085800     GO TO   CALL-INIT-03-03.                                     IC2254.2
+085900 CALL-TEST-03-03-1.                                               IC2254.2
+086000     MOVE   "CALL-TEST-03-03-1" TO PAR-NAME.                      IC2254.2
+086100     IF      DN1 = 20                                             IC2254.2
+086200             PERFORM PASS                                         IC2254.2
+086300             PERFORM PRINT-DETAIL                                 IC2254.2
+086400     ELSE                                                         IC2254.2
+086500             MOVE    DN1  TO COMPUTED-N                           IC2254.2
+086600             MOVE    20   TO CORRECT-N                            IC2254.2
+086700             MOVE   "VALUE OF DN1 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+086800             PERFORM FAIL                                         IC2254.2
+086900             PERFORM PRINT-DETAIL.                                IC2254.2
+087000     ADD     1 TO REC-CT.                                         IC2254.2
+087100 CALL-TEST-03-03-2.                                               IC2254.2
+087200     MOVE   "CALL-TEST-03-03-2" TO PAR-NAME.                      IC2254.2
+087300     IF      DN2 = 30                                             IC2254.2
+087400             PERFORM PASS                                         IC2254.2
+087500             PERFORM PRINT-DETAIL                                 IC2254.2
+087600     ELSE                                                         IC2254.2
+087700             MOVE    DN2  TO COMPUTED-N                           IC2254.2
+087800             MOVE    30   TO CORRECT-N                            IC2254.2
+087900             MOVE   "VALUE OF DN2 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+088000             PERFORM FAIL                                         IC2254.2
+088100             PERFORM PRINT-DETAIL.                                IC2254.2
+088200     ADD     1 TO REC-CT.                                         IC2254.2
+088300 CALL-TEST-03-03-3.                                               IC2254.2
+088400     MOVE   "CALL-TEST-03-03-3" TO PAR-NAME.                      IC2254.2
+088500     IF      DN3 = 21                                             IC2254.2
+088600             PERFORM PASS                                         IC2254.2
+088700             PERFORM PRINT-DETAIL                                 IC2254.2
+088800     ELSE                                                         IC2254.2
+088900             MOVE    DN3  TO COMPUTED-N                           IC2254.2
+089000             MOVE    21   TO CORRECT-N                            IC2254.2
+089100             MOVE   "INCORRECT DN3 VALUE RETURNED" TO RE-MARK     IC2254.2
+089200             PERFORM FAIL                                         IC2254.2
+089300             PERFORM PRINT-DETAIL.                                IC2254.2
+089400     ADD     1 TO REC-CT.                                         IC2254.2
+089500 CALL-TEST-03-03-4.                                               IC2254.2
+089600     MOVE   "CALL-TEST-03-03-4" TO PAR-NAME.                      IC2254.2
+089700     IF      DN4 = 9                                              IC2254.2
+089800             PERFORM PASS                                         IC2254.2
+089900             PERFORM PRINT-DETAIL                                 IC2254.2
+090000     ELSE                                                         IC2254.2
+090100             MOVE    DN4  TO COMPUTED-N                           IC2254.2
+090200             MOVE    9    TO CORRECT-N                            IC2254.2
+090300             MOVE   "VALUE OF DN4 HAS BEEN CHANGED" TO RE-MARK    IC2254.2
+090400             PERFORM FAIL                                         IC2254.2
+090500             PERFORM PRINT-DETAIL.                                IC2254.2
+090600*                                                                 IC2254.2
+090700     GO TO EXIT-IC225A.                                           IC2254.2
+090800*                                                                 IC2254.2
+090900 CALL-DELETE-03.                                                  IC2254.2
+091000*        IF THE ON OVERFLOW PHRASE IS NOT RECOGNIZED, DELETE ALL  IC2254.2
+091100*    OF THE ABOVE CALL-TEST-03 PARAGRAPHS, STARTING WITH          IC2254.2
+091200*    CALL-TEST-03-01.                                             IC2254.2
+091300     PERFORM DE-LETE.                                             IC2254.2
+091400     PERFORM PRINT-DETAIL.                                        IC2254.2
+091500 EXIT-IC225A.                                                     IC2254.2
+091600     GO TO CCVS-EXIT.                                             IC2254.2
+091700 SECT-IC225A-002 SECTION.                                         IC2254.2
+091800 CHECK-TEST-03.                                                   IC2254.2
+091900     MOVE ZERO TO FAIL-FLAG.                                      IC2254.2
+092000     ADD 1 TO CALL-COUNT.                                         IC2254.2
+092100     IF DN4 NOT EQUAL TO CALL-COUNT                               IC2254.2
+092200         ADD 1 TO FAIL-FLAG.                                      IC2254.2
+092300     IF DN3 NOT EQUAL TO 21                                       IC2254.2
+092400         ADD 1 TO FAIL-FLAG.                                      IC2254.2
+092500     IF DN2 NOT EQUAL TO 30                                       IC2254.2
+092600         ADD 1 TO FAIL-FLAG.                                      IC2254.2
+092700     IF DN1 NOT EQUAL TO 20                                       IC2254.2
+092800         ADD 1 TO FAIL-FLAG.                                      IC2254.2
+092900 CCVS-EXIT SECTION.                                               IC2254.2
+093000 CCVS-999999.                                                     IC2254.2
+093100     GO TO CLOSE-FILES.                                           IC2254.2
+093200 END PROGRAM IC225A.                                              IC2254.2

--- a/z390/IC225A1.CBL
+++ b/z390/IC225A1.CBL
@@ -1,0 +1,128 @@
+093300 IDENTIFICATION DIVISION.                                         IC2254.2
+      *
+      * This is the z390 version of IC225A-1
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC225A1
+      * IC225A has been modified to call IC225A1 instead of IC225A-1.
+      *
+093400 PROGRAM-ID.                                                      IC2254.2
+093500     IC225A1.                                                     IC2254.2
+093600****************************************************************  IC2254.2
+093700*                                                              *  IC2254.2
+093800*    THIS PROGRAM FORMS PART OF THE COBOL COMPILER VALIDATION  *  IC2254.2
+093900*    SYSTEM (CCVS) USED TO TEST COBOL COMPILERS FOR            *  IC2254.2
+094000*    CONFORMANCE WITH THE AMERICAN NATIONAL STANDARD           *  IC2254.2
+094100*    (ANSI DOCUMENT REFERENCE: X3.23-1985) AND THE STANDARD OF *  IC2254.2
+094200*    THE INTERNATIONAL ORGANIZATION FOR STANDARDISATION        *  IC2254.2
+094300*    (ISO DOCUMENT REFERENCE: ISO-1989-1985).                  *  IC2254.2
+094400*                                                              *  IC2254.2
+094500*    THIS CCVS INCORPORATES ENHANCEMENTS TO THE CCVS FOR THE   *  IC2254.2
+094600*    1974 STANDARD (ANSI DOCUMENT REFERENCE: X3.23-1974; ISO   *  IC2254.2
+094700*    DOCUMENT REFERENCE: ISO-1989-1978).                       *  IC2254.2
+094800*                                                              *  IC2254.2
+094900*    THESE ENHANCEMENTS WERE SPECIFIED BY A PROJECT TEAM WHICH *  IC2254.2
+095000*    WAS FUNDED BY THE COMMISSION FOR EUROPEAN COMMUNITIES AND *  IC2254.2
+095100*    WHICH WAS RESPONSIBLE FOR TECHNICAL ISSUES TO:            *  IC2254.2
+095200*                                                              *  IC2254.2
+095300*          THE FEDERAL SOFTWARE TESTING CENTER                 *  IC2254.2
+095400*          OFFICE OF SOFTWARE DEVELOPMENT                      *  IC2254.2
+095500*                & INFORMATION TECHNOLOGY                      *  IC2254.2
+095600*          TWO SKYLINE PLACE                                   *  IC2254.2
+095700*          SUITE 1100                                          *  IC2254.2
+095800*          5203 LEESBURG PIKE                                  *  IC2254.2
+095900*          FALLS CHURCH                                        *  IC2254.2
+096000*          VA 22041                                            *  IC2254.2
+096100*          U.S.A.                                              *  IC2254.2
+096200*                                                              *  IC2254.2
+096300*    THE PROJECT TEAM MEMBERS WERE:                            *  IC2254.2
+096400*                                                              *  IC2254.2
+096500*          BIADI (BUREAU INTER ADMINISTRATION                  *  IC2254.2
+096600*                 DE DOCUMENTATION INFORMATIQUE)               *  IC2254.2
+096700*          21 RUE BARA                                         *  IC2254.2
+096800*          F-92132 ISSY                                        *  IC2254.2
+096900*          FRANCE                                              *  IC2254.2
+097000*                                                              *  IC2254.2
+097100*                                                              *  IC2254.2
+097200*          GMD (GESELLSCHAFT FUR MATHEMATIK                    *  IC2254.2
+097300*               UND DATENVERARBEITUNG MBH)                     *  IC2254.2
+097400*          SCHLOSS BIRLINGHOVEN                                *  IC2254.2
+097500*          POSTFACH 12 40                                      *  IC2254.2
+097600*          D-5205 ST. AUGUSTIN 1                               *  IC2254.2
+097700*          GERMANY FR                                          *  IC2254.2
+097800*                                                              *  IC2254.2
+097900*                                                              *  IC2254.2
+098000*          NCC (THE NATIONAL COMPUTING CENTRE LTD)             *  IC2254.2
+098100*          OXFORD ROAD                                         *  IC2254.2
+098200*          MANCHESTER                                          *  IC2254.2
+098300*          M1 7ED                                              *  IC2254.2
+098400*          UNITED KINGDOM                                      *  IC2254.2
+098500*                                                              *  IC2254.2
+098600*                                                              *  IC2254.2
+098700*    THIS TEST SUITE WAS PRODUCED BY THE NATIONAL COMPUTING    *  IC2254.2
+098800*    CENTRE IN ENGLAND AND IS THE OFFICIAL CCVS TEST SUITE     *  IC2254.2
+098900*    USED THROUGHOUT EUROPE AND THE UNITED STATES OF AMERICA.  *  IC2254.2
+099000*                                                              *  IC2254.2
+099100****************************************************************  IC2254.2
+099200*                                                              *  IC2254.2
+099300*    VALIDATION FOR:-                                          *  IC2254.2
+099400*                                                              *  IC2254.2
+099500*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2254.2
+099600*                                                              *  IC2254.2
+099700*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2254.2
+099800*                                                              *  IC2254.2
+099900****************************************************************  IC2254.2
+100000*                                                              *  IC2254.2
+100100*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2254.2
+100200*                                                              *  IC2254.2
+100300*        X-55  - SYSTEM PRINTER NAME.                          *  IC2254.2
+100400*        X-82  - SOURCE COMPUTER NAME.                         *  IC2254.2
+100500*        X-83  - OBJECT COMPUTER NAME.                         *  IC2254.2
+100600*                                                              *  IC2254.2
+100700****************************************************************  IC2254.2
+100800*                                                              *  IC2254.2
+100900*    PROGRAM IC225A AND IC225A-1 WILL TEST THE NEW LANGUAGE    *  IC2254.2
+101000*    ELEMENTS FOR THE LEVEL 2 INTER-PROGRAM COMMUNICATION      *  IC2254.2
+101100*    MODULE.                                                   *  IC2254.2
+101200*    THE NEW LANGUAGE ELEMENTS TO BE TESTED WILL BE:           *  IC2254.2
+101300*          "BY REFERENCE"     PHRASE                           *  IC2254.2
+101400*    THE TWO PROGRAMS WILL BE COMPILED IN THE SAME FLOW        *  IC2254.2
+101500*    (TO TEST THE "END PROGRAM" STATEMENT) AS SHOWN BELOW:     *  IC2254.2
+101600*    IDENTIFICATION DIVISION.                                  *  IC2254.2
+101700*    PROGRAM-ID. IC225A.                                       *  IC2254.2
+101800*              .                                               *  IC2254.2
+101900*              .                                               *  IC2254.2
+102000*              .                                               *  IC2254.2
+102100*    END PROGRAM IC225A.                                       *  IC2254.2
+102200*    PROGRAM-ID. IC225A-1.                                     *  IC2254.2
+102300*              .                                               *  IC2254.2
+102400*              .                                               *  IC2254.2
+102500*              .                                               *  IC2254.2
+102600****************************************************************  IC2254.2
+102700 ENVIRONMENT DIVISION.                                            IC2254.2
+102800 CONFIGURATION SECTION.                                           IC2254.2
+102900 SOURCE-COMPUTER.                                                 IC2254.2
+103000     XXXXX082.                                                    IC2254.2
+103100 OBJECT-COMPUTER.                                                 IC2254.2
+103200     XXXXX083.                                                    IC2254.2
+103300*INPUT-OUTPUT SECTION.                                            IC2254.2
+103400 DATA DIVISION.                                                   IC2254.2
+103500 FILE SECTION.                                                    IC2254.2
+103600 WORKING-STORAGE SECTION.                                         IC2254.2
+103700 77  WS1 PICTURE S999.                                            IC2254.2
+103800 77  WS2 PICTURE S999                                             IC2254.2
+103900         USAGE COMPUTATIONAL, VALUE ZERO.                         IC2254.2
+104000 LINKAGE SECTION.                                                 IC2254.2
+104100 77  DN1 PICTURE S99.                                             IC2254.2
+104200 77  DN2 PICTURE S99 USAGE COMPUTATIONAL.                         IC2254.2
+104300 77  DN3 PICTURE S99.                                             IC2254.2
+104400 77  DN4 PICTURE S99 USAGE COMPUTATIONAL.                         IC2254.2
+104500 PROCEDURE DIVISION USING DN1, DN2, DN3, DN4.                     IC2254.2
+104600 SECT-IC225A-1-001 SECTION.                                       IC2254.2
+104700 CALL-TEST-001.                                                   IC2254.2
+104800     MOVE DN1 TO WS1.                                             IC2254.2
+104900     ADD 1 TO WS1.                                                IC2254.2
+105000     ADD 1 TO WS2.                                                IC2254.2
+105100     MOVE WS1 TO DN3.                                             IC2254.2
+105200     MOVE WS2 TO DN4.                                             IC2254.2
+105300 CALL-EXIT-001.                                                   IC2254.2
+105400     EXIT PROGRAM.                                                IC2254.2

--- a/z390/IC226A.CBL
+++ b/z390/IC226A.CBL
@@ -1,0 +1,393 @@
+000100 IDENTIFICATION DIVISION.                                         IC2264.2
+      *
+      * This is the z390 version of IC226A
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC226A1
+      * IC226A has been modified to call IC226A1 instead of IC226A-1.
+      *
+000200 PROGRAM-ID.                                                      IC2264.2
+000300     IC226A.                                                      IC2264.2
+000400****************************************************************  IC2264.2
+000500*                                                              *  IC2264.2
+000600*    VALIDATION FOR:-                                          *  IC2264.2
+000700*                                                              *  IC2264.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2264.2
+000900*                                                              *  IC2264.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2264.2
+001100*                                                              *  IC2264.2
+001200****************************************************************  IC2264.2
+001300*                                                              *  IC2264.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2264.2
+001500*                                                              *  IC2264.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC2264.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC2264.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC2264.2
+001900*                                                              *  IC2264.2
+002000****************************************************************  IC2264.2
+002100*                                                              *  IC2264.2
+002200*    PROGRAM IC226A AND IC226A-1 WILL TEST THE NEW LANGUAGE    *  IC2264.2
+002300*    ELEMENTS FOR THE LEVEL 2 INTER-PROGRAM COMMUNICATION      *  IC2264.2
+002400*    MODULE.                                                   *  IC2264.2
+002500*    THE NEW LANGUAGE ELEMENT  TO BE TESTED WILL BE:           *  IC2264.2
+002600*          THE "EXTERNAL"     PHRASE                           *  IC2264.2
+002700*    THE TWO PROGRAMS WILL BE COMPILED IN THE SAME FLOW        *  IC2264.2
+002800*    (TO TEST THE "END PROGRAM" STATEMENT) AS SHOWN BELOW:     *  IC2264.2
+002900*    IDENTIFICATION DIVISION.                                  *  IC2264.2
+003000*    PROGRAM-ID. IC226A.                                       *  IC2264.2
+003100*              .                                               *  IC2264.2
+003200*              .                                               *  IC2264.2
+003300*              .                                               *  IC2264.2
+003400*    END PROGRAM IC226A.                                       *  IC2264.2
+003500*    PROGRAM-ID. IC226A-1.                                     *  IC2264.2
+003600*              .                                               *  IC2264.2
+003700*              .                                               *  IC2264.2
+003800*              .                                               *  IC2264.2
+003900****************************************************************  IC2264.2
+004000 ENVIRONMENT DIVISION.                                            IC2264.2
+004100 CONFIGURATION SECTION.                                           IC2264.2
+004200 SOURCE-COMPUTER.                                                 IC2264.2
+004300     XXXXX082.                                                    IC2264.2
+004400 OBJECT-COMPUTER.                                                 IC2264.2
+004500     XXXXX083.                                                    IC2264.2
+004600 INPUT-OUTPUT SECTION.                                            IC2264.2
+004700 FILE-CONTROL.                                                    IC2264.2
+004800     SELECT PRINT-FILE ASSIGN TO                                  IC2264.2
+004900     XXXXX055.                                                    IC2264.2
+005000 DATA DIVISION.                                                   IC2264.2
+005100 FILE SECTION.                                                    IC2264.2
+005200 FD  PRINT-FILE.                                                  IC2264.2
+005300 01  PRINT-REC PICTURE X(120).                                    IC2264.2
+005400 01  DUMMY-RECORD PICTURE X(120).                                 IC2264.2
+005500 WORKING-STORAGE SECTION.                                         IC2264.2
+005600 01  EXTERNAL-DATA IS EXTERNAL.                                   IC2264.2
+005700   03        EXT-DATA-1          PIC X(2).                        IC2264.2
+005800   03        EXT-DATA-2          PIC X(6).                        IC2264.2
+005900   03        EXT-DATA-3          PIC 9(8).                        IC2264.2
+006000   03        EXT-DATA-4          PIC 9(4).                        IC2264.2
+006100 01  SUB                         PIC 9(4)  VALUE ZERO.            IC2264.2
+006200*                                                                 IC2264.2
+006300 01  TEST-RESULTS.                                                IC2264.2
+006400     02 FILLER                   PIC X      VALUE SPACE.          IC2264.2
+006500     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC2264.2
+006600     02 FILLER                   PIC X      VALUE SPACE.          IC2264.2
+006700     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC2264.2
+006800     02 FILLER                   PIC X      VALUE SPACE.          IC2264.2
+006900     02  PAR-NAME.                                                IC2264.2
+007000       03 FILLER                 PIC X(19)  VALUE SPACE.          IC2264.2
+007100       03  PARDOT-X              PIC X      VALUE SPACE.          IC2264.2
+007200       03 DOTVALUE               PIC 99     VALUE ZERO.           IC2264.2
+007300     02 FILLER                   PIC X(8)   VALUE SPACE.          IC2264.2
+007400     02 RE-MARK                  PIC X(61).                       IC2264.2
+007500 01  TEST-COMPUTED.                                               IC2264.2
+007600     02 FILLER                   PIC X(30)  VALUE SPACE.          IC2264.2
+007700     02 FILLER                   PIC X(17)  VALUE                 IC2264.2
+007800            "       COMPUTED=".                                   IC2264.2
+007900     02 COMPUTED-X.                                               IC2264.2
+008000     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC2264.2
+008100     03 COMPUTED-N               REDEFINES COMPUTED-A             IC2264.2
+008200                                 PIC -9(9).9(9).                  IC2264.2
+008300     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC2264.2
+008400     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC2264.2
+008500     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC2264.2
+008600     03       CM-18V0 REDEFINES COMPUTED-A.                       IC2264.2
+008700         04 COMPUTED-18V0                    PIC -9(18).          IC2264.2
+008800         04 FILLER                           PIC X.               IC2264.2
+008900     03 FILLER PIC X(50) VALUE SPACE.                             IC2264.2
+009000 01  TEST-CORRECT.                                                IC2264.2
+009100     02 FILLER PIC X(30) VALUE SPACE.                             IC2264.2
+009200     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC2264.2
+009300     02 CORRECT-X.                                                IC2264.2
+009400     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC2264.2
+009500     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC2264.2
+009600     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC2264.2
+009700     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC2264.2
+009800     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC2264.2
+009900     03      CR-18V0 REDEFINES CORRECT-A.                         IC2264.2
+010000         04 CORRECT-18V0                     PIC -9(18).          IC2264.2
+010100         04 FILLER                           PIC X.               IC2264.2
+010200     03 FILLER PIC X(2) VALUE SPACE.                              IC2264.2
+010300     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC2264.2
+010400 01  CCVS-C-1.                                                    IC2264.2
+010500     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC2264.2
+010600-    "SS  PARAGRAPH-NAME                                          IC2264.2
+010700-    "       REMARKS".                                            IC2264.2
+010800     02 FILLER                     PIC X(20)    VALUE SPACE.      IC2264.2
+010900 01  CCVS-C-2.                                                    IC2264.2
+011000     02 FILLER                     PIC X        VALUE SPACE.      IC2264.2
+011100     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC2264.2
+011200     02 FILLER                     PIC X(15)    VALUE SPACE.      IC2264.2
+011300     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC2264.2
+011400     02 FILLER                     PIC X(94)    VALUE SPACE.      IC2264.2
+011500 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC2264.2
+011600 01  REC-CT                        PIC 99       VALUE ZERO.       IC2264.2
+011700 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC2264.2
+011800 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC2264.2
+011900 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC2264.2
+012000 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC2264.2
+012100 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC2264.2
+012200 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC2264.2
+012300 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC2264.2
+012400 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC2264.2
+012500 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC2264.2
+012600 01  CCVS-H-1.                                                    IC2264.2
+012700     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2264.2
+012800     02  FILLER                    PIC X(42)    VALUE             IC2264.2
+012900     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC2264.2
+013000     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2264.2
+013100 01  CCVS-H-2A.                                                   IC2264.2
+013200   02  FILLER                        PIC X(40)  VALUE SPACE.      IC2264.2
+013300   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC2264.2
+013400   02  FILLER                        PIC XXXX   VALUE             IC2264.2
+013500     "4.2 ".                                                      IC2264.2
+013600   02  FILLER                        PIC X(28)  VALUE             IC2264.2
+013700            " COPY - NOT FOR DISTRIBUTION".                       IC2264.2
+013800   02  FILLER                        PIC X(41)  VALUE SPACE.      IC2264.2
+013900                                                                  IC2264.2
+014000 01  CCVS-H-2B.                                                   IC2264.2
+014100   02  FILLER                        PIC X(15)  VALUE             IC2264.2
+014200            "TEST RESULT OF ".                                    IC2264.2
+014300   02  TEST-ID                       PIC X(9).                    IC2264.2
+014400   02  FILLER                        PIC X(4)   VALUE             IC2264.2
+014500            " IN ".                                               IC2264.2
+014600   02  FILLER                        PIC X(12)  VALUE             IC2264.2
+014700     " HIGH       ".                                              IC2264.2
+014800   02  FILLER                        PIC X(22)  VALUE             IC2264.2
+014900            " LEVEL VALIDATION FOR ".                             IC2264.2
+015000   02  FILLER                        PIC X(58)  VALUE             IC2264.2
+015100     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2264.2
+015200 01  CCVS-H-3.                                                    IC2264.2
+015300     02  FILLER                      PIC X(34)  VALUE             IC2264.2
+015400            " FOR OFFICIAL USE ONLY    ".                         IC2264.2
+015500     02  FILLER                      PIC X(58)  VALUE             IC2264.2
+015600     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2264.2
+015700     02  FILLER                      PIC X(28)  VALUE             IC2264.2
+015800            "  COPYRIGHT   1985 ".                                IC2264.2
+015900 01  CCVS-E-1.                                                    IC2264.2
+016000     02 FILLER                       PIC X(52)  VALUE SPACE.      IC2264.2
+016100     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC2264.2
+016200     02 ID-AGAIN                     PIC X(9).                    IC2264.2
+016300     02 FILLER                       PIC X(45)  VALUE SPACES.     IC2264.2
+016400 01  CCVS-E-2.                                                    IC2264.2
+016500     02  FILLER                      PIC X(31)  VALUE SPACE.      IC2264.2
+016600     02  FILLER                      PIC X(21)  VALUE SPACE.      IC2264.2
+016700     02 CCVS-E-2-2.                                               IC2264.2
+016800         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC2264.2
+016900         03 FILLER                   PIC X      VALUE SPACE.      IC2264.2
+017000         03 ENDER-DESC               PIC X(44)  VALUE             IC2264.2
+017100            "ERRORS ENCOUNTERED".                                 IC2264.2
+017200 01  CCVS-E-3.                                                    IC2264.2
+017300     02  FILLER                      PIC X(22)  VALUE             IC2264.2
+017400            " FOR OFFICIAL USE ONLY".                             IC2264.2
+017500     02  FILLER                      PIC X(12)  VALUE SPACE.      IC2264.2
+017600     02  FILLER                      PIC X(58)  VALUE             IC2264.2
+017700     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2264.2
+017800     02  FILLER                      PIC X(13)  VALUE SPACE.      IC2264.2
+017900     02 FILLER                       PIC X(15)  VALUE             IC2264.2
+018000             " COPYRIGHT 1985".                                   IC2264.2
+018100 01  CCVS-E-4.                                                    IC2264.2
+018200     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC2264.2
+018300     02 FILLER                       PIC X(4)   VALUE " OF ".     IC2264.2
+018400     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC2264.2
+018500     02 FILLER                       PIC X(40)  VALUE             IC2264.2
+018600      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC2264.2
+018700 01  XXINFO.                                                      IC2264.2
+018800     02 FILLER                       PIC X(19)  VALUE             IC2264.2
+018900            "*** INFORMATION ***".                                IC2264.2
+019000     02 INFO-TEXT.                                                IC2264.2
+019100       04 FILLER                     PIC X(8)   VALUE SPACE.      IC2264.2
+019200       04 XXCOMPUTED                 PIC X(20).                   IC2264.2
+019300       04 FILLER                     PIC X(5)   VALUE SPACE.      IC2264.2
+019400       04 XXCORRECT                  PIC X(20).                   IC2264.2
+019500     02 INF-ANSI-REFERENCE           PIC X(48).                   IC2264.2
+019600 01  HYPHEN-LINE.                                                 IC2264.2
+019700     02 FILLER  PIC IS X VALUE IS SPACE.                          IC2264.2
+019800     02 FILLER  PIC IS X(65)    VALUE IS "************************IC2264.2
+019900-    "*****************************************".                 IC2264.2
+020000     02 FILLER  PIC IS X(54)    VALUE IS "************************IC2264.2
+020100-    "******************************".                            IC2264.2
+020200 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC2264.2
+020300     "IC226A".                                                    IC2264.2
+020400 PROCEDURE DIVISION.                                              IC2264.2
+020500 CCVS1 SECTION.                                                   IC2264.2
+020600 OPEN-FILES.                                                      IC2264.2
+020700     OPEN     OUTPUT PRINT-FILE.                                  IC2264.2
+020800     MOVE CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.   IC2264.2
+020900     MOVE    SPACE TO TEST-RESULTS.                               IC2264.2
+021000     PERFORM  HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.             IC2264.2
+021100     GO TO CCVS1-EXIT.                                            IC2264.2
+021200 CLOSE-FILES.                                                     IC2264.2
+021300     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC2264.2
+021400 TERMINATE-CCVS.                                                  IC2264.2
+021500S    EXIT PROGRAM.                                                IC2264.2
+021600STERMINATE-CALL.                                                  IC2264.2
+021700     STOP     RUN.                                                IC2264.2
+021800 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         IC2264.2
+021900 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           IC2264.2
+022000 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          IC2264.2
+022100 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      IC2264.2
+022200     MOVE "****TEST DELETED****" TO RE-MARK.                      IC2264.2
+022300 PRINT-DETAIL.                                                    IC2264.2
+022400     IF REC-CT NOT EQUAL TO ZERO                                  IC2264.2
+022500             MOVE "." TO PARDOT-X                                 IC2264.2
+022600             MOVE REC-CT TO DOTVALUE.                             IC2264.2
+022700     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      IC2264.2
+022800     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               IC2264.2
+022900        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 IC2264.2
+023000          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 IC2264.2
+023100     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC2264.2
+023200     MOVE SPACE TO CORRECT-X.                                     IC2264.2
+023300     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC2264.2
+023400     MOVE     SPACE TO RE-MARK.                                   IC2264.2
+023500 HEAD-ROUTINE.                                                    IC2264.2
+023600     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2264.2
+023700     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2264.2
+023800     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2264.2
+023900     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2264.2
+024000 COLUMN-NAMES-ROUTINE.                                            IC2264.2
+024100     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2264.2
+024200     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2264.2
+024300     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC2264.2
+024400 END-ROUTINE.                                                     IC2264.2
+024500     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.IC2264.2
+024600 END-RTN-EXIT.                                                    IC2264.2
+024700     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2264.2
+024800 END-ROUTINE-1.                                                   IC2264.2
+024900      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      IC2264.2
+025000      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               IC2264.2
+025100      ADD PASS-COUNTER TO ERROR-HOLD.                             IC2264.2
+025200*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC2264.2
+025300      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC2264.2
+025400      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC2264.2
+025500      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC2264.2
+025600      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC2264.2
+025700  END-ROUTINE-12.                                                 IC2264.2
+025800      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC2264.2
+025900     IF       ERROR-COUNTER IS EQUAL TO ZERO                      IC2264.2
+026000         MOVE "NO " TO ERROR-TOTAL                                IC2264.2
+026100         ELSE                                                     IC2264.2
+026200         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC2264.2
+026300     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC2264.2
+026400     PERFORM WRITE-LINE.                                          IC2264.2
+026500 END-ROUTINE-13.                                                  IC2264.2
+026600     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC2264.2
+026700         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC2264.2
+026800         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC2264.2
+026900     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC2264.2
+027000     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2264.2
+027100      IF   INSPECT-COUNTER EQUAL TO ZERO                          IC2264.2
+027200          MOVE "NO " TO ERROR-TOTAL                               IC2264.2
+027300      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   IC2264.2
+027400      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            IC2264.2
+027500      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          IC2264.2
+027600     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2264.2
+027700 WRITE-LINE.                                                      IC2264.2
+027800     ADD 1 TO RECORD-COUNT.                                       IC2264.2
+027900Y    IF RECORD-COUNT GREATER 50                                   IC2264.2
+028000Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC2264.2
+028100Y        MOVE SPACE TO DUMMY-RECORD                               IC2264.2
+028200Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC2264.2
+028300Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC2264.2
+028400Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC2264.2
+028500Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC2264.2
+028600Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC2264.2
+028700Y        MOVE ZERO TO RECORD-COUNT.                               IC2264.2
+028800     PERFORM WRT-LN.                                              IC2264.2
+028900 WRT-LN.                                                          IC2264.2
+029000     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC2264.2
+029100     MOVE SPACE TO DUMMY-RECORD.                                  IC2264.2
+029200 BLANK-LINE-PRINT.                                                IC2264.2
+029300     PERFORM WRT-LN.                                              IC2264.2
+029400 FAIL-ROUTINE.                                                    IC2264.2
+029500     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC2264.2
+029600     IF     CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.IC2264.2
+029700     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2264.2
+029800     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC2264.2
+029900     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2264.2
+030000     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2264.2
+030100     GO TO  FAIL-ROUTINE-EX.                                      IC2264.2
+030200 FAIL-ROUTINE-WRITE.                                              IC2264.2
+030300     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC2264.2
+030400     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC2264.2
+030500     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC2264.2
+030600     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC2264.2
+030700 FAIL-ROUTINE-EX. EXIT.                                           IC2264.2
+030800 BAIL-OUT.                                                        IC2264.2
+030900     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC2264.2
+031000     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC2264.2
+031100 BAIL-OUT-WRITE.                                                  IC2264.2
+031200     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC2264.2
+031300     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2264.2
+031400     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2264.2
+031500     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2264.2
+031600 BAIL-OUT-EX. EXIT.                                               IC2264.2
+031700 CCVS1-EXIT.                                                      IC2264.2
+031800     EXIT.                                                        IC2264.2
+031900 SECT-IC226A-001 SECTION.                                         IC2264.2
+032000 EXT-INIT-01.                                                     IC2264.2
+032100     MOVE   1         TO REC-CT.                                  IC2264.2
+032200     MOVE   "X-21 4.5.1" TO ANSI-REFERENCE.                       IC2264.2
+032300     MOVE   "EXTERNAL CLAUSE" TO FEATURE.                         IC2264.2
+032400     MOVE   "AA"      TO EXT-DATA-1.                              IC2264.2
+032500     MOVE   "FIRST]"  TO EXT-DATA-2.                              IC2264.2
+032600     MOVE    12345678 TO EXT-DATA-3.                              IC2264.2
+032700     MOVE    1        TO EXT-DATA-4.                              IC2264.2
+032800 EXT-TEST-01-01-0.                                                IC2264.2
+032900     CALL   "IC226A1"                                             IC2264.2
+033000     END-CALL.                                                    IC2264.2
+033100     GO TO   EXT-TEST-01-01-1.                                    IC2264.2
+033200 EXT-DELETE-01-01.                                                IC2264.2
+033300     PERFORM DE-LETE.                                             IC2264.2
+033400     PERFORM PRINT-DETAIL.                                        IC2264.2
+033500     GO TO   CCVS-EXIT.                                           IC2264.2
+033600 EXT-TEST-01-01-1.                                                IC2264.2
+033700     MOVE   "EXT-TEST-01-01-1" TO PAR-NAME.                       IC2264.2
+033800     IF      EXT-DATA-1 = "ZZ"                                    IC2264.2
+033900             PERFORM PASS                                         IC2264.2
+034000             PERFORM PRINT-DETAIL                                 IC2264.2
+034100     ELSE                                                         IC2264.2
+034200             MOVE    EXT-DATA-1  TO COMPUTED-X                    IC2264.2
+034300             MOVE   "ZZ" TO CORRECT-X                             IC2264.2
+034400             MOVE   "INCORRECT VALUE RETURNED" TO RE-MARK         IC2264.2
+034500             PERFORM FAIL                                         IC2264.2
+034600             PERFORM PRINT-DETAIL.                                IC2264.2
+034700     ADD     1 TO REC-CT.                                         IC2264.2
+034800 CALL-TEST-01-01-2.                                               IC2264.2
+034900     MOVE   "CALL-TEST-01-01-2" TO PAR-NAME.                      IC2264.2
+035000     IF      EXT-DATA-2 = "CHANGE"                                IC2264.2
+035100             PERFORM PASS                                         IC2264.2
+035200             PERFORM PRINT-DETAIL                                 IC2264.2
+035300     ELSE                                                         IC2264.2
+035400             MOVE    EXT-DATA-2  TO COMPUTED-X                    IC2264.2
+035500             MOVE   "CHANGE" TO CORRECT-X                         IC2264.2
+035600             MOVE   "INCORRECT VALUE RETURNED" TO RE-MARK         IC2264.2
+035700             PERFORM FAIL                                         IC2264.2
+035800             PERFORM PRINT-DETAIL.                                IC2264.2
+035900     ADD     1 TO REC-CT.                                         IC2264.2
+036000 CALL-TEST-01-01-3.                                               IC2264.2
+036100     MOVE   "CALL-TEST-01-01-3" TO PAR-NAME.                      IC2264.2
+036200     IF      EXT-DATA-3 = 87654321                                IC2264.2
+036300             PERFORM PASS                                         IC2264.2
+036400             PERFORM PRINT-DETAIL                                 IC2264.2
+036500     ELSE                                                         IC2264.2
+036600             MOVE    EXT-DATA-3  TO COMPUTED-N                    IC2264.2
+036700             MOVE    87654321 TO CORRECT-N                        IC2264.2
+036800             MOVE   "INCORRECT VALUE RETURNED" TO RE-MARK         IC2264.2
+036900             PERFORM FAIL                                         IC2264.2
+037000             PERFORM PRINT-DETAIL.                                IC2264.2
+037100     ADD     1 TO REC-CT.                                         IC2264.2
+037200 CALL-TEST-01-01-4.                                               IC2264.2
+037300     MOVE   "CALL-TEST-01-01-4" TO PAR-NAME.                      IC2264.2
+037400     IF      EXT-DATA-4 = 11                                      IC2264.2
+037500             PERFORM PASS                                         IC2264.2
+037600             PERFORM PRINT-DETAIL                                 IC2264.2
+037700     ELSE                                                         IC2264.2
+037800             MOVE    EXT-DATA-4 TO COMPUTED-N                     IC2264.2
+037900             MOVE    11   TO CORRECT-N                            IC2264.2
+038000             MOVE   "INCORRECT VALUE RETURNED" TO RE-MARK         IC2264.2
+038100             PERFORM FAIL                                         IC2264.2
+038200             PERFORM PRINT-DETAIL.                                IC2264.2
+038300*                                                                 IC2264.2
+038400 CCVS-EXIT SECTION.                                               IC2264.2
+038500 CCVS-999999.                                                     IC2264.2
+038600     GO TO CLOSE-FILES.                                           IC2264.2
+038700 END PROGRAM IC226A.                                              IC2264.2

--- a/z390/IC226A1.CBL
+++ b/z390/IC226A1.CBL
@@ -1,0 +1,125 @@
+038800 IDENTIFICATION DIVISION.                                         IC2264.2
+      *
+      * This is the z390 version of IC226A-1
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC226A1
+      * IC226A has been modified to call IC226A1 instead of IC226A-1.
+      *
+038900 PROGRAM-ID.                                                      IC2264.2
+039000     IC226A1.                                                     IC2264.2
+039100****************************************************************  IC2264.2
+039200*                                                              *  IC2264.2
+039300*    THIS PROGRAM FORMS PART OF THE COBOL COMPILER VALIDATION  *  IC2264.2
+039400*    SYSTEM (CCVS) USED TO TEST COBOL COMPILERS FOR            *  IC2264.2
+039500*    CONFORMANCE WITH THE AMERICAN NATIONAL STANDARD           *  IC2264.2
+039600*    (ANSI DOCUMENT REFERENCE: X3.23-1985) AND THE STANDARD OF *  IC2264.2
+039700*    THE INTERNATIONAL ORGANIZATION FOR STANDARDISATION        *  IC2264.2
+039800*    (ISO DOCUMENT REFERENCE: ISO-1989-1985).                  *  IC2264.2
+039900*                                                              *  IC2264.2
+040000*    THIS CCVS INCORPORATES ENHANCEMENTS TO THE CCVS FOR THE   *  IC2264.2
+040100*    1974 STANDARD (ANSI DOCUMENT REFERENCE: X3.23-1974; ISO   *  IC2264.2
+040200*    DOCUMENT REFERENCE: ISO-1989-1978).                       *  IC2264.2
+040300*                                                              *  IC2264.2
+040400*    THESE ENHANCEMENTS WERE SPECIFIED BY A PROJECT TEAM WHICH *  IC2264.2
+040500*    WAS FUNDED BY THE COMMISSION FOR EUROPEAN COMMUNITIES AND *  IC2264.2
+040600*    WHICH WAS RESPONSIBLE FOR TECHNICAL ISSUES TO:            *  IC2264.2
+040700*                                                              *  IC2264.2
+040800*          THE FEDERAL SOFTWARE TESTING CENTER                 *  IC2264.2
+040900*          OFFICE OF SOFTWARE DEVELOPMENT                      *  IC2264.2
+041000*                & INFORMATION TECHNOLOGY                      *  IC2264.2
+041100*          TWO SKYLINE PLACE                                   *  IC2264.2
+041200*          SUITE 1100                                          *  IC2264.2
+041300*          5203 LEESBURG PIKE                                  *  IC2264.2
+041400*          FALLS CHURCH                                        *  IC2264.2
+041500*          VA 22041                                            *  IC2264.2
+041600*          U.S.A.                                              *  IC2264.2
+041700*                                                              *  IC2264.2
+041800*    THE PROJECT TEAM MEMBERS WERE:                            *  IC2264.2
+041900*                                                              *  IC2264.2
+042000*          BIADI (BUREAU INTER ADMINISTRATION                  *  IC2264.2
+042100*                 DE DOCUMENTATION INFORMATIQUE)               *  IC2264.2
+042200*          21 RUE BARA                                         *  IC2264.2
+042300*          F-92132 ISSY                                        *  IC2264.2
+042400*          FRANCE                                              *  IC2264.2
+042500*                                                              *  IC2264.2
+042600*                                                              *  IC2264.2
+042700*          GMD (GESELLSCHAFT FUR MATHEMATIK                    *  IC2264.2
+042800*               UND DATENVERARBEITUNG MBH)                     *  IC2264.2
+042900*          SCHLOSS BIRLINGHOVEN                                *  IC2264.2
+043000*          POSTFACH 12 40                                      *  IC2264.2
+043100*          D-5205 ST. AUGUSTIN 1                               *  IC2264.2
+043200*          GERMANY FR                                          *  IC2264.2
+043300*                                                              *  IC2264.2
+043400*                                                              *  IC2264.2
+043500*          NCC (THE NATIONAL COMPUTING CENTRE LTD)             *  IC2264.2
+043600*          OXFORD ROAD                                         *  IC2264.2
+043700*          MANCHESTER                                          *  IC2264.2
+043800*          M1 7ED                                              *  IC2264.2
+043900*          UNITED KINGDOM                                      *  IC2264.2
+044000*                                                              *  IC2264.2
+044100*                                                              *  IC2264.2
+044200*    THIS TEST SUITE WAS PRODUCED BY THE NATIONAL COMPUTING    *  IC2264.2
+044300*    CENTRE IN ENGLAND AND IS THE OFFICIAL CCVS TEST SUITE     *  IC2264.2
+044400*    USED THROUGHOUT EUROPE AND THE UNITED STATES OF AMERICA.  *  IC2264.2
+044500*                                                              *  IC2264.2
+044600****************************************************************  IC2264.2
+044700*                                                              *  IC2264.2
+044800*    VALIDATION FOR:-                                          *  IC2264.2
+044900*                                                              *  IC2264.2
+045000*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2264.2
+045100*                                                              *  IC2264.2
+045200*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2264.2
+045300*                                                              *  IC2264.2
+045400****************************************************************  IC2264.2
+045500*                                                              *  IC2264.2
+045600*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2264.2
+045700*                                                              *  IC2264.2
+045800*        X-14  - SEQUENTIAL MASS STORAGE                       *  IC2264.2
+045900*        X-55  - SYSTEM PRINTER NAME.                          *  IC2264.2
+046000*        X-82  - SOURCE COMPUTER NAME.                         *  IC2264.2
+046100*        X-83  - OBJECT COMPUTER NAME.                         *  IC2264.2
+046200*                                                              *  IC2264.2
+046300****************************************************************  IC2264.2
+046400*                                                              *  IC2264.2
+046500*    PROGRAM IC226A AND IC226A-1 WILL TEST THE NEW LANGUAGE    *  IC2264.2
+046600*    ELEMENTS FOR THE LEVEL 2 INTER-PROGRAM COMMUNICATION      *  IC2264.2
+046700*    MODULE.                                                   *  IC2264.2
+046800*    THE NEW LANGUAGE ELEMENTS TO BE TESTED WILL BE:           *  IC2264.2
+046900*           THE "EXTERNAL" CLAUSE IN WORKING-STORAGE.          *  IC2264.2
+047000*    THE TWO PROGRAMS WILL BE COMPILED IN THE SAME FLOW        *  IC2264.2
+047100*    (TO TEST THE "END PROGRAM" STATEMENT) AS SHOWN BELOW:     *  IC2264.2
+047200*    IDENTIFICATION DIVISION.                                  *  IC2264.2
+047300*    PROGRAM-ID. IC226A.                                       *  IC2264.2
+047400*              .                                               *  IC2264.2
+047500*              .                                               *  IC2264.2
+047600*              .                                               *  IC2264.2
+047700*    END PROGRAM IC226A.                                       *  IC2264.2
+047800*    PROGRAM-ID. IC226A-1.                                     *  IC2264.2
+047900*              .                                               *  IC2264.2
+048000*              .                                               *  IC2264.2
+048100*              .                                               *  IC2264.2
+048200****************************************************************  IC2264.2
+048300 ENVIRONMENT DIVISION.                                            IC2264.2
+048400 CONFIGURATION SECTION.                                           IC2264.2
+048500 SOURCE-COMPUTER.                                                 IC2264.2
+048600     XXXXX082.                                                    IC2264.2
+048700 OBJECT-COMPUTER.                                                 IC2264.2
+048800     XXXXX083.                                                    IC2264.2
+048900*INPUT-OUTPUT SECTION.                                            IC2264.2
+049000 DATA DIVISION.                                                   IC2264.2
+049100 FILE SECTION.                                                    IC2264.2
+049200 WORKING-STORAGE SECTION.                                         IC2264.2
+049300 01  EXTERNAL-DATA IS EXTERNAL.                                   IC2264.2
+049400   03        EXT-DATA-1          PIC X(2).                        IC2264.2
+049500   03        EXT-DATA-2          PIC X(6).                        IC2264.2
+049600   03        EXT-DATA-3          PIC 9(8).                        IC2264.2
+049700   03        EXT-DATA-4          PIC 9(4).                        IC2264.2
+049800 PROCEDURE DIVISION.                                              IC2264.2
+049900 SECT-IC226A-1-001 SECTION.                                       IC2264.2
+050000 EXT-TEST-001.                                                    IC2264.2
+050100     MOVE   "ZZ"      TO EXT-DATA-1.                              IC2264.2
+050200     MOVE   "CHANGE"  TO EXT-DATA-2.                              IC2264.2
+050300     MOVE    87654321 TO EXT-DATA-3.                              IC2264.2
+050400     ADD     10       TO EXT-DATA-4.                              IC2264.2
+050500 EXT-EXIT-001.                                                    IC2264.2
+050600     EXIT PROGRAM.                                                IC2264.2

--- a/z390/IC227A.CBL
+++ b/z390/IC227A.CBL
@@ -1,0 +1,974 @@
+000100 IDENTIFICATION DIVISION.                                         IC2274.2
+      *
+      * This is the z390 version of IC227A
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC227A1
+      * IC227A has been modified to call IC227A1 instead of IC227A-1.
+      *
+000200 PROGRAM-ID.                                                      IC2274.2
+000300     IC227A.                                                      IC2274.2
+000400****************************************************************  IC2274.2
+000500*                                                              *  IC2274.2
+000600*    VALIDATION FOR:-                                          *  IC2274.2
+000700*                                                              *  IC2274.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2274.2
+000900*                                                              *  IC2274.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2274.2
+001100*                                                              *  IC2274.2
+001200****************************************************************  IC2274.2
+001300*                                                              *  IC2274.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2274.2
+001500*                                                              *  IC2274.2
+001600*            X-55   SYSTEM PRINTER                             *  IC2274.2
+001700*            X-82   SOURCE-COMPUTER                            *  IC2274.2
+001800*            X-83   OBJECT-COMPUTER.                           *  IC2274.2
+001900*                                                              *  IC2274.2
+002000****************************************************************  IC2274.2
+002100*                                                              *  IC2274.2
+002200*    PROGRAMS IC227A AND IC227A-1 TEST LEVEL 2 LANGUAGE        *  IC2274.2
+002300*    ELEMENTS FROM THE INTER-PROGRAM COMMUNICATION MODULE.     *  IC2274.2
+002400*    THE PARTICULAR ELEMENTS TESTED ARE:                       *  IC2274.2
+002500*        THE "EXTERNAL" CLAUSE IN THE FILE DESCRIPTION ENTRY   *  IC2274.2
+002600*                                                              *  IC2274.2
+002700*    ALTHOUGH IC227A AND IC227A-1 ARE SEPARATELY COMPILED      *  IC2274.2
+002800*    PROGRAMS, BOTH ARE INTENDED TO BE COMPILED BY THE SAME    *  IC2274.2
+002900*    INVOCATION OF THE COMPILER, IN ORDER TO TEST STREAM       *  IC2274.2
+003000*    COMPILATION AND RECOGNITION OF THE END PROGRAM HEADER.    *  IC2274.2
+003100*                                                              *  IC2274.2
+003200*    THE STRUCTURE OF THE SOURCE FILE IS:                         IC2274.2
+003300*                                                              *  IC2274.2
+003400*    IDENTIFICATION DIVISION.                                  *  IC2274.2
+003500*    PROGRAM-ID.  IC227A.                                      *  IC2274.2
+003600*              .                                               *  IC2274.2
+003700*              .                                               *  IC2274.2
+003800*              .                                               *  IC2274.2
+003900*    END PROGRAM IC227A.                                       *  IC2274.2
+004000*    IDENTIFICATION DIVISION.                                  *  IC2274.2
+004100*    PROGRAM-ID.  IC227A-1.                                    *  IC2274.2
+004200*              .                                               *  IC2274.2
+004300*              .                                               *  IC2274.2
+004400*              .                                               *  IC2274.2
+004500*    END PROGRAM IC227A-1.                                     *  IC2274.2
+004600*                                                              *  IC2274.2
+004700****************************************************************  IC2274.2
+004800*                                                                 IC2274.2
+004900 ENVIRONMENT DIVISION.                                            IC2274.2
+005000 CONFIGURATION SECTION.                                           IC2274.2
+005100 SOURCE-COMPUTER.                                                 IC2274.2
+005200     XXXXX082.                                                    IC2274.2
+005300 OBJECT-COMPUTER.                                                 IC2274.2
+005400     XXXXX083.                                                    IC2274.2
+005500*                                                                 IC2274.2
+005600 INPUT-OUTPUT SECTION.                                            IC2274.2
+005700 FILE-CONTROL.                                                    IC2274.2
+005800     SELECT PRINT-FILE ASSIGN TO                                  IC2274.2
+005900     XXXXX055.                                                    IC2274.2
+006000*                                                                 IC2274.2
+006100     SELECT EXTERNAL-FILE ASSIGN TO                               IC2274.2
+006200     XXXXX014                                                     IC2274.2
+006300     FILE STATUS IS EXTERNAL-FILE-FS.                             IC2274.2
+006400*                                                                 IC2274.2
+006500 DATA DIVISION.                                                   IC2274.2
+006600 FILE SECTION.                                                    IC2274.2
+006700 FD  PRINT-FILE.                                                  IC2274.2
+006800 01  PRINT-REC PICTURE X(120).                                    IC2274.2
+006900 01  DUMMY-RECORD PICTURE X(120).                                 IC2274.2
+007000*                                                                 IC2274.2
+007100 FD  EXTERNAL-FILE                                                IC2274.2
+007200         IS EXTERNAL                                              IC2274.2
+007300         RECORD CONTAINS 18 CHARACTERS.                           IC2274.2
+007400 01  EXTERNAL-FILE-RECORD.                                        IC2274.2
+007500     03  EXT-DATA-1              PIC X(2).                        IC2274.2
+007600     03  EXT-DATA-2              PIC X(6).                        IC2274.2
+007700     03  EXT-DATA-3              PIC 9(6).                        IC2274.2
+007800     03  EXT-DATA-4              PIC 9(4).                        IC2274.2
+007900*                                                                 IC2274.2
+008000 WORKING-STORAGE SECTION.                                         IC2274.2
+008100*                                                                 IC2274.2
+008200***************************************************************   IC2274.2
+008300*                                                             *   IC2274.2
+008400*    WORKING-STORAGE DATA ITEMS SPECIFIC TO THIS TEST SUITE   *   IC2274.2
+008500*                                                             *   IC2274.2
+008600***************************************************************   IC2274.2
+008700*                                                                 IC2274.2
+008800 01  EXTERNAL-RECORD-HOLD.                                        IC2274.2
+008900     03  WSE-DATA-1              PIC X(2).                        IC2274.2
+009000     03  WSE-DATA-2              PIC X(6).                        IC2274.2
+009100     03  WSE-DATA-3              PIC 9(6).                        IC2274.2
+009200     03  WSE-DATA-4              PIC 9(4).                        IC2274.2
+009300*                                                                 IC2274.2
+009400 01  EXTERNAL-RECORD-WORK.                                        IC2274.2
+009500     03  WRK-DATA-1              PIC X(2).                        IC2274.2
+009600     03  WRK-DATA-2              PIC X(6).                        IC2274.2
+009700     03  WRK-DATA-3              PIC 9(6).                        IC2274.2
+009800     03  WRK-DATA-4              PIC 9(4).                        IC2274.2
+009900*                                                                 IC2274.2
+010000 01  EXTERNAL-FILE-FS            PIC XX.                          IC2274.2
+010100 01  F-S-PARAM                   PIC XX.                          IC2274.2
+010200 01  ACTION-CODE                 PIC 99.                          IC2274.2
+010300 77  ID1 PICTURE X(8) VALUE "IC227A1".                            IC2274.2
+010400*                                                                 IC2274.2
+010500***************************************************************   IC2274.2
+010600*                                                             *   IC2274.2
+010700*    WORKING-STORAGE DATA ITEMS USED BY THE CCVS              *   IC2274.2
+010800*                                                             *   IC2274.2
+010900***************************************************************   IC2274.2
+011000*                                                                 IC2274.2
+011100 01  TEST-RESULTS.                                                IC2274.2
+011200     02 FILLER                   PIC X      VALUE SPACE.          IC2274.2
+011300     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC2274.2
+011400     02 FILLER                   PIC X      VALUE SPACE.          IC2274.2
+011500     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC2274.2
+011600     02 FILLER                   PIC X      VALUE SPACE.          IC2274.2
+011700     02  PAR-NAME.                                                IC2274.2
+011800       03 FILLER                 PIC X(19)  VALUE SPACE.          IC2274.2
+011900       03  PARDOT-X              PIC X      VALUE SPACE.          IC2274.2
+012000       03 DOTVALUE               PIC 99     VALUE ZERO.           IC2274.2
+012100     02 FILLER                   PIC X(8)   VALUE SPACE.          IC2274.2
+012200     02 RE-MARK                  PIC X(61).                       IC2274.2
+012300 01  TEST-COMPUTED.                                               IC2274.2
+012400     02 FILLER                   PIC X(30)  VALUE SPACE.          IC2274.2
+012500     02 FILLER                   PIC X(17)  VALUE                 IC2274.2
+012600            "       COMPUTED=".                                   IC2274.2
+012700     02 COMPUTED-X.                                               IC2274.2
+012800     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC2274.2
+012900     03 COMPUTED-N               REDEFINES COMPUTED-A             IC2274.2
+013000                                 PIC -9(9).9(9).                  IC2274.2
+013100     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC2274.2
+013200     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC2274.2
+013300     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC2274.2
+013400     03       CM-18V0 REDEFINES COMPUTED-A.                       IC2274.2
+013500         04 COMPUTED-18V0                    PIC -9(18).          IC2274.2
+013600         04 FILLER                           PIC X.               IC2274.2
+013700     03 FILLER PIC X(50) VALUE SPACE.                             IC2274.2
+013800 01  TEST-CORRECT.                                                IC2274.2
+013900     02 FILLER PIC X(30) VALUE SPACE.                             IC2274.2
+014000     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC2274.2
+014100     02 CORRECT-X.                                                IC2274.2
+014200     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC2274.2
+014300     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC2274.2
+014400     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC2274.2
+014500     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC2274.2
+014600     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC2274.2
+014700     03      CR-18V0 REDEFINES CORRECT-A.                         IC2274.2
+014800         04 CORRECT-18V0                     PIC -9(18).          IC2274.2
+014900         04 FILLER                           PIC X.               IC2274.2
+015000     03 FILLER PIC X(2) VALUE SPACE.                              IC2274.2
+015100     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC2274.2
+015200 01  CCVS-C-1.                                                    IC2274.2
+015300     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC2274.2
+015400-    "SS  PARAGRAPH-NAME                                          IC2274.2
+015500-    "       REMARKS".                                            IC2274.2
+015600     02 FILLER                     PIC X(20)    VALUE SPACE.      IC2274.2
+015700 01  CCVS-C-2.                                                    IC2274.2
+015800     02 FILLER                     PIC X        VALUE SPACE.      IC2274.2
+015900     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC2274.2
+016000     02 FILLER                     PIC X(15)    VALUE SPACE.      IC2274.2
+016100     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC2274.2
+016200     02 FILLER                     PIC X(94)    VALUE SPACE.      IC2274.2
+016300 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC2274.2
+016400 01  REC-CT                        PIC 99       VALUE ZERO.       IC2274.2
+016500 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC2274.2
+016600 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC2274.2
+016700 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC2274.2
+016800 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC2274.2
+016900 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC2274.2
+017000 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC2274.2
+017100 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC2274.2
+017200 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC2274.2
+017300 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC2274.2
+017400 01  CCVS-H-1.                                                    IC2274.2
+017500     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2274.2
+017600     02  FILLER                    PIC X(42)    VALUE             IC2274.2
+017700     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC2274.2
+017800     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2274.2
+017900 01  CCVS-H-2A.                                                   IC2274.2
+018000   02  FILLER                        PIC X(40)  VALUE SPACE.      IC2274.2
+018100   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC2274.2
+018200   02  FILLER                        PIC XXXX   VALUE             IC2274.2
+018300     "4.2 ".                                                      IC2274.2
+018400   02  FILLER                        PIC X(28)  VALUE             IC2274.2
+018500            " COPY - NOT FOR DISTRIBUTION".                       IC2274.2
+018600   02  FILLER                        PIC X(41)  VALUE SPACE.      IC2274.2
+018700                                                                  IC2274.2
+018800 01  CCVS-H-2B.                                                   IC2274.2
+018900   02  FILLER                        PIC X(15)  VALUE             IC2274.2
+019000            "TEST RESULT OF ".                                    IC2274.2
+019100   02  TEST-ID                       PIC X(9).                    IC2274.2
+019200   02  FILLER                        PIC X(4)   VALUE             IC2274.2
+019300            " IN ".                                               IC2274.2
+019400   02  FILLER                        PIC X(12)  VALUE             IC2274.2
+019500     " HIGH       ".                                              IC2274.2
+019600   02  FILLER                        PIC X(22)  VALUE             IC2274.2
+019700            " LEVEL VALIDATION FOR ".                             IC2274.2
+019800   02  FILLER                        PIC X(58)  VALUE             IC2274.2
+019900     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2274.2
+020000 01  CCVS-H-3.                                                    IC2274.2
+020100     02  FILLER                      PIC X(34)  VALUE             IC2274.2
+020200            " FOR OFFICIAL USE ONLY    ".                         IC2274.2
+020300     02  FILLER                      PIC X(58)  VALUE             IC2274.2
+020400     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2274.2
+020500     02  FILLER                      PIC X(28)  VALUE             IC2274.2
+020600            "  COPYRIGHT   1985,1986 ".                           IC2274.2
+020700 01  CCVS-E-1.                                                    IC2274.2
+020800     02 FILLER                       PIC X(52)  VALUE SPACE.      IC2274.2
+020900     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC2274.2
+021000     02 ID-AGAIN                     PIC X(9).                    IC2274.2
+021100     02 FILLER                       PIC X(45)  VALUE SPACES.     IC2274.2
+021200 01  CCVS-E-2.                                                    IC2274.2
+021300     02  FILLER                      PIC X(31)  VALUE SPACE.      IC2274.2
+021400     02  FILLER                      PIC X(21)  VALUE SPACE.      IC2274.2
+021500     02 CCVS-E-2-2.                                               IC2274.2
+021600         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC2274.2
+021700         03 FILLER                   PIC X      VALUE SPACE.      IC2274.2
+021800         03 ENDER-DESC               PIC X(44)  VALUE             IC2274.2
+021900            "ERRORS ENCOUNTERED".                                 IC2274.2
+022000 01  CCVS-E-3.                                                    IC2274.2
+022100     02  FILLER                      PIC X(22)  VALUE             IC2274.2
+022200            " FOR OFFICIAL USE ONLY".                             IC2274.2
+022300     02  FILLER                      PIC X(12)  VALUE SPACE.      IC2274.2
+022400     02  FILLER                      PIC X(58)  VALUE             IC2274.2
+022500     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2274.2
+022600     02  FILLER                      PIC X(8)   VALUE SPACE.      IC2274.2
+022700     02  FILLER                      PIC X(20)  VALUE             IC2274.2
+022800             " COPYRIGHT 1985,1986".                              IC2274.2
+022900 01  CCVS-E-4.                                                    IC2274.2
+023000     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC2274.2
+023100     02 FILLER                       PIC X(4)   VALUE " OF ".     IC2274.2
+023200     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC2274.2
+023300     02 FILLER                       PIC X(40)  VALUE             IC2274.2
+023400      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC2274.2
+023500 01  XXINFO.                                                      IC2274.2
+023600     02 FILLER                       PIC X(19)  VALUE             IC2274.2
+023700            "*** INFORMATION ***".                                IC2274.2
+023800     02 INFO-TEXT.                                                IC2274.2
+023900       04 FILLER                     PIC X(8)   VALUE SPACE.      IC2274.2
+024000       04 XXCOMPUTED                 PIC X(20).                   IC2274.2
+024100       04 FILLER                     PIC X(5)   VALUE SPACE.      IC2274.2
+024200       04 XXCORRECT                  PIC X(20).                   IC2274.2
+024300     02 INF-ANSI-REFERENCE           PIC X(48).                   IC2274.2
+024400 01  HYPHEN-LINE.                                                 IC2274.2
+024500     02 FILLER  PIC IS X VALUE IS SPACE.                          IC2274.2
+024600     02 FILLER  PIC IS X(65)    VALUE IS "************************IC2274.2
+024700-    "*****************************************".                 IC2274.2
+024800     02 FILLER  PIC IS X(54)    VALUE IS "************************IC2274.2
+024900-    "******************************".                            IC2274.2
+025000 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC2274.2
+025100     "IC227A".                                                    IC2274.2
+025200*                                                                 IC2274.2
+025300*                                                                 IC2274.2
+025400 PROCEDURE DIVISION.                                              IC2274.2
+025500 CCVS1 SECTION.                                                   IC2274.2
+025600 OPEN-FILES.                                                      IC2274.2
+025700     OPEN    OUTPUT PRINT-FILE.                                   IC2274.2
+025800     MOVE  CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.  IC2274.2
+025900     MOVE    SPACE TO TEST-RESULTS.                               IC2274.2
+026000     PERFORM HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.              IC2274.2
+026100     GO TO CCVS1-EXIT.                                            IC2274.2
+026200 CLOSE-FILES.                                                     IC2274.2
+026300     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC2274.2
+026400 TERMINATE-CCVS.                                                  IC2274.2
+026500     STOP     RUN.                                                IC2274.2
+026600*                                                                 IC2274.2
+026700 INSPT.                                                           IC2274.2
+026800     MOVE   "INSPT" TO P-OR-F.                                    IC2274.2
+026900     ADD     1 TO INSPECT-COUNTER.                                IC2274.2
+027000     PERFORM PRINT-DETAIL.                                        IC2274.2
+027100                                                                  IC2274.2
+027200 PASS.                                                            IC2274.2
+027300     MOVE   "PASS " TO P-OR-F.                                    IC2274.2
+027400     ADD     1 TO PASS-COUNTER.                                   IC2274.2
+027500     PERFORM PRINT-DETAIL.                                        IC2274.2
+027600*                                                                 IC2274.2
+027700 FAIL.                                                            IC2274.2
+027800     MOVE   "FAIL*" TO P-OR-F.                                    IC2274.2
+027900     ADD     1 TO ERROR-COUNTER.                                  IC2274.2
+028000     PERFORM PRINT-DETAIL.                                        IC2274.2
+028100*                                                                 IC2274.2
+028200 DE-LETE.                                                         IC2274.2
+028300     MOVE   "****TEST DELETED****" TO RE-MARK.                    IC2274.2
+028400     MOVE   "*****" TO P-OR-F.                                    IC2274.2
+028500     ADD     1 TO DELETE-COUNTER.                                 IC2274.2
+028600     PERFORM PRINT-DETAIL.                                        IC2274.2
+028700                                                                  IC2274.2
+028800 PRINT-DETAIL.                                                    IC2274.2
+028900     IF REC-CT NOT EQUAL TO ZERO                                  IC2274.2
+029000             MOVE "." TO PARDOT-X                                 IC2274.2
+029100             MOVE REC-CT TO DOTVALUE.                             IC2274.2
+029200     MOVE    TEST-RESULTS TO PRINT-REC.                           IC2274.2
+029300     PERFORM WRITE-LINE.                                          IC2274.2
+029400     IF P-OR-F EQUAL TO "FAIL*"                                   IC2274.2
+029500          PERFORM WRITE-LINE                                      IC2274.2
+029600          PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX               IC2274.2
+029700     ELSE                                                         IC2274.2
+029800          PERFORM BAIL-OUT THRU BAIL-OUT-EX.                      IC2274.2
+029900     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC2274.2
+030000     MOVE SPACE TO CORRECT-X.                                     IC2274.2
+030100     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC2274.2
+030200     MOVE     SPACE TO RE-MARK.                                   IC2274.2
+030300*                                                                 IC2274.2
+030400 HEAD-ROUTINE.                                                    IC2274.2
+030500     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2274.2
+030600     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2274.2
+030700     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2274.2
+030800     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2274.2
+030900 COLUMN-NAMES-ROUTINE.                                            IC2274.2
+031000     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2274.2
+031100     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2274.2
+031200     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC2274.2
+031300 END-ROUTINE.                                                     IC2274.2
+031400     MOVE HYPHEN-LINE TO DUMMY-RECORD.                            IC2274.2
+031500     PERFORM WRITE-LINE 5 TIMES.                                  IC2274.2
+031600 END-RTN-EXIT.                                                    IC2274.2
+031700     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2274.2
+031800*                                                                 IC2274.2
+031900 END-ROUTINE-1.                                                   IC2274.2
+032000      ADD     ERROR-COUNTER   TO ERROR-HOLD                       IC2274.2
+032100      ADD     INSPECT-COUNTER TO ERROR-HOLD.                      IC2274.2
+032200      ADD     DELETE-COUNTER  TO ERROR-HOLD.                      IC2274.2
+032300      ADD     PASS-COUNTER    TO ERROR-HOLD.                      IC2274.2
+032400*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC2274.2
+032500      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC2274.2
+032600      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC2274.2
+032700      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC2274.2
+032800      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC2274.2
+032900  END-ROUTINE-12.                                                 IC2274.2
+033000      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC2274.2
+033100      IF       ERROR-COUNTER IS EQUAL TO ZERO                     IC2274.2
+033200         MOVE "NO " TO ERROR-TOTAL                                IC2274.2
+033300         ELSE                                                     IC2274.2
+033400         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC2274.2
+033500     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC2274.2
+033600     PERFORM WRITE-LINE.                                          IC2274.2
+033700 END-ROUTINE-13.                                                  IC2274.2
+033800     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC2274.2
+033900         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC2274.2
+034000         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC2274.2
+034100     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC2274.2
+034200     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2274.2
+034300     IF   INSPECT-COUNTER EQUAL TO ZERO                           IC2274.2
+034400          MOVE "NO " TO ERROR-TOTAL                               IC2274.2
+034500     ELSE                                                         IC2274.2
+034600          MOVE INSPECT-COUNTER TO ERROR-TOTAL.                    IC2274.2
+034700     MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.             IC2274.2
+034800     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2274.2
+034900     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2274.2
+035000*                                                                 IC2274.2
+035100 WRITE-LINE.                                                      IC2274.2
+035200     ADD 1 TO RECORD-COUNT.                                       IC2274.2
+035300Y    IF RECORD-COUNT GREATER 50                                   IC2274.2
+035400Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC2274.2
+035500Y        MOVE SPACE TO DUMMY-RECORD                               IC2274.2
+035600Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC2274.2
+035700Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC2274.2
+035800Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC2274.2
+035900Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC2274.2
+036000Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC2274.2
+036100Y        MOVE ZERO TO RECORD-COUNT.                               IC2274.2
+036200     PERFORM WRT-LN.                                              IC2274.2
+036300 WRT-LN.                                                          IC2274.2
+036400     WRITE   DUMMY-RECORD AFTER ADVANCING 1 LINES.                IC2274.2
+036500     MOVE    SPACE TO DUMMY-RECORD.                               IC2274.2
+036600 BLANK-LINE-PRINT.                                                IC2274.2
+036700     PERFORM WRT-LN.                                              IC2274.2
+036800 FAIL-ROUTINE.                                                    IC2274.2
+036900     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC2274.2
+037000     IF   CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.  IC2274.2
+037100     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2274.2
+037200     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC2274.2
+037300     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2274.2
+037400     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2274.2
+037500     GO TO  FAIL-ROUTINE-EX.                                      IC2274.2
+037600 FAIL-ROUTINE-WRITE.                                              IC2274.2
+037700     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC2274.2
+037800     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC2274.2
+037900     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC2274.2
+038000     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC2274.2
+038100 FAIL-ROUTINE-EX. EXIT.                                           IC2274.2
+038200 BAIL-OUT.                                                        IC2274.2
+038300     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC2274.2
+038400     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC2274.2
+038500 BAIL-OUT-WRITE.                                                  IC2274.2
+038600     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC2274.2
+038700     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2274.2
+038800     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2274.2
+038900     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2274.2
+039000 BAIL-OUT-EX. EXIT.                                               IC2274.2
+039100 CCVS1-EXIT.                                                      IC2274.2
+039200     EXIT.                                                        IC2274.2
+039300*                                                                 IC2274.2
+039400****************************************************************  IC2274.2
+039500*                                                              *  IC2274.2
+039600*    THIS POINT MARKS THE END OF THE CCVS MONITOR ROUTINES AND *  IC2274.2
+039700*    THE START OF THE TESTS OF SPECIFIC COBOL FEATURES.        *  IC2274.2
+039800*                                                              *  IC2274.2
+039900****************************************************************  IC2274.2
+040000*                                                                 IC2274.2
+040100 SECT-IC227A-01 SECTION.                                          IC2274.2
+040200 EXT-INIT-01.                                                     IC2274.2
+040300*                                                                 IC2274.2
+040400*    *************************************************            IC2274.2
+040500*    *                                               *            IC2274.2
+040600*    *    MAKE EXTERNAL FILE RECORD AREA AVAILABLE   *            IC2274.2
+040700*    *                                               *            IC2274.2
+040800*    *************************************************            IC2274.2
+040900*                                                                 IC2274.2
+041000     OPEN    OUTPUT EXTERNAL-FILE.                                IC2274.2
+041100*                                                                 IC2274.2
+041200     MOVE    1 TO REC-CT.                                         IC2274.2
+041300     MOVE   "EXTERNAL FILE RECORD" TO FEATURE.                    IC2274.2
+041400     MOVE   "X-23 4.5.1" TO ANSI-REFERENCE.                       IC2274.2
+041500     MOVE   "EXT-REC-TEST-01"     TO PAR-NAME.                    IC2274.2
+041600     MOVE   "******************"  TO EXTERNAL-FILE-RECORD.        IC2274.2
+041700     MOVE   "**"                  TO F-S-PARAM.                   IC2274.2
+041800     MOVE   "AA"                  TO WRK-DATA-1                   IC2274.2
+041900     MOVE   "PQRSTU"              TO WRK-DATA-2                   IC2274.2
+042000     MOVE    123456               TO WRK-DATA-3                   IC2274.2
+042100     MOVE    9876                 TO WRK-DATA-4.                  IC2274.2
+042200     MOVE    EXTERNAL-RECORD-WORK TO EXTERNAL-RECORD-HOLD.        IC2274.2
+042300     MOVE   "<>"                  TO EXTERNAL-FILE-FS.            IC2274.2
+042400     GO TO   EXT-REC-TEST-01.                                     IC2274.2
+042500 EXT-REC-DELETE-01.                                               IC2274.2
+042600     PERFORM DE-LETE.                                             IC2274.2
+042700     GO TO   EXT-REC-DELETE-01-02.                                IC2274.2
+042800*                                                                 IC2274.2
+042900*    *************************************************            IC2274.2
+043000*    *                                               *            IC2274.2
+043100*    *   CHECK THAT SUBPROGRAM SEES SAME RECORD AREA *            IC2274.2
+043200*    *                                               *            IC2274.2
+043300*    *************************************************            IC2274.2
+043400*                                                                 IC2274.2
+043500 EXT-REC-TEST-01.                                                 IC2274.2
+043600     MOVE    1 TO ACTION-CODE.                                    IC2274.2
+043700     CALL   "IC227A1" USING ACTION-CODE                           IC2274.2
+043800                             EXTERNAL-RECORD-WORK                 IC2274.2
+043900                             F-S-PARAM.                           IC2274.2
+044000     IF EXTERNAL-FILE-RECORD EQUAL EXTERNAL-RECORD-HOLD           IC2274.2
+044100         PERFORM PASS                                             IC2274.2
+044200     ELSE                                                         IC2274.2
+044300         MOVE   "SUBPROGRAM DID NOT WRITE TO RECORD AREA"         IC2274.2
+044400                   TO RE-MARK                                     IC2274.2
+044500         MOVE    EXTERNAL-FILE-RECORD TO COMPUTED-A               IC2274.2
+044600         MOVE    EXTERNAL-RECORD-HOLD TO CORRECT-A                IC2274.2
+044700         PERFORM FAIL                                             IC2274.2
+044800     END-IF.                                                      IC2274.2
+044900     GO TO  EXT-REC-TEST-01-02.                                   IC2274.2
+045000 EXT-REC-DELETE-01-02.                                            IC2274.2
+045100     ADD     1 TO REC-CT                                          IC2274.2
+045200     PERFORM DE-LETE.                                             IC2274.2
+045300     GO TO   EXT-REC-DELETE-01-03.                                IC2274.2
+045400 EXT-REC-TEST-01-02.                                              IC2274.2
+045500     ADD     1 TO REC-CT.                                         IC2274.2
+045600     IF EXTERNAL-RECORD-WORK EQUAL "******************"           IC2274.2
+045700         PERFORM PASS                                             IC2274.2
+045800     ELSE                                                         IC2274.2
+045900         MOVE   "SUBPROGRAM DID NOT READ FROM RECORD AREA"        IC2274.2
+046000                   TO RE-MARK                                     IC2274.2
+046100         MOVE    EXTERNAL-RECORD-WORK TO COMPUTED-A               IC2274.2
+046200         MOVE    "******************" TO CORRECT-A                IC2274.2
+046300         PERFORM FAIL                                             IC2274.2
+046400     END-IF.                                                      IC2274.2
+046500     GO TO  EXT-REC-TEST-01-03.                                   IC2274.2
+046600 EXT-REC-DELETE-01-03.                                            IC2274.2
+046700     ADD     1 TO REC-CT                                          IC2274.2
+046800     PERFORM DE-LETE.                                             IC2274.2
+046900     GO TO   EXT-REC-TEST-01-END.                                 IC2274.2
+047000 EXT-REC-TEST-01-03.                                              IC2274.2
+047100     ADD     1 TO REC-CT.                                         IC2274.2
+047200     IF F-S-PARAM IS EQUAL "XX"                                   IC2274.2
+047300         PERFORM PASS                                             IC2274.2
+047400     ELSE                                                         IC2274.2
+047500         MOVE   "WRONG FILE STATUS VALUE RETURNED"                IC2274.2
+047600                   TO RE-MARK                                     IC2274.2
+047700         MOVE    F-S-PARAM TO COMPUTED-A                          IC2274.2
+047800         MOVE    "XX" TO CORRECT-A                                IC2274.2
+047900         PERFORM FAIL                                             IC2274.2
+048000     END-IF.                                                      IC2274.2
+048100 EXT-REC-TEST-01-END.                                             IC2274.2
+048200*                                                                 IC2274.2
+048300*                                                                 IC2274.2
+048400 EXT-INIT-02.                                                     IC2274.2
+048500*                                                                 IC2274.2
+048600*    *************************************************            IC2274.2
+048700*    *                                               *            IC2274.2
+048800*    *    WRITE RECORD FROM PARAMETERS TO FILE       *            IC2274.2
+048900*    *                                               *            IC2274.2
+049000*    *************************************************            IC2274.2
+049100*                                                                 IC2274.2
+049200     MOVE    1 TO REC-CT.                                         IC2274.2
+049300     MOVE   "EXTERNAL FILE WRITE" TO FEATURE.                     IC2274.2
+049400     MOVE   "X-23 4.5.1" TO ANSI-REFERENCE.                       IC2274.2
+049500     MOVE   "EXT-FILE-TEST-02"    TO PAR-NAME.                    IC2274.2
+049600     MOVE   "******************"  TO EXTERNAL-FILE-RECORD.        IC2274.2
+049700     MOVE   "**"                  TO F-S-PARAM.                   IC2274.2
+049800     MOVE   "AA"                  TO WRK-DATA-1                   IC2274.2
+049900     MOVE   "PQRSTU"              TO WRK-DATA-2                   IC2274.2
+050000     MOVE    123456               TO WRK-DATA-3                   IC2274.2
+050100     MOVE    9876                 TO WRK-DATA-4.                  IC2274.2
+050200     MOVE   "<>"                  TO EXTERNAL-FILE-FS.            IC2274.2
+050300     GO TO   EXT-FILE-TEST-02.                                    IC2274.2
+050400 EXT-FILE-DELETE-02.                                              IC2274.2
+050500     PERFORM DE-LETE.                                             IC2274.2
+050600     MOVE    EXTERNAL-RECORD-WORK TO EXTERNAL-FILE-RECORD.        IC2274.2
+050700     WRITE   EXTERNAL-FILE-RECORD.                                IC2274.2
+050800     GO TO   EXT-FILE-DELETE-02-02.                               IC2274.2
+050900*                                                                 IC2274.2
+051000*    *************************************************            IC2274.2
+051100*    *                                               *            IC2274.2
+051200*    *   CHECK THAT SUBPROGRAM WILL WRITE            *            IC2274.2
+051300*    *                                               *            IC2274.2
+051400*    *************************************************            IC2274.2
+051500*                                                                 IC2274.2
+051600 EXT-FILE-TEST-02.                                                IC2274.2
+051700     MOVE    2 TO ACTION-CODE.                                    IC2274.2
+051800     CALL   "IC227A1" USING CONTENT   ACTION-CODE                 IC2274.2
+051900                             REFERENCE EXTERNAL-RECORD-WORK       IC2274.2
+052000                                       F-S-PARAM.                 IC2274.2
+052100     IF F-S-PARAM IS EQUAL "00"                                   IC2274.2
+052200         PERFORM PASS                                             IC2274.2
+052300     ELSE                                                         IC2274.2
+052400         MOVE   "UNEXPECTED FILE STATUS VALUE RETURNED"           IC2274.2
+052500                   TO RE-MARK                                     IC2274.2
+052600         MOVE    F-S-PARAM TO COMPUTED-A                          IC2274.2
+052700         MOVE    "00" TO CORRECT-A                                IC2274.2
+052800         PERFORM FAIL                                             IC2274.2
+052900     END-IF.                                                      IC2274.2
+053000     GO TO   EXT-FILE-TEST-02-02.                                 IC2274.2
+053100 EXT-FILE-DELETE-02-02.                                           IC2274.2
+053200     ADD     1 TO REC-CT                                          IC2274.2
+053300     PERFORM DE-LETE.                                             IC2274.2
+053400     GO TO   EXT-FILE-TEST-02-END.                                IC2274.2
+053500 EXT-FILE-TEST-02-02.                                             IC2274.2
+053600     ADD     1 TO REC-CT.                                         IC2274.2
+053700     IF EXTERNAL-FILE-FS IS EQUAL TO "<>"                         IC2274.2
+053800          PERFORM PASS                                            IC2274.2
+053900     ELSE                                                         IC2274.2
+054000          MOVE   "MAIN PROGRAM FILE STATUS UPDATED" TO RE-MARK    IC2274.2
+054100          MOVE   "<>" TO CORRECT-A                                IC2274.2
+054200          MOVE    EXTERNAL-FILE-FS TO COMPUTED-A                  IC2274.2
+054300          PERFORM FAIL.                                           IC2274.2
+054400*                                                                 IC2274.2
+054500 EXT-FILE-TEST-02-END.                                            IC2274.2
+054600*                                                                 IC2274.2
+054700*                                                                 IC2274.2
+054800 EXT-INIT-03.                                                     IC2274.2
+054900*                                                                 IC2274.2
+055000*    *************************************************            IC2274.2
+055100*    *                                               *            IC2274.2
+055200*    *    WRITE A RECORD FROM THE MAIN PROGRAM       *            IC2274.2
+055300*    *                                               *            IC2274.2
+055400*    *************************************************            IC2274.2
+055500*                                                                 IC2274.2
+055600     MOVE    1 TO REC-CT.                                         IC2274.2
+055700     MOVE   "EXTERNAL FILE WRITE" TO FEATURE.                     IC2274.2
+055800     MOVE   "X-23 4.5.1" TO ANSI-REFERENCE.                       IC2274.2
+055900     MOVE   "EXT-FILE-TEST-03"    TO PAR-NAME.                    IC2274.2
+056000     MOVE   "BB"                  TO EXT-DATA-1                   IC2274.2
+056100     MOVE   "ZYXWVU"              TO EXT-DATA-2                   IC2274.2
+056200     MOVE    222222               TO EXT-DATA-3                   IC2274.2
+056300     MOVE    9765                 TO EXT-DATA-4.                  IC2274.2
+056400     MOVE   "<>"                  TO EXTERNAL-FILE-FS.            IC2274.2
+056500     GO TO   EXT-FILE-TEST-03-01.                                 IC2274.2
+056600 EXT-FILE-DELETE-03.                                              IC2274.2
+056700     PERFORM DE-LETE.                                             IC2274.2
+056800     GO TO   EXT-FILE-TEST-03-END.                                IC2274.2
+056900*                                                                 IC2274.2
+057000 EXT-FILE-TEST-03-01.                                             IC2274.2
+057100     WRITE   EXTERNAL-FILE-RECORD.                                IC2274.2
+057200     IF EXTERNAL-FILE-FS IS EQUAL TO "00"                         IC2274.2
+057300          PERFORM PASS                                            IC2274.2
+057400     ELSE                                                         IC2274.2
+057500          MOVE   "MAIN PROGRAM FILE STATUS NON-ZERO" TO RE-MARK   IC2274.2
+057600          MOVE   "00" TO CORRECT-A                                IC2274.2
+057700          MOVE    EXTERNAL-FILE-FS TO COMPUTED-A                  IC2274.2
+057800          PERFORM FAIL.                                           IC2274.2
+057900*                                                                 IC2274.2
+058000 EXT-FILE-TEST-03-END.                                            IC2274.2
+058100*                                                                 IC2274.2
+058200*                                                                 IC2274.2
+058300 EXT-INIT-04.                                                     IC2274.2
+058400*                                                                 IC2274.2
+058500*    *************************************************            IC2274.2
+058600*    *                                               *            IC2274.2
+058700*    *    CLOSE THE FILE THROUGH THE SUBPROGRAM      *            IC2274.2
+058800*    *                                               *            IC2274.2
+058900*    *************************************************            IC2274.2
+059000*                                                                 IC2274.2
+059100     MOVE    1 TO REC-CT.                                         IC2274.2
+059200     MOVE   "EXTERNAL FILE CLOSE" TO FEATURE.                     IC2274.2
+059300     MOVE   "X-23 4.5.1" TO ANSI-REFERENCE.                       IC2274.2
+059400     MOVE   "EXT-FILE-TEST-04"    TO PAR-NAME.                    IC2274.2
+059500     MOVE   "**"                  TO F-S-PARAM.                   IC2274.2
+059600     MOVE   "<>"                  TO EXTERNAL-FILE-FS.            IC2274.2
+059700     GO TO   EXT-FILE-TEST-04-01.                                 IC2274.2
+059800 EXT-FILE-DELETE-04-01.                                           IC2274.2
+059900     PERFORM DE-LETE.                                             IC2274.2
+060000     CLOSE   EXTERNAL-FILE.                                       IC2274.2
+060100     GO TO   EXT-FILE-DELETE-04-02.                               IC2274.2
+060200*                                                                 IC2274.2
+060300 EXT-FILE-TEST-04-01.                                             IC2274.2
+060400     MOVE    3 TO ACTION-CODE.                                    IC2274.2
+060500     CALL   "IC227A1" USING CONTENT   ACTION-CODE                 IC2274.2
+060600                                       EXTERNAL-RECORD-WORK       IC2274.2
+060700                             REFERENCE F-S-PARAM.                 IC2274.2
+060800     IF F-S-PARAM IS EQUAL "00"                                   IC2274.2
+060900         PERFORM PASS                                             IC2274.2
+061000     ELSE                                                         IC2274.2
+061100         MOVE   "UNEXPECTED FILE STATUS VALUE RETURNED"           IC2274.2
+061200                   TO RE-MARK                                     IC2274.2
+061300         MOVE    F-S-PARAM TO COMPUTED-A                          IC2274.2
+061400         MOVE    "00" TO CORRECT-A                                IC2274.2
+061500         PERFORM FAIL                                             IC2274.2
+061600     END-IF.                                                      IC2274.2
+061700     GO TO   EXT-FILE-TEST-04-02.                                 IC2274.2
+061800 EXT-FILE-DELETE-04-02.                                           IC2274.2
+061900     ADD     1 TO REC-CT                                          IC2274.2
+062000     PERFORM DE-LETE.                                             IC2274.2
+062100     GO TO   EXT-FILE-TEST-04-END.                                IC2274.2
+062200 EXT-FILE-TEST-04-02.                                             IC2274.2
+062300     ADD     1 TO REC-CT.                                         IC2274.2
+062400     IF EXTERNAL-FILE-FS IS EQUAL TO "<>"                         IC2274.2
+062500          PERFORM PASS                                            IC2274.2
+062600     ELSE                                                         IC2274.2
+062700          MOVE   "MAIN PROGRAM FILE STATUS UPDATED" TO RE-MARK    IC2274.2
+062800          MOVE   "<>" TO CORRECT-A                                IC2274.2
+062900          MOVE    EXTERNAL-FILE-FS TO COMPUTED-A                  IC2274.2
+063000          PERFORM FAIL.                                           IC2274.2
+063100*                                                                 IC2274.2
+063200 EXT-FILE-TEST-04-END.                                            IC2274.2
+063300*                                                                 IC2274.2
+063400*                                                                 IC2274.2
+063500 EXT-INIT-05.                                                     IC2274.2
+063600*                                                                 IC2274.2
+063700*    *************************************************            IC2274.2
+063800*    *                                               *            IC2274.2
+063900*    *    OPEN FILE FOR INPUT FROM SUBPROGRAM        *            IC2274.2
+064000*    *                                               *            IC2274.2
+064100*    *************************************************            IC2274.2
+064200*                                                                 IC2274.2
+064300     MOVE    1 TO REC-CT.                                         IC2274.2
+064400     MOVE   "EXTERNAL FILE OPEN"  TO FEATURE.                     IC2274.2
+064500     MOVE   "X-23 4.5.1" TO ANSI-REFERENCE.                       IC2274.2
+064600     MOVE   "EXT-FILE-TEST-05"    TO PAR-NAME.                    IC2274.2
+064700     MOVE   "******************"  TO EXTERNAL-RECORD-WORK.        IC2274.2
+064800     MOVE    EXTERNAL-RECORD-WORK TO EXTERNAL-RECORD-HOLD.        IC2274.2
+064900     MOVE   "**"                  TO F-S-PARAM.                   IC2274.2
+065000     MOVE   "<>"                  TO EXTERNAL-FILE-FS.            IC2274.2
+065100     GO TO   EXT-FILE-TEST-05-01.                                 IC2274.2
+065200 EXT-FILE-DELETE-05.                                              IC2274.2
+065300     PERFORM DE-LETE.                                             IC2274.2
+065400     OPEN    INPUT EXTERNAL-FILE.                                 IC2274.2
+065500     GO TO   EXT-FILE-DELETE-05-02.                               IC2274.2
+065600 EXT-FILE-TEST-05-01.                                             IC2274.2
+065700     MOVE    4 TO ACTION-CODE.                                    IC2274.2
+065800     CALL    ID1    USING BY CONTENT   ACTION-CODE                IC2274.2
+065900                             REFERENCE EXTERNAL-RECORD-WORK       IC2274.2
+066000                          BY REFERENCE F-S-PARAM.                 IC2274.2
+066100     IF F-S-PARAM IS EQUAL "00"                                   IC2274.2
+066200         PERFORM PASS                                             IC2274.2
+066300     ELSE                                                         IC2274.2
+066400         MOVE   "UNEXPECTED FILE STATUS VALUE RETURNED"           IC2274.2
+066500                   TO RE-MARK                                     IC2274.2
+066600         MOVE    F-S-PARAM TO COMPUTED-A                          IC2274.2
+066700         MOVE    "00" TO CORRECT-A                                IC2274.2
+066800         PERFORM FAIL                                             IC2274.2
+066900     END-IF.                                                      IC2274.2
+067000     GO TO   EXT-FILE-TEST-05-02.                                 IC2274.2
+067100 EXT-FILE-DELETE-05-02.                                           IC2274.2
+067200     ADD     1 TO REC-CT                                          IC2274.2
+067300     PERFORM DE-LETE.                                             IC2274.2
+067400     GO TO   EXT-FILE-DELETE-05-03.                               IC2274.2
+067500 EXT-FILE-TEST-05-02.                                             IC2274.2
+067600     ADD     1 TO REC-CT.                                         IC2274.2
+067700     IF EXTERNAL-FILE-FS IS EQUAL TO "<>"                         IC2274.2
+067800          PERFORM PASS                                            IC2274.2
+067900     ELSE                                                         IC2274.2
+068000          MOVE   "MAIN PROGRAM FILE STATUS UPDATED" TO RE-MARK    IC2274.2
+068100          MOVE   "<>" TO CORRECT-A                                IC2274.2
+068200          MOVE    EXTERNAL-FILE-FS TO COMPUTED-A                  IC2274.2
+068300          PERFORM FAIL.                                           IC2274.2
+068400*    GO TO   EXT-FILE-TEST-05-03.                                 IC2274.2
+068500 EXT-FILE-DELETE-05-03.                                           IC2274.2
+068600     ADD     1 TO REC-CT.                                         IC2274.2
+068700     PERFORM DE-LETE.                                             IC2274.2
+068800     GO TO   EXT-FILE-DELETE-05-04.                               IC2274.2
+068900 EXT-FILE-TEST-05-03.                                             IC2274.2
+069000     ADD     1 TO REC-CT.                                         IC2274.2
+069100     IF EXTERNAL-FILE-RECORD = EXTERNAL-RECORD-HOLD               IC2274.2
+069200          PERFORM PASS                                            IC2274.2
+069300     ELSE                                                         IC2274.2
+069400          MOVE   "PARAMETER NOT RETURNED THROUGH RECORD AREA"     IC2274.2
+069500                    TO RE-MARK                                    IC2274.2
+069600          MOVE    EXTERNAL-FILE-RECORD TO COMPUTED-A              IC2274.2
+069700          MOVE    EXTERNAL-RECORD-HOLD TO CORRECT-A               IC2274.2
+069800          PERFORM FAIL.                                           IC2274.2
+069900     GO TO   EXT-FILE-TEST-05-04.                                 IC2274.2
+070000 EXT-FILE-DELETE-05-04.                                           IC2274.2
+070100     ADD     1 TO REC-CT.                                         IC2274.2
+070200     PERFORM DE-LETE.                                             IC2274.2
+070300     GO TO   EXT-FILE-TEST-05-END.                                IC2274.2
+070400 EXT-FILE-TEST-05-04.                                             IC2274.2
+070500     ADD     1 TO REC-CT.                                         IC2274.2
+070600     IF EXTERNAL-RECORD-WORK IS = "OPEN   OPEN   OPEN"            IC2274.2
+070700          PERFORM PASS                                            IC2274.2
+070800     ELSE                                                         IC2274.2
+070900          MOVE   "PARAMETER RETURN INCORRECT" TO RE-MARK          IC2274.2
+071000          MOVE   "OPEN   OPEN   OPEN"  TO CORRECT-A               IC2274.2
+071100          MOVE    EXTERNAL-RECORD-WORK TO COMPUTED-A              IC2274.2
+071200          PERFORM FAIL.                                           IC2274.2
+071300*                                                                 IC2274.2
+071400 EXT-FILE-TEST-05-END.                                            IC2274.2
+071500*                                                                 IC2274.2
+071600*                                                                 IC2274.2
+071700 EXT-INIT-06.                                                     IC2274.2
+071800*                                                                 IC2274.2
+071900*    *************************************************            IC2274.2
+072000*    *                                               *            IC2274.2
+072100*    *    READ THE FIRST RECORD FROM THE FILE WITH   *            IC2274.2
+072200*    *    THE MAIN PROGRAM .                         *            IC2274.2
+072300*    *                                               *            IC2274.2
+072400*    *************************************************            IC2274.2
+072500*                                                                 IC2274.2
+072600     MOVE    1 TO REC-CT.                                         IC2274.2
+072700     MOVE   "EXTERNAL FILE READ"  TO FEATURE.                     IC2274.2
+072800     MOVE   "X-23 4.5.1"          TO ANSI-REFERENCE.              IC2274.2
+072900     MOVE   "EXT-FILE-TEST-06"    TO PAR-NAME.                    IC2274.2
+073000     MOVE   "%%%%%%%%%%%%%%%%%%"  TO EXTERNAL-FILE-RECORD.        IC2274.2
+073100     MOVE   "AAPQRSTU1234569876"  TO EXTERNAL-RECORD-HOLD.        IC2274.2
+073200     MOVE   "<>"                  TO EXTERNAL-FILE-FS.            IC2274.2
+073300     GO TO   EXT-FILE-TEST-06-01.                                 IC2274.2
+073400 EXT-FILE-DELETE-06.                                              IC2274.2
+073500     PERFORM DE-LETE.                                             IC2274.2
+073600     GO TO   EXT-FILE-DELETE-06-02.                               IC2274.2
+073700 EXT-FILE-TEST-06-01.                                             IC2274.2
+073800     READ    EXTERNAL-FILE NEXT RECORD                            IC2274.2
+073900            AT END GO TO EXT-FILE-TEST-06-02.                     IC2274.2
+074000     IF EXTERNAL-FILE-FS IS EQUAL "00"                            IC2274.2
+074100         PERFORM PASS                                             IC2274.2
+074200     ELSE                                                         IC2274.2
+074300         MOVE   "UNEXPECTED FILE STATUS VALUE RETURNED"           IC2274.2
+074400                   TO RE-MARK                                     IC2274.2
+074500         MOVE    EXTERNAL-FILE-FS TO COMPUTED-A                   IC2274.2
+074600         MOVE    "00" TO CORRECT-A                                IC2274.2
+074700         PERFORM FAIL                                             IC2274.2
+074800     END-IF.                                                      IC2274.2
+074900     GO TO   EXT-FILE-TEST-06-02.                                 IC2274.2
+075000 EXT-FILE-DELETE-06-02.                                           IC2274.2
+075100     ADD     1 TO REC-CT                                          IC2274.2
+075200     PERFORM DE-LETE.                                             IC2274.2
+075300     GO TO   EXT-FILE-TEST-06-END.                                IC2274.2
+075400 EXT-FILE-TEST-06-02.                                             IC2274.2
+075500     ADD     1 TO REC-CT.                                         IC2274.2
+075600     IF EXTERNAL-FILE-RECORD = EXTERNAL-RECORD-HOLD               IC2274.2
+075700          PERFORM PASS                                            IC2274.2
+075800     ELSE                                                         IC2274.2
+075900          MOVE "EXPECTED RECORD NOT READ FROM FILE"               IC2274.2
+076000                    TO RE-MARK                                    IC2274.2
+076100          MOVE    EXTERNAL-FILE-RECORD TO COMPUTED-A              IC2274.2
+076200          MOVE    EXTERNAL-RECORD-HOLD TO CORRECT-A               IC2274.2
+076300          PERFORM FAIL.                                           IC2274.2
+076400*                                                                 IC2274.2
+076500 EXT-FILE-TEST-06-END.                                            IC2274.2
+076600*                                                                 IC2274.2
+076700*                                                                 IC2274.2
+076800 EXT-INIT-07.                                                     IC2274.2
+076900*                                                                 IC2274.2
+077000*    *************************************************            IC2274.2
+077100*    *                                               *            IC2274.2
+077200*    *    READ SECOND RECORD FROM THE FILE THROUGH   *            IC2274.2
+077300*    *    THE SUBPROGRAM                             *            IC2274.2
+077400*    *                                               *            IC2274.2
+077500*    *************************************************            IC2274.2
+077600*                                                                 IC2274.2
+077700     MOVE    1 TO REC-CT.                                         IC2274.2
+077800     MOVE   "EXTERNAL FILE READ"  TO FEATURE.                     IC2274.2
+077900     MOVE   "X-23 4.5.1" TO ANSI-REFERENCE.                       IC2274.2
+078000     MOVE   "EXT-FILE-TEST-07"    TO PAR-NAME.                    IC2274.2
+078100     MOVE   "%%%%%%%%%%%%%%%%%%"  TO EXTERNAL-FILE-RECORD.        IC2274.2
+078200     MOVE   ";;;;;;;;;;;;;;;;;;"  TO EXTERNAL-RECORD-WORK.        IC2274.2
+078300     MOVE   "BBZYXWVU2222229765"  TO EXTERNAL-RECORD-HOLD.        IC2274.2
+078400     MOVE   "**"                  TO F-S-PARAM.                   IC2274.2
+078500     MOVE   "<>"                  TO EXTERNAL-FILE-FS.            IC2274.2
+078600     GO TO   EXT-FILE-TEST-07-01.                                 IC2274.2
+078700 EXT-FILE-DELETE-07.                                              IC2274.2
+078800     PERFORM DE-LETE.                                             IC2274.2
+078900     GO TO   EXT-FILE-DELETE-07-02.                               IC2274.2
+079000 EXT-FILE-TEST-07-01.                                             IC2274.2
+079100     MOVE    5 TO ACTION-CODE.                                    IC2274.2
+079200     CALL    ID1    USING BY CONTENT   ACTION-CODE                IC2274.2
+079300                             REFERENCE EXTERNAL-RECORD-WORK       IC2274.2
+079400                          BY REFERENCE F-S-PARAM.                 IC2274.2
+079500     IF F-S-PARAM IS EQUAL "00"                                   IC2274.2
+079600         PERFORM PASS                                             IC2274.2
+079700     ELSE                                                         IC2274.2
+079800         MOVE   "UNEXPECTED FILE STATUS VALUE RETURNED"           IC2274.2
+079900                   TO RE-MARK                                     IC2274.2
+080000         MOVE    F-S-PARAM TO COMPUTED-A                          IC2274.2
+080100         MOVE    "00" TO CORRECT-A                                IC2274.2
+080200         PERFORM FAIL                                             IC2274.2
+080300     END-IF.                                                      IC2274.2
+080400     GO TO   EXT-FILE-TEST-07-02.                                 IC2274.2
+080500 EXT-FILE-DELETE-07-02.                                           IC2274.2
+080600     ADD     1 TO REC-CT                                          IC2274.2
+080700     PERFORM DE-LETE.                                             IC2274.2
+080800     GO TO   EXT-FILE-DELETE-07-03.                               IC2274.2
+080900 EXT-FILE-TEST-07-02.                                             IC2274.2
+081000     ADD     1 TO REC-CT.                                         IC2274.2
+081100     IF EXTERNAL-FILE-FS IS EQUAL TO "<>"                         IC2274.2
+081200          PERFORM PASS                                            IC2274.2
+081300     ELSE                                                         IC2274.2
+081400          MOVE   "MAIN PROGRAM FILE STATUS UPDATED" TO RE-MARK    IC2274.2
+081500          MOVE   "<>" TO CORRECT-A                                IC2274.2
+081600          MOVE    EXTERNAL-FILE-FS TO COMPUTED-A                  IC2274.2
+081700          PERFORM FAIL.                                           IC2274.2
+081800     GO TO   EXT-FILE-TEST-07-03.                                 IC2274.2
+081900 EXT-FILE-DELETE-07-03.                                           IC2274.2
+082000     ADD     1 TO REC-CT.                                         IC2274.2
+082100     PERFORM DE-LETE.                                             IC2274.2
+082200     GO TO   EXT-FILE-DELETE-07-04.                               IC2274.2
+082300 EXT-FILE-TEST-07-03.                                             IC2274.2
+082400     ADD     1 TO REC-CT.                                         IC2274.2
+082500     IF EXTERNAL-FILE-RECORD = EXTERNAL-RECORD-HOLD               IC2274.2
+082600          PERFORM PASS                                            IC2274.2
+082700     ELSE                                                         IC2274.2
+082800          MOVE "EXPECTED RECORD NOT RETURNED THROUGH RECORD AREA" IC2274.2
+082900                    TO RE-MARK                                    IC2274.2
+083000          MOVE    EXTERNAL-FILE-RECORD TO COMPUTED-A              IC2274.2
+083100          MOVE    EXTERNAL-RECORD-HOLD TO CORRECT-A               IC2274.2
+083200          PERFORM FAIL.                                           IC2274.2
+083300     GO TO   EXT-FILE-TEST-07-04.                                 IC2274.2
+083400 EXT-FILE-DELETE-07-04.                                           IC2274.2
+083500     ADD     1 TO REC-CT.                                         IC2274.2
+083600     PERFORM DE-LETE.                                             IC2274.2
+083700     GO TO   EXT-FILE-TEST-07-END.                                IC2274.2
+083800 EXT-FILE-TEST-07-04.                                             IC2274.2
+083900     ADD     1 TO REC-CT.                                         IC2274.2
+084000     IF EXTERNAL-RECORD-WORK IS = EXTERNAL-RECORD-HOLD            IC2274.2
+084100          PERFORM PASS                                            IC2274.2
+084200     ELSE                                                         IC2274.2
+084300          MOVE   "PARAMETER RETURN INCORRECT" TO RE-MARK          IC2274.2
+084400          MOVE    EXTERNAL-RECORD-HOLD TO CORRECT-A               IC2274.2
+084500          MOVE    EXTERNAL-RECORD-WORK TO COMPUTED-A              IC2274.2
+084600          PERFORM FAIL.                                           IC2274.2
+084700*                                                                 IC2274.2
+084800 EXT-FILE-TEST-07-END.                                            IC2274.2
+084900*                                                                 IC2274.2
+085000*                                                                 IC2274.2
+085100 EXT-INIT-08.                                                     IC2274.2
+085200*                                                                 IC2274.2
+085300*    *************************************************            IC2274.2
+085400*    *                                               *            IC2274.2
+085500*    *    ATTEMPT TO READ A THIRD RECORD FROM THE    *            IC2274.2
+085600*    *    FILE THROUGH THE SUBPROGRAM.  THIS SHOULD  *            IC2274.2
+085700*    *    CAUSE AN END OF FILE CONDITION.            *            IC2274.2
+085800*    *                                               *            IC2274.2
+085900*    *************************************************            IC2274.2
+086000*                                                                 IC2274.2
+086100     MOVE    1 TO REC-CT.                                         IC2274.2
+086200     MOVE   "EXTERNAL FILE EOF"   TO FEATURE.                     IC2274.2
+086300     MOVE   "X-23 4.5.1" TO ANSI-REFERENCE.                       IC2274.2
+086400     MOVE   "EXT-FILE-TEST-08"    TO PAR-NAME.                    IC2274.2
+086500     MOVE   "%%%%%%%%%%%%%%%%%%"  TO EXTERNAL-FILE-RECORD.        IC2274.2
+086600     MOVE   ";;;;;;;;;;;;;;;;;;"  TO EXTERNAL-RECORD-WORK.        IC2274.2
+086700     MOVE   "END-FILE  END-FILE"  TO EXTERNAL-RECORD-HOLD.        IC2274.2
+086800     MOVE   "**"                  TO F-S-PARAM.                   IC2274.2
+086900     MOVE   "<>"                  TO EXTERNAL-FILE-FS.            IC2274.2
+087000     GO TO   EXT-FILE-TEST-08-01.                                 IC2274.2
+087100 EXT-FILE-DELETE-08.                                              IC2274.2
+087200     PERFORM DE-LETE.                                             IC2274.2
+087300     GO TO   EXT-FILE-DELETE-08-02.                               IC2274.2
+087400 EXT-FILE-TEST-08-01.                                             IC2274.2
+087500     MOVE    5 TO ACTION-CODE.                                    IC2274.2
+087600     CALL   "IC227A1"  USING CONTENT   ACTION-CODE                IC2274.2
+087700                             REFERENCE EXTERNAL-RECORD-WORK       IC2274.2
+087800                          BY REFERENCE F-S-PARAM.                 IC2274.2
+087900     IF F-S-PARAM IS EQUAL "10"                                   IC2274.2
+088000         PERFORM PASS                                             IC2274.2
+088100     ELSE                                                         IC2274.2
+088200         MOVE   "UNEXPECTED FILE STATUS VALUE RETURNED"           IC2274.2
+088300                   TO RE-MARK                                     IC2274.2
+088400         MOVE    F-S-PARAM TO COMPUTED-A                          IC2274.2
+088500         MOVE    "10" TO CORRECT-A                                IC2274.2
+088600         PERFORM FAIL                                             IC2274.2
+088700     END-IF.                                                      IC2274.2
+088800     GO TO   EXT-FILE-TEST-08-02.                                 IC2274.2
+088900 EXT-FILE-DELETE-08-02.                                           IC2274.2
+089000     ADD     1 TO REC-CT                                          IC2274.2
+089100     PERFORM DE-LETE.                                             IC2274.2
+089200     GO TO   EXT-FILE-DELETE-08-03.                               IC2274.2
+089300 EXT-FILE-TEST-08-02.                                             IC2274.2
+089400     ADD     1 TO REC-CT.                                         IC2274.2
+089500     IF EXTERNAL-FILE-FS IS EQUAL TO "<>"                         IC2274.2
+089600          PERFORM PASS                                            IC2274.2
+089700     ELSE                                                         IC2274.2
+089800          MOVE   "MAIN PROGRAM FILE STATUS UPDATED" TO RE-MARK    IC2274.2
+089900          MOVE   "<>" TO CORRECT-A                                IC2274.2
+090000          MOVE    EXTERNAL-FILE-FS TO COMPUTED-A                  IC2274.2
+090100          PERFORM FAIL.                                           IC2274.2
+090200*    GO TO   EXT-FILE-TEST-08-03.                                 IC2274.2
+090300 EXT-FILE-DELETE-08-03.                                           IC2274.2
+090400     ADD     1 TO REC-CT.                                         IC2274.2
+090500     PERFORM DE-LETE.                                             IC2274.2
+090600     GO TO   EXT-FILE-DELETE-08-04.                               IC2274.2
+090700 EXT-FILE-TEST-08-03.                                             IC2274.2
+090800     ADD     1 TO REC-CT.                                         IC2274.2
+090900     IF EXTERNAL-FILE-RECORD = EXTERNAL-RECORD-HOLD               IC2274.2
+091000          PERFORM PASS                                            IC2274.2
+091100     ELSE                                                         IC2274.2
+091200          MOVE "EXPECTED VALUE NOT RETURNED THROUGH RECORD AREA"  IC2274.2
+091300                    TO RE-MARK                                    IC2274.2
+091400          MOVE    EXTERNAL-FILE-RECORD TO COMPUTED-A              IC2274.2
+091500          MOVE    EXTERNAL-RECORD-HOLD TO CORRECT-A               IC2274.2
+091600          PERFORM FAIL.                                           IC2274.2
+091700*    GO TO   EXT-FILE-TEST-08-04.                                 IC2274.2
+091800 EXT-FILE-DELETE-08-04.                                           IC2274.2
+091900     ADD     1 TO REC-CT.                                         IC2274.2
+092000     PERFORM DE-LETE.                                             IC2274.2
+092100     GO TO   EXT-FILE-TEST-08-END.                                IC2274.2
+092200 EXT-FILE-TEST-08-04.                                             IC2274.2
+092300     ADD     1 TO REC-CT.                                         IC2274.2
+092400     IF EXTERNAL-RECORD-WORK IS = EXTERNAL-RECORD-HOLD            IC2274.2
+092500          PERFORM PASS                                            IC2274.2
+092600     ELSE                                                         IC2274.2
+092700          MOVE   "PARAMETER RETURN INCORRECT" TO RE-MARK          IC2274.2
+092800          MOVE    EXTERNAL-RECORD-HOLD TO CORRECT-A               IC2274.2
+092900          MOVE    EXTERNAL-RECORD-WORK TO COMPUTED-A              IC2274.2
+093000          PERFORM FAIL.                                           IC2274.2
+093100*                                                                 IC2274.2
+093200 EXT-FILE-TEST-08-END.                                            IC2274.2
+093300*                                                                 IC2274.2
+093400*                                                                 IC2274.2
+093500 EXT-INIT-09.                                                     IC2274.2
+093600*                                                                 IC2274.2
+093700*    *************************************************            IC2274.2
+093800*    *                                               *            IC2274.2
+093900*    *    CLOSE THE EXTERNAL FILE FROM THE MAIN      *            IC2274.2
+094000*    *    PROGRAM.                                   *            IC2274.2
+094100*    *                                               *            IC2274.2
+094200*    *************************************************            IC2274.2
+094300*                                                                 IC2274.2
+094400     MOVE    1 TO REC-CT.                                         IC2274.2
+094500     MOVE   "EXTERNAL FILE CLOSE" TO FEATURE.                     IC2274.2
+094600     MOVE   "X-23 4.5.1" TO ANSI-REFERENCE.                       IC2274.2
+094700     MOVE   "EXT-FILE-TEST-09"    TO PAR-NAME.                    IC2274.2
+094800     MOVE   "<>"                  TO EXTERNAL-FILE-FS.            IC2274.2
+094900     GO TO   EXT-FILE-TEST-09-01.                                 IC2274.2
+095000 EXT-FILE-DELETE-09.                                              IC2274.2
+095100     PERFORM DE-LETE.                                             IC2274.2
+095200     GO TO   EXT-FILE-TEST-09-END.                                IC2274.2
+095300 EXT-FILE-TEST-09-01.                                             IC2274.2
+095400     CLOSE EXTERNAL-FILE.                                         IC2274.2
+095500     IF EXTERNAL-FILE-FS IS EQUAL TO "00"                         IC2274.2
+095600          PERFORM PASS                                            IC2274.2
+095700     ELSE                                                         IC2274.2
+095800          MOVE   "FILE CLOSE FAILURE" TO RE-MARK                  IC2274.2
+095900          MOVE   "00" TO CORRECT-A                                IC2274.2
+096000          MOVE    EXTERNAL-FILE-FS TO COMPUTED-A                  IC2274.2
+096100          PERFORM FAIL.                                           IC2274.2
+096200 EXT-FILE-TEST-09-END.                                            IC2274.2
+096300*                                                                 IC2274.2
+096400*                                                                 IC2274.2
+096500 CCVS-EXIT SECTION.                                               IC2274.2
+096600 CCVS-999999.                                                     IC2274.2
+096700     GO TO CLOSE-FILES.                                           IC2274.2
+096800 END PROGRAM IC227A.                                              IC2274.2

--- a/z390/IC227A1.CBL
+++ b/z390/IC227A1.CBL
@@ -1,0 +1,238 @@
+096900 IDENTIFICATION DIVISION.                                         IC2274.2
+      *
+      * This is the z390 version of IC227A-1
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC227A1
+      * IC227A has been modified to call IC227A1 instead of IC227A-1.
+      *
+097000 PROGRAM-ID.                                                      IC2274.2
+097100     IC227A1.                                                     IC2274.2
+097200****************************************************************  IC2274.2
+097300*                                                              *  IC2274.2
+097400*    THIS PROGRAM FORMS PART OF THE COBOL COMPILER VALIDATION  *  IC2274.2
+097500*    SYSTEM (CCVS) USED TO TEST COBOL COMPILERS FOR            *  IC2274.2
+097600*    CONFORMANCE WITH THE AMERICAN NATIONAL STANDARD           *  IC2274.2
+097700*    (ANSI DOCUMENT REFERENCE: X3.23-1985) AND THE STANDARD OF *  IC2274.2
+097800*    THE INTERNATIONAL ORGANIZATION FOR STANDARDISATION        *  IC2274.2
+097900*    (ISO DOCUMENT REFERENCE: ISO-1989-1985).                  *  IC2274.2
+098000*                                                              *  IC2274.2
+098100*    THIS CCVS INCORPORATES ENHANCEMENTS TO THE CCVS FOR THE   *  IC2274.2
+098200*    1974 STANDARD (ANSI DOCUMENT REFERENCE: X3.23-1974; ISO   *  IC2274.2
+098300*    DOCUMENT REFERENCE: ISO-1989-1978).                       *  IC2274.2
+098400*                                                              *  IC2274.2
+098500*    THESE ENHANCEMENTS WERE SPECIFIED BY A PROJECT TEAM WHICH *  IC2274.2
+098600*    WAS FUNDED BY THE COMMISSION FOR EUROPEAN COMMUNITIES AND *  IC2274.2
+098700*    WHICH WAS RESPONSIBLE FOR TECHNICAL ISSUES TO:            *  IC2274.2
+098800*                                                              *  IC2274.2
+098900*          THE FEDERAL SOFTWARE TESTING CENTER                 *  IC2274.2
+099000*          OFFICE OF SOFTWARE DEVELOPMENT                      *  IC2274.2
+099100*                & INFORMATION TECHNOLOGY                      *  IC2274.2
+099200*          TWO SKYLINE PLACE                                   *  IC2274.2
+099300*          SUITE 1100                                          *  IC2274.2
+099400*          5203 LEESBURG PIKE                                  *  IC2274.2
+099500*          FALLS CHURCH                                        *  IC2274.2
+099600*          VA 22041                                            *  IC2274.2
+099700*          U.S.A.                                              *  IC2274.2
+099800*                                                              *  IC2274.2
+099900*    THE PROJECT TEAM MEMBERS WERE:                            *  IC2274.2
+100000*                                                              *  IC2274.2
+100100*          BIADI (BUREAU INTER ADMINISTRATION                  *  IC2274.2
+100200*                 DE DOCUMENTATION INFORMATIQUE)               *  IC2274.2
+100300*          21 RUE BARA                                         *  IC2274.2
+100400*          F-92132 ISSY                                        *  IC2274.2
+100500*          FRANCE                                              *  IC2274.2
+100600*                                                              *  IC2274.2
+100700*                                                              *  IC2274.2
+100800*          GMD (GESELLSCHAFT FUR MATHEMATIK                    *  IC2274.2
+100900*               UND DATENVERARBEITUNG MBH)                     *  IC2274.2
+101000*          SCHLOSS BIRLINGHOVEN                                *  IC2274.2
+101100*          POSTFACH 12 40                                      *  IC2274.2
+101200*          D-5205 ST. AUGUSTIN 1                               *  IC2274.2
+101300*          GERMANY FR                                          *  IC2274.2
+101400*                                                              *  IC2274.2
+101500*                                                              *  IC2274.2
+101600*          NCC (THE NATIONAL COMPUTING CENTRE LTD)             *  IC2274.2
+101700*          OXFORD ROAD                                         *  IC2274.2
+101800*          MANCHESTER                                          *  IC2274.2
+101900*          M1 7ED                                              *  IC2274.2
+102000*          UNITED KINGDOM                                      *  IC2274.2
+102100*                                                              *  IC2274.2
+102200*                                                              *  IC2274.2
+102300*    THIS TEST SUITE WAS PRODUCED BY THE NATIONAL COMPUTING    *  IC2274.2
+102400*    CENTRE IN ENGLAND AND IS THE OFFICIAL CCVS TEST SUITE     *  IC2274.2
+102500*    USED THROUGHOUT EUROPE AND THE UNITED STATES OF AMERICA.  *  IC2274.2
+102600*                                                              *  IC2274.2
+102700*    REVISED 1986 AUGUST                                       *  IC2274.2
+102800*                                                              *  IC2274.2
+102900****************************************************************  IC2274.2
+103000*                                                              *  IC2274.2
+103100*    VALIDATION FOR:-                                          *  IC2274.2
+103200*                                                              *  IC2274.2
+103300*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2274.2
+103400*                                                              *  IC2274.2
+103500*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2274.2
+103600*                                                              *  IC2274.2
+103700****************************************************************  IC2274.2
+103800*                                                              *  IC2274.2
+103900*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2274.2
+104000*                                                              *  IC2274.2
+104100*            X-82   SOURCE-COMPUTER                            *  IC2274.2
+104200*            X-83   OBJECT-COMPUTER.                           *  IC2274.2
+104300*                                                              *  IC2274.2
+104400****************************************************************  IC2274.2
+104500*                                                              *  IC2274.2
+104600*    PROGRAMS IC227A AND IC227A-1 TEST LEVEL 2 LANGUAGE        *  IC2274.2
+104700*    ELEMENTS FROM THE INTER-PROGRAM COMMUNICATION MODULE.     *  IC2274.2
+104800*    THE PARTICULAR ELEMENTS TESTED ARE:                       *  IC2274.2
+104900*        THE "EXTERNAL" CLAUSE IN THE FILE DESCRIPTION ENTRY   *  IC2274.2
+105000*                                                              *  IC2274.2
+105100*    ALTHOUGH IC227A AND IC227A-1 ARE SEPARATELY COMPILED      *  IC2274.2
+105200*    PROGRAMS, BOTH ARE INTENDED TO BE COMPILED BY THE SAME    *  IC2274.2
+105300*    INVOCATION OF THE COMPILER, IN ORDER TO TEST STREAM       *  IC2274.2
+105400*    COMPILATION AND RECOGNITION OF THE END PROGRAM HEADER.    *  IC2274.2
+105500*                                                              *  IC2274.2
+105600*    THE STRUCTURE OF THE SOURCE FILE IS:                      *  IC2274.2
+105700*                                                              *  IC2274.2
+105800*    IDENTIFICATION DIVISION.                                  *  IC2274.2
+105900*    PROGRAM-ID.  IC227A.                                      *  IC2274.2
+106000*              .                                               *  IC2274.2
+106100*              .                                               *  IC2274.2
+106200*              .                                               *  IC2274.2
+106300*    END PROGRAM IC227A.                                       *  IC2274.2
+106400*    IDENTIFICATION DIVISION.                                  *  IC2274.2
+106500*    PROGRAM-ID.  IC227A-1.                                    *  IC2274.2
+106600*              .                                               *  IC2274.2
+106700*              .                                               *  IC2274.2
+106800*              .                                               *  IC2274.2
+106900*    END PROGRAM IC227A-1.                                     *  IC2274.2
+107000*                                                              *  IC2274.2
+107100****************************************************************  IC2274.2
+107200*                                                                 IC2274.2
+107300 ENVIRONMENT DIVISION.                                            IC2274.2
+107400 CONFIGURATION SECTION.                                           IC2274.2
+107500 SOURCE-COMPUTER.                                                 IC2274.2
+107600     XXXXX082.                                                    IC2274.2
+107700 OBJECT-COMPUTER.                                                 IC2274.2
+107800     XXXXX083.                                                    IC2274.2
+107900*                                                                 IC2274.2
+108000 INPUT-OUTPUT SECTION.                                            IC2274.2
+108100 FILE-CONTROL.                                                    IC2274.2
+108200     SELECT EXTERNAL-FILE ASSIGN TO                               IC2274.2
+108300     XXXXX014                                                     IC2274.2
+108400     FILE STATUS IS LINKAGE-FS.                                   IC2274.2
+108500*                                                                 IC2274.2
+108600 DATA DIVISION.                                                   IC2274.2
+108700 FILE SECTION.                                                    IC2274.2
+108800 FD  EXTERNAL-FILE                                                IC2274.2
+108900         IS EXTERNAL                                              IC2274.2
+109000         RECORD CONTAINS 18 CHARACTERS.                           IC2274.2
+109100 01  EXTERNAL-FILE-RECORD.                                        IC2274.2
+109200     03  EXT-DATA-1              PIC X(2).                        IC2274.2
+109300     03  EXT-DATA-2              PIC X(6).                        IC2274.2
+109400     03  EXT-DATA-3              PIC 9(6).                        IC2274.2
+109500     03  EXT-DATA-4              PIC 9(4).                        IC2274.2
+109600*                                                                 IC2274.2
+109700 WORKING-STORAGE SECTION.                                         IC2274.2
+109800*                                                                 IC2274.2
+109900***************************************************************   IC2274.2
+110000*                                                             *   IC2274.2
+110100*    WORKING-STORAGE DATA ITEMS SPECIFIC TO THIS TEST SUITE   *   IC2274.2
+110200*                                                             *   IC2274.2
+110300***************************************************************   IC2274.2
+110400*                                                                 IC2274.2
+110500 01  EXTERNAL-RECORD-WORK.                                        IC2274.2
+110600     03  WRK-DATA-1              PIC X(2).                        IC2274.2
+110700     03  WRK-DATA-2              PIC X(6).                        IC2274.2
+110800     03  WRK-DATA-3              PIC 9(6).                        IC2274.2
+110900     03  WRK-DATA-4              PIC 9(4).                        IC2274.2
+111000*                                                                 IC2274.2
+111100 LINKAGE SECTION.                                                 IC2274.2
+111200*                                                                 IC2274.2
+111300 01  LINKAGE-RECORD-WORK.                                         IC2274.2
+111400     05  WRK-DATA-1              PIC X(2).                        IC2274.2
+111500     05  WRK-DATA-2              PIC X(6).                        IC2274.2
+111600     05  WRK-DATA-3              PIC 9(6).                        IC2274.2
+111700     05  WRK-DATA-4              PIC 9(4).                        IC2274.2
+111800*                                                                 IC2274.2
+111900 01  LINKAGE-FS                  PIC XX.                          IC2274.2
+112000 01  ACTION-CODE                 PIC 99.                          IC2274.2
+112100*                                                                 IC2274.2
+112200*                                                                 IC2274.2
+112300 PROCEDURE DIVISION USING ACTION-CODE                             IC2274.2
+112400                          LINKAGE-RECORD-WORK                     IC2274.2
+112500                          LINKAGE-FS.                             IC2274.2
+112600*                                                                 IC2274.2
+112700 SECT-IC227A-1-01 SECTION.                                        IC2274.2
+112800 EXT-DECODE-01.                                                   IC2274.2
+112900*                                                                 IC2274.2
+113000*    *************************************************            IC2274.2
+113100*    *                                               *            IC2274.2
+113200*    *    USE THE ACTION CODE PARAMETER TO IDENTIFY  *            IC2274.2
+113300*    *    THE FUNCTION REQUIRED ON THIS ENTRY.       *            IC2274.2
+113400*    *                                               *            IC2274.2
+113500*    *************************************************            IC2274.2
+113600*                                                                 IC2274.2
+113700     GO TO   SUBPROGRAM-FUNCTION-01                               IC2274.2
+113800             SUBPROGRAM-FUNCTION-02                               IC2274.2
+113900             SUBPROGRAM-FUNCTION-03                               IC2274.2
+114000             SUBPROGRAM-FUNCTION-04                               IC2274.2
+114100             SUBPROGRAM-FUNCTION-05                               IC2274.2
+114200                 DEPENDING ON ACTION-CODE.                        IC2274.2
+114300*                                                                 IC2274.2
+114400*    CONTROL SHOULD NEVER REACH HERE, BUT ...                     IC2274.2
+114500*                                                                 IC2274.2
+114600     MOVE   "FFFFFFFFFFFFFFFFFF" TO LINKAGE-RECORD-WORK           IC2274.2
+114700     MOVE   "FF"                 TO LINKAGE-FS                    IC2274.2
+114800     EXIT PROGRAM.                                                IC2274.2
+114900*                                                                 IC2274.2
+115000*                                                                 IC2274.2
+115100 SUBPROGRAM-FUNCTION-01.                                          IC2274.2
+115200     MOVE    EXTERNAL-FILE-RECORD TO EXTERNAL-RECORD-WORK         IC2274.2
+115300     MOVE    LINKAGE-RECORD-WORK  TO EXTERNAL-FILE-RECORD         IC2274.2
+115400     MOVE    EXTERNAL-RECORD-WORK TO LINKAGE-RECORD-WORK.         IC2274.2
+115500     MOVE   "XX"                  TO LINKAGE-FS.                  IC2274.2
+115600     EXIT PROGRAM.                                                IC2274.2
+115700*                                                                 IC2274.2
+115800*                                                                 IC2274.2
+115900 SUBPROGRAM-FUNCTION-02.                                          IC2274.2
+116000*                                                                 IC2274.2
+116100*        WRITE A RECORD TO THE EXTERNAL FILE                      IC2274.2
+116200*                                                                 IC2274.2
+116300     MOVE    LINKAGE-RECORD-WORK TO EXTERNAL-FILE-RECORD.         IC2274.2
+116400     WRITE   EXTERNAL-FILE-RECORD.                                IC2274.2
+116500     EXIT    PROGRAM.                                             IC2274.2
+116600*                                                                 IC2274.2
+116700*                                                                 IC2274.2
+116800 SUBPROGRAM-FUNCTION-03.                                          IC2274.2
+116900*                                                                 IC2274.2
+117000*        CLOSE THE EXTERNAL FILE                                  IC2274.2
+117100*                                                                 IC2274.2
+117200     CLOSE   EXTERNAL-FILE.                                       IC2274.2
+117300     EXIT    PROGRAM.                                             IC2274.2
+117400*                                                                 IC2274.2
+117500*                                                                 IC2274.2
+117600 SUBPROGRAM-FUNCTION-04.                                          IC2274.2
+117700*                                                                 IC2274.2
+117800*        OPEN THE EXTERNAL FILE FOR INPUT                         IC2274.2
+117900*                                                                 IC2274.2
+118000     OPEN    INPUT EXTERNAL-FILE.                                 IC2274.2
+118100     MOVE   "OPEN   OPEN   OPEN"  TO EXTERNAL-FILE-RECORD.        IC2274.2
+118200     MOVE    EXTERNAL-FILE-RECORD TO LINKAGE-RECORD-WORK.         IC2274.2
+118300     EXIT    PROGRAM.                                             IC2274.2
+118400*                                                                 IC2274.2
+118500*                                                                 IC2274.2
+118600 SUBPROGRAM-FUNCTION-05.                                          IC2274.2
+118700*                                                                 IC2274.2
+118800*        READ A RECORD FROM THE EXTERNAL FILE                     IC2274.2
+118900*                                                                 IC2274.2
+119000     READ    EXTERNAL-FILE                                        IC2274.2
+119100                AT END GO TO SUBPROGRAM-FUNCTION-05-EOF.          IC2274.2
+119200     MOVE    EXTERNAL-FILE-RECORD TO LINKAGE-RECORD-WORK.         IC2274.2
+119300     EXIT    PROGRAM.                                             IC2274.2
+119400*                                                                 IC2274.2
+119500 SUBPROGRAM-FUNCTION-05-EOF.                                      IC2274.2
+119600     MOVE    EXTERNAL-FILE-RECORD TO LINKAGE-RECORD-WORK.         IC2274.2
+119700     MOVE   "END-FILE  END-FILE"  TO EXTERNAL-FILE-RECORD.        IC2274.2
+119800     EXIT    PROGRAM.                                             IC2274.2
+119900*                                                                 IC2274.2
+120000 END PROGRAM IC227A1.                                             IC2274.2

--- a/z390/IC228A.CBL
+++ b/z390/IC228A.CBL
@@ -1,0 +1,395 @@
+000100 IDENTIFICATION DIVISION.                                         IC2284.2
+      *
+      * This is the z390 version of IC228A
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC228A1
+      * IC228A has been modified to call IC228A1 instead of IC228A-1.
+      *
+000200 PROGRAM-ID.                                                      IC2284.2
+000300     IC228A.                                                      IC2284.2
+000400****************************************************************  IC2284.2
+000500*                                                              *  IC2284.2
+000600*    VALIDATION FOR:-                                          *  IC2284.2
+000700*                                                              *  IC2284.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2284.2
+000900*                                                              *  IC2284.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2284.2
+001100*                                                              *  IC2284.2
+001200****************************************************************  IC2284.2
+001300*                                                              *  IC2284.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2284.2
+001500*                                                              *  IC2284.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC2284.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC2284.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC2284.2
+001900*                                                              *  IC2284.2
+002000****************************************************************  IC2284.2
+002100*                                                              *  IC2284.2
+002200*    PROGRAM IC228A AND IC228A-1 WILL TEST THE NEW LANGUAGE    *  IC2284.2
+002300*    ELEMENTS FOR THE LEVEL 2 INTER-PROGRAM COMMUNICATION      *  IC2284.2
+002400*    MODULE.                                                   *  IC2284.2
+002500*    THE NEW LANGUAGE ELEMENT  TO BE TESTED WILL BE:           *  IC2284.2
+002600*          THE "GLOBAL"       PHRASE IN WORKING-STORAGE.       *  IC2284.2
+002700*    THE TWO PROGRAMS WILL BE COMPILED IN THE SAME FLOW        *  IC2284.2
+002800*    (TO TEST THE "END PROGRAM" STATEMENT) AS SHOWN BELOW:     *  IC2284.2
+002900*    IDENTIFICATION DIVISION.                                  *  IC2284.2
+003000*    PROGRAM-ID. IC228A.                                       *  IC2284.2
+003100*              .                                               *  IC2284.2
+003200*              .                                               *  IC2284.2
+003300*              .                                               *  IC2284.2
+003400*    IDENTIFICATION DIVISION.                                  *  IC2284.2
+003500*    PROGRAM-ID. IC228A-1.                                     *  IC2284.2
+003600*              .                                               *  IC2284.2
+003700*              .                                               *  IC2284.2
+003800*              .                                               *  IC2284.2
+003900*    END PROGRAM IC228A-1.                                     *  IC2284.2
+004000*    END PROGRAM IC228A.                                       *  IC2284.2
+004100****************************************************************  IC2284.2
+004200 ENVIRONMENT DIVISION.                                            IC2284.2
+004300 CONFIGURATION SECTION.                                           IC2284.2
+004400 SOURCE-COMPUTER.                                                 IC2284.2
+004500     XXXXX082.                                                    IC2284.2
+004600 OBJECT-COMPUTER.                                                 IC2284.2
+004700     XXXXX083.                                                    IC2284.2
+004800 INPUT-OUTPUT SECTION.                                            IC2284.2
+004900 FILE-CONTROL.                                                    IC2284.2
+005000     SELECT PRINT-FILE ASSIGN TO                                  IC2284.2
+005100     XXXXX055.                                                    IC2284.2
+005200 DATA DIVISION.                                                   IC2284.2
+005300 FILE SECTION.                                                    IC2284.2
+005400 FD  PRINT-FILE.                                                  IC2284.2
+005500 01  PRINT-REC PICTURE X(120).                                    IC2284.2
+005600 01  DUMMY-RECORD PICTURE X(120).                                 IC2284.2
+005700 WORKING-STORAGE SECTION.                                         IC2284.2
+005800 01  GLOBAL-DATA IS GLOBAL.                                       IC2284.2
+005900   03        GLO-DATA-1          PIC X(2).                        IC2284.2
+006000   03        GLO-DATA-2          PIC X(6).                        IC2284.2
+006100           88  CHANGE-MADE-OK  VALUE "CHANGE".                    IC2284.2
+006200   03        GLO-DATA-3          PIC 9(8).                        IC2284.2
+006300   03        GLO-DATA-4          PIC 9(4).                        IC2284.2
+006400 01  SUB                         PIC 9(4)  VALUE ZERO.            IC2284.2
+006500*                                                                 IC2284.2
+006600 01  TEST-RESULTS.                                                IC2284.2
+006700     02 FILLER                   PIC X      VALUE SPACE.          IC2284.2
+006800     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC2284.2
+006900     02 FILLER                   PIC X      VALUE SPACE.          IC2284.2
+007000     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC2284.2
+007100     02 FILLER                   PIC X      VALUE SPACE.          IC2284.2
+007200     02  PAR-NAME.                                                IC2284.2
+007300       03 FILLER                 PIC X(19)  VALUE SPACE.          IC2284.2
+007400       03  PARDOT-X              PIC X      VALUE SPACE.          IC2284.2
+007500       03 DOTVALUE               PIC 99     VALUE ZERO.           IC2284.2
+007600     02 FILLER                   PIC X(8)   VALUE SPACE.          IC2284.2
+007700     02 RE-MARK                  PIC X(61).                       IC2284.2
+007800 01  TEST-COMPUTED.                                               IC2284.2
+007900     02 FILLER                   PIC X(30)  VALUE SPACE.          IC2284.2
+008000     02 FILLER                   PIC X(17)  VALUE                 IC2284.2
+008100            "       COMPUTED=".                                   IC2284.2
+008200     02 COMPUTED-X.                                               IC2284.2
+008300     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC2284.2
+008400     03 COMPUTED-N               REDEFINES COMPUTED-A             IC2284.2
+008500                                 PIC -9(9).9(9).                  IC2284.2
+008600     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC2284.2
+008700     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC2284.2
+008800     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC2284.2
+008900     03       CM-18V0 REDEFINES COMPUTED-A.                       IC2284.2
+009000         04 COMPUTED-18V0                    PIC -9(18).          IC2284.2
+009100         04 FILLER                           PIC X.               IC2284.2
+009200     03 FILLER PIC X(50) VALUE SPACE.                             IC2284.2
+009300 01  TEST-CORRECT.                                                IC2284.2
+009400     02 FILLER PIC X(30) VALUE SPACE.                             IC2284.2
+009500     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC2284.2
+009600     02 CORRECT-X.                                                IC2284.2
+009700     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC2284.2
+009800     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC2284.2
+009900     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC2284.2
+010000     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC2284.2
+010100     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC2284.2
+010200     03      CR-18V0 REDEFINES CORRECT-A.                         IC2284.2
+010300         04 CORRECT-18V0                     PIC -9(18).          IC2284.2
+010400         04 FILLER                           PIC X.               IC2284.2
+010500     03 FILLER PIC X(2) VALUE SPACE.                              IC2284.2
+010600     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC2284.2
+010700 01  CCVS-C-1.                                                    IC2284.2
+010800     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC2284.2
+010900-    "SS  PARAGRAPH-NAME                                          IC2284.2
+011000-    "       REMARKS".                                            IC2284.2
+011100     02 FILLER                     PIC X(20)    VALUE SPACE.      IC2284.2
+011200 01  CCVS-C-2.                                                    IC2284.2
+011300     02 FILLER                     PIC X        VALUE SPACE.      IC2284.2
+011400     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC2284.2
+011500     02 FILLER                     PIC X(15)    VALUE SPACE.      IC2284.2
+011600     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC2284.2
+011700     02 FILLER                     PIC X(94)    VALUE SPACE.      IC2284.2
+011800 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC2284.2
+011900 01  REC-CT                        PIC 99       VALUE ZERO.       IC2284.2
+012000 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC2284.2
+012100 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC2284.2
+012200 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC2284.2
+012300 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC2284.2
+012400 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC2284.2
+012500 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC2284.2
+012600 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC2284.2
+012700 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC2284.2
+012800 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC2284.2
+012900 01  CCVS-H-1.                                                    IC2284.2
+013000     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2284.2
+013100     02  FILLER                    PIC X(42)    VALUE             IC2284.2
+013200     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC2284.2
+013300     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2284.2
+013400 01  CCVS-H-2A.                                                   IC2284.2
+013500   02  FILLER                        PIC X(40)  VALUE SPACE.      IC2284.2
+013600   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC2284.2
+013700   02  FILLER                        PIC XXXX   VALUE             IC2284.2
+013800     "4.2 ".                                                      IC2284.2
+013900   02  FILLER                        PIC X(28)  VALUE             IC2284.2
+014000            " COPY - NOT FOR DISTRIBUTION".                       IC2284.2
+014100   02  FILLER                        PIC X(41)  VALUE SPACE.      IC2284.2
+014200                                                                  IC2284.2
+014300 01  CCVS-H-2B.                                                   IC2284.2
+014400   02  FILLER                        PIC X(15)  VALUE             IC2284.2
+014500            "TEST RESULT OF ".                                    IC2284.2
+014600   02  TEST-ID                       PIC X(9).                    IC2284.2
+014700   02  FILLER                        PIC X(4)   VALUE             IC2284.2
+014800            " IN ".                                               IC2284.2
+014900   02  FILLER                        PIC X(12)  VALUE             IC2284.2
+015000     " HIGH       ".                                              IC2284.2
+015100   02  FILLER                        PIC X(22)  VALUE             IC2284.2
+015200            " LEVEL VALIDATION FOR ".                             IC2284.2
+015300   02  FILLER                        PIC X(58)  VALUE             IC2284.2
+015400     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2284.2
+015500 01  CCVS-H-3.                                                    IC2284.2
+015600     02  FILLER                      PIC X(34)  VALUE             IC2284.2
+015700            " FOR OFFICIAL USE ONLY    ".                         IC2284.2
+015800     02  FILLER                      PIC X(58)  VALUE             IC2284.2
+015900     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2284.2
+016000     02  FILLER                      PIC X(28)  VALUE             IC2284.2
+016100            "  COPYRIGHT   1985 ".                                IC2284.2
+016200 01  CCVS-E-1.                                                    IC2284.2
+016300     02 FILLER                       PIC X(52)  VALUE SPACE.      IC2284.2
+016400     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC2284.2
+016500     02 ID-AGAIN                     PIC X(9).                    IC2284.2
+016600     02 FILLER                       PIC X(45)  VALUE SPACES.     IC2284.2
+016700 01  CCVS-E-2.                                                    IC2284.2
+016800     02  FILLER                      PIC X(31)  VALUE SPACE.      IC2284.2
+016900     02  FILLER                      PIC X(21)  VALUE SPACE.      IC2284.2
+017000     02 CCVS-E-2-2.                                               IC2284.2
+017100         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC2284.2
+017200         03 FILLER                   PIC X      VALUE SPACE.      IC2284.2
+017300         03 ENDER-DESC               PIC X(44)  VALUE             IC2284.2
+017400            "ERRORS ENCOUNTERED".                                 IC2284.2
+017500 01  CCVS-E-3.                                                    IC2284.2
+017600     02  FILLER                      PIC X(22)  VALUE             IC2284.2
+017700            " FOR OFFICIAL USE ONLY".                             IC2284.2
+017800     02  FILLER                      PIC X(12)  VALUE SPACE.      IC2284.2
+017900     02  FILLER                      PIC X(58)  VALUE             IC2284.2
+018000     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2284.2
+018100     02  FILLER                      PIC X(13)  VALUE SPACE.      IC2284.2
+018200     02 FILLER                       PIC X(15)  VALUE             IC2284.2
+018300             " COPYRIGHT 1985".                                   IC2284.2
+018400 01  CCVS-E-4.                                                    IC2284.2
+018500     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC2284.2
+018600     02 FILLER                       PIC X(4)   VALUE " OF ".     IC2284.2
+018700     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC2284.2
+018800     02 FILLER                       PIC X(40)  VALUE             IC2284.2
+018900      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC2284.2
+019000 01  XXINFO.                                                      IC2284.2
+019100     02 FILLER                       PIC X(19)  VALUE             IC2284.2
+019200            "*** INFORMATION ***".                                IC2284.2
+019300     02 INFO-TEXT.                                                IC2284.2
+019400       04 FILLER                     PIC X(8)   VALUE SPACE.      IC2284.2
+019500       04 XXCOMPUTED                 PIC X(20).                   IC2284.2
+019600       04 FILLER                     PIC X(5)   VALUE SPACE.      IC2284.2
+019700       04 XXCORRECT                  PIC X(20).                   IC2284.2
+019800     02 INF-ANSI-REFERENCE           PIC X(48).                   IC2284.2
+019900 01  HYPHEN-LINE.                                                 IC2284.2
+020000     02 FILLER  PIC IS X VALUE IS SPACE.                          IC2284.2
+020100     02 FILLER  PIC IS X(65)    VALUE IS "************************IC2284.2
+020200-    "*****************************************".                 IC2284.2
+020300     02 FILLER  PIC IS X(54)    VALUE IS "************************IC2284.2
+020400-    "******************************".                            IC2284.2
+020500 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC2284.2
+020600     "IC228A".                                                    IC2284.2
+020700 PROCEDURE DIVISION.                                              IC2284.2
+020800 CCVS1 SECTION.                                                   IC2284.2
+020900 OPEN-FILES.                                                      IC2284.2
+021000     OPEN     OUTPUT PRINT-FILE.                                  IC2284.2
+021100     MOVE CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.   IC2284.2
+021200     MOVE    SPACE TO TEST-RESULTS.                               IC2284.2
+021300     PERFORM  HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.             IC2284.2
+021400     GO TO CCVS1-EXIT.                                            IC2284.2
+021500 CLOSE-FILES.                                                     IC2284.2
+021600     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC2284.2
+021700 TERMINATE-CCVS.                                                  IC2284.2
+021800S    EXIT PROGRAM.                                                IC2284.2
+021900STERMINATE-CALL.                                                  IC2284.2
+022000     STOP     RUN.                                                IC2284.2
+022100 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         IC2284.2
+022200 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           IC2284.2
+022300 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          IC2284.2
+022400 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      IC2284.2
+022500     MOVE "****TEST DELETED****" TO RE-MARK.                      IC2284.2
+022600 PRINT-DETAIL.                                                    IC2284.2
+022700     IF REC-CT NOT EQUAL TO ZERO                                  IC2284.2
+022800             MOVE "." TO PARDOT-X                                 IC2284.2
+022900             MOVE REC-CT TO DOTVALUE.                             IC2284.2
+023000     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      IC2284.2
+023100     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               IC2284.2
+023200        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 IC2284.2
+023300          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 IC2284.2
+023400     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC2284.2
+023500     MOVE SPACE TO CORRECT-X.                                     IC2284.2
+023600     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC2284.2
+023700     MOVE     SPACE TO RE-MARK.                                   IC2284.2
+023800 HEAD-ROUTINE.                                                    IC2284.2
+023900     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2284.2
+024000     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2284.2
+024100     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2284.2
+024200     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2284.2
+024300 COLUMN-NAMES-ROUTINE.                                            IC2284.2
+024400     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2284.2
+024500     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2284.2
+024600     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC2284.2
+024700 END-ROUTINE.                                                     IC2284.2
+024800     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.IC2284.2
+024900 END-RTN-EXIT.                                                    IC2284.2
+025000     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2284.2
+025100 END-ROUTINE-1.                                                   IC2284.2
+025200      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      IC2284.2
+025300      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               IC2284.2
+025400      ADD PASS-COUNTER TO ERROR-HOLD.                             IC2284.2
+025500*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC2284.2
+025600      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC2284.2
+025700      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC2284.2
+025800      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC2284.2
+025900      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC2284.2
+026000  END-ROUTINE-12.                                                 IC2284.2
+026100      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC2284.2
+026200     IF       ERROR-COUNTER IS EQUAL TO ZERO                      IC2284.2
+026300         MOVE "NO " TO ERROR-TOTAL                                IC2284.2
+026400         ELSE                                                     IC2284.2
+026500         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC2284.2
+026600     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC2284.2
+026700     PERFORM WRITE-LINE.                                          IC2284.2
+026800 END-ROUTINE-13.                                                  IC2284.2
+026900     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC2284.2
+027000         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC2284.2
+027100         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC2284.2
+027200     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC2284.2
+027300     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2284.2
+027400      IF   INSPECT-COUNTER EQUAL TO ZERO                          IC2284.2
+027500          MOVE "NO " TO ERROR-TOTAL                               IC2284.2
+027600      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   IC2284.2
+027700      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            IC2284.2
+027800      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          IC2284.2
+027900     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2284.2
+028000 WRITE-LINE.                                                      IC2284.2
+028100     ADD 1 TO RECORD-COUNT.                                       IC2284.2
+028200Y    IF RECORD-COUNT GREATER 50                                   IC2284.2
+028300Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC2284.2
+028400Y        MOVE SPACE TO DUMMY-RECORD                               IC2284.2
+028500Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC2284.2
+028600Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC2284.2
+028700Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC2284.2
+028800Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC2284.2
+028900Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC2284.2
+029000Y        MOVE ZERO TO RECORD-COUNT.                               IC2284.2
+029100     PERFORM WRT-LN.                                              IC2284.2
+029200 WRT-LN.                                                          IC2284.2
+029300     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC2284.2
+029400     MOVE SPACE TO DUMMY-RECORD.                                  IC2284.2
+029500 BLANK-LINE-PRINT.                                                IC2284.2
+029600     PERFORM WRT-LN.                                              IC2284.2
+029700 FAIL-ROUTINE.                                                    IC2284.2
+029800     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC2284.2
+029900     IF     CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.IC2284.2
+030000     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2284.2
+030100     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC2284.2
+030200     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2284.2
+030300     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2284.2
+030400     GO TO  FAIL-ROUTINE-EX.                                      IC2284.2
+030500 FAIL-ROUTINE-WRITE.                                              IC2284.2
+030600     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC2284.2
+030700     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC2284.2
+030800     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC2284.2
+030900     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC2284.2
+031000 FAIL-ROUTINE-EX. EXIT.                                           IC2284.2
+031100 BAIL-OUT.                                                        IC2284.2
+031200     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC2284.2
+031300     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC2284.2
+031400 BAIL-OUT-WRITE.                                                  IC2284.2
+031500     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC2284.2
+031600     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2284.2
+031700     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2284.2
+031800     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2284.2
+031900 BAIL-OUT-EX. EXIT.                                               IC2284.2
+032000 CCVS1-EXIT.                                                      IC2284.2
+032100     EXIT.                                                        IC2284.2
+032200 SECT-IC228A-001 SECTION.                                         IC2284.2
+032300 GLO-INIT-01.                                                     IC2284.2
+032400     MOVE   "X-20 4.3.2" TO ANSI-REFERENCE.                       IC2284.2
+032500     MOVE   "GLOBAL CLAUSE" TO FEATURE.                           IC2284.2
+032600     MOVE   "AA"      TO GLO-DATA-1.                              IC2284.2
+032700     MOVE   "FIRST]"  TO GLO-DATA-2.                              IC2284.2
+032800     MOVE    12345678 TO GLO-DATA-3.                              IC2284.2
+032900     MOVE    1        TO GLO-DATA-4.                              IC2284.2
+033000 GLO-TEST-01-01-0.                                                IC2284.2
+033100     CALL   "IC228A-1"                                            IC2284.2
+033200     END-CALL.                                                    IC2284.2
+033300     GO TO   GLO-TEST-01-01-1.                                    IC2284.2
+033400 GLO-DELETE-01-01.                                                IC2284.2
+033500     PERFORM DE-LETE.                                             IC2284.2
+033600     PERFORM PRINT-DETAIL.                                        IC2284.2
+033700     GO TO   CCVS-EXIT.                                           IC2284.2
+033800 GLO-TEST-01-01-1.                                                IC2284.2
+033900     MOVE   "GLO-TEST-01-01-1" TO PAR-NAME.                       IC2284.2
+034000     IF      GLO-DATA-1 = "ZZ"                                    IC2284.2
+034100             PERFORM PASS                                         IC2284.2
+034200             PERFORM PRINT-DETAIL                                 IC2284.2
+034300     ELSE                                                         IC2284.2
+034400             MOVE    GLO-DATA-1  TO COMPUTED-X                    IC2284.2
+034500             MOVE   "ZZ" TO CORRECT-X                             IC2284.2
+034600             MOVE   "INCORRECT VALUE RETURNED" TO RE-MARK         IC2284.2
+034700             PERFORM FAIL                                         IC2284.2
+034800             PERFORM PRINT-DETAIL.                                IC2284.2
+034900     ADD     1 TO REC-CT.                                         IC2284.2
+035000 CALL-TEST-01-01-2.                                               IC2284.2
+035100     MOVE   "CALL-TEST-01-01-2" TO PAR-NAME.                      IC2284.2
+035200     IF      CHANGE-MADE-OK                                       IC2284.2
+035300             PERFORM PASS                                         IC2284.2
+035400             PERFORM PRINT-DETAIL                                 IC2284.2
+035500     ELSE                                                         IC2284.2
+035600             MOVE    GLO-DATA-2  TO COMPUTED-X                    IC2284.2
+035700             MOVE   "CHANGE" TO CORRECT-X                         IC2284.2
+035800             MOVE   "INCORRECT VALUE RETURNED" TO RE-MARK         IC2284.2
+035900             PERFORM FAIL                                         IC2284.2
+036000             PERFORM PRINT-DETAIL.                                IC2284.2
+036100     ADD     1 TO REC-CT.                                         IC2284.2
+036200 CALL-TEST-01-01-3.                                               IC2284.2
+036300     MOVE   "CALL-TEST-01-01-3" TO PAR-NAME.                      IC2284.2
+036400     IF      GLO-DATA-3 = 87654321                                IC2284.2
+036500             PERFORM PASS                                         IC2284.2
+036600             PERFORM PRINT-DETAIL                                 IC2284.2
+036700     ELSE                                                         IC2284.2
+036800             MOVE    GLO-DATA-3  TO COMPUTED-N                    IC2284.2
+036900             MOVE    87654321 TO CORRECT-N                        IC2284.2
+037000             MOVE   "INCORRECT VALUE RETURNED" TO RE-MARK         IC2284.2
+037100             PERFORM FAIL                                         IC2284.2
+037200             PERFORM PRINT-DETAIL.                                IC2284.2
+037300     ADD     1 TO REC-CT.                                         IC2284.2
+037400 CALL-TEST-01-01-4.                                               IC2284.2
+037500     MOVE   "CALL-TEST-01-01-4" TO PAR-NAME.                      IC2284.2
+037600     IF      GLO-DATA-4 = 11                                      IC2284.2
+037700             PERFORM PASS                                         IC2284.2
+037800             PERFORM PRINT-DETAIL                                 IC2284.2
+037900     ELSE                                                         IC2284.2
+038000             MOVE    GLO-DATA-4  TO COMPUTED-N                    IC2284.2
+038100             MOVE    11   TO CORRECT-N                            IC2284.2
+038200             MOVE   "INCORRECT VALUE RETURNED" TO RE-MARK         IC2284.2
+038300             PERFORM FAIL                                         IC2284.2
+038400             PERFORM PRINT-DETAIL.                                IC2284.2
+038500*                                                                 IC2284.2
+038600 CCVS-EXIT SECTION.                                               IC2284.2
+038700 CCVS-999999.                                                     IC2284.2
+038800     GO TO CLOSE-FILES.                                           IC2284.2
+044500 END PROGRAM IC228A.                                              IC2284.2

--- a/z390/IC228A1.CBL
+++ b/z390/IC228A1.CBL
@@ -1,0 +1,62 @@
+038900 IDENTIFICATION DIVISION.                                         IC2284.2
+      *
+      * This is the z390 version of IC228A-1
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC228A1
+      * IC228A has been modified to call IC228A1 instead of IC228A-1.
+      *
+039000 PROGRAM-ID.                                                      IC2284.2
+039100     IC228A1.                                                     IC2284.2
+039200****************************************************************  IC2284.2
+039300*                                                              *  IC2284.2
+039400*    VALIDATION FOR:-                                          *  IC2284.2
+039500*                                                              *  IC2284.2
+039600*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2284.2
+039700*                                                              *  IC2284.2
+039800*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2284.2
+039900*                                                              *  IC2284.2
+040000****************************************************************  IC2284.2
+040100*                                                              *  IC2284.2
+040200*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2284.2
+040300*                                                              *  IC2284.2
+040400*        X-55  - SYSTEM PRINTER NAME.                          *  IC2284.2
+040500*        X-82  - SOURCE COMPUTER NAME.                         *  IC2284.2
+040600*        X-83  - OBJECT COMPUTER NAME.                         *  IC2284.2
+040700*                                                              *  IC2284.2
+040800****************************************************************  IC2284.2
+040900*                                                              *  IC2284.2
+041000*    PROGRAM IC228A AND IC228A-1 WILL TEST THE NEW LANGUAGE    *  IC2284.2
+041100*    ELEMENTS FOR THE LEVEL 2 INTER-PROGRAM COMMUNICATION      *  IC2284.2
+041200*    MODULE.                                                   *  IC2284.2
+041300*    THE NEW LANGUAGE ELEMENTS TO BE TESTED WILL BE:           *  IC2284.2
+041400*           THE "GLOBAL" CLAUSE IN WORKING-STORAGE.          *    IC2284.2
+041500*    THE TWO PROGRAMS WILL BE COMPILED IN THE SAME FLOW        *  IC2284.2
+041600*    (TO TEST THE "END PROGRAM" STATEMENT) AS SHOWN BELOW:     *  IC2284.2
+041700*    IDENTIFICATION DIVISION.                                  *  IC2284.2
+041800*    PROGRAM-ID. IC228A.                                       *  IC2284.2
+041900*              .                                               *  IC2284.2
+042000*              .                                               *  IC2284.2
+042100*              .                                               *  IC2284.2
+042200*    IDENTIFICATION DIVISION.                                  *  IC2284.2
+042300*    PROGRAM-ID. IC228A-1.                                     *  IC2284.2
+042400*              .                                               *  IC2284.2
+042500*              .                                               *  IC2284.2
+042600*              .                                               *  IC2284.2
+042700*    END PROGRAM IC228A-1.                                     *  IC2284.2
+042800*    END PROGRAM IC228A.                                       *  IC2284.2
+042900****************************************************************  IC2284.2
+043000 ENVIRONMENT DIVISION.                                            IC2284.2
+043100*INPUT-OUTPUT SECTION.                                            IC2284.2
+043200 DATA DIVISION.                                                   IC2284.2
+043300*FILE SECTION.                                                    IC2284.2
+043400 WORKING-STORAGE SECTION.                                         IC2284.2
+043500 PROCEDURE DIVISION.                                              IC2284.2
+043600 SECT-IC228A-1-001 SECTION.                                       IC2284.2
+043700 GLO-TEST-001.                                                    IC2284.2
+043800     MOVE   "ZZ"      TO GLO-DATA-1.                              IC2284.2
+043900     MOVE   "CHANGE"  TO GLO-DATA-2.                              IC2284.2
+044000     MOVE    87654321 TO GLO-DATA-3.                              IC2284.2
+044100     ADD     10       TO GLO-DATA-4.                              IC2284.2
+044200 GLO-EXIT-001.                                                    IC2284.2
+044300     EXIT PROGRAM.                                                IC2284.2
+044400 END PROGRAM IC228A1.                                             IC2284.2

--- a/z390/IC233A.CBL
+++ b/z390/IC233A.CBL
@@ -1,0 +1,408 @@
+000100 IDENTIFICATION DIVISION.                                         IC2334.2
+      *
+      * This is the z390 version of IC233A
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC233A1
+      * IC233A has been modified to call IC233A1 instead of IC233A-1.
+      *
+000200 PROGRAM-ID.                                                      IC2334.2
+000300     IC233A.                                                      IC2334.2
+000400****************************************************************  IC2334.2
+000500*                                                              *  IC2334.2
+000600*    VALIDATION FOR:-                                          *  IC2334.2
+000700*                                                              *  IC2334.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2334.2
+000900*                                                              *  IC2334.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2334.2
+001100*                                                              *  IC2334.2
+001200****************************************************************  IC2334.2
+001300*                                                              *  IC2334.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2334.2
+001500*                                                              *  IC2334.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC2334.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC2334.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC2334.2
+001900*        X-18  - OPTIONAL SEQUENTIAL MASS STORAGE FILE.        *  IC2334.2
+002000****************************************************************  IC2334.2
+002100*                                                              *  IC2334.2
+002200*    PROGRAMS IC233A AND IC233A-1 TEST THAT A "USE" PROCEDURE  *  IC2334.2
+002300*    IN A CALLING PROGRAM IS INVOKED BY A QUALIFYING CONDITION *  IC2334.2
+002400*    OCCURRING IN A CONTAINED PROGRAM.                         *  IC2334.2
+002500*                                                              *  IC2334.2
+002600*    BOTH PROGRAMS WILL BE COMPILED IN ONE INVOCATION OF THE   *  IC2334.2
+002700*    COMPILER AS SHOWN BELOW:                                  *  IC2334.2
+002800*    IDENTIFICATION DIVISION.                                  *  IC2334.2
+002900*    PROGRAM-ID. IC233A.                                       *  IC2334.2
+003000*              .                                               *  IC2334.2
+003100*              .                                               *  IC2334.2
+003200*              .                                               *  IC2334.2
+003300*    IDENTIFICATION DIVISION.                                  *  IC2334.2
+003400*    PROGRAM-ID. IC233A-1.                                     *  IC2334.2
+003500*              .                                               *  IC2334.2
+003600*              .                                               *  IC2334.2
+003700*    END PROGRAM IC233A-1.                                     *  IC2334.2
+003800*    END PROGRAM IC233A.                                       *  IC2334.2
+003900****************************************************************  IC2334.2
+004000 ENVIRONMENT DIVISION.                                            IC2334.2
+004100 CONFIGURATION SECTION.                                           IC2334.2
+004200 SOURCE-COMPUTER.                                                 IC2334.2
+004300     XXXXX082.                                                    IC2334.2
+004400 OBJECT-COMPUTER.                                                 IC2334.2
+004500     XXXXX083.                                                    IC2334.2
+004600 INPUT-OUTPUT SECTION.                                            IC2334.2
+004700 FILE-CONTROL.                                                    IC2334.2
+004800     SELECT PRINT-FILE ASSIGN TO                                  IC2334.2
+004900     XXXXX055.                                                    IC2334.2
+005000     SELECT OPTIONAL TEST-FILE ASSIGN TO                          IC2334.2
+005100     XXXXX018.                                                    IC2334.2
+005200 DATA DIVISION.                                                   IC2334.2
+005300 FILE SECTION.                                                    IC2334.2
+005400 FD  PRINT-FILE.                                                  IC2334.2
+005500 01  PRINT-REC PICTURE X(120).                                    IC2334.2
+005600 01  DUMMY-RECORD PICTURE X(120).                                 IC2334.2
+005700 FD  TEST-FILE GLOBAL.                                            IC2334.2
+005800 01  TEST-REC PIC X(20).                                          IC2334.2
+005900 WORKING-STORAGE SECTION.                                         IC2334.2
+006000 01  DILFRAP                     PIC 9.                           IC2334.2
+006100 01  TEST-RESULTS.                                                IC2334.2
+006200     02 FILLER                   PIC X      VALUE SPACE.          IC2334.2
+006300     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC2334.2
+006400     02 FILLER                   PIC X      VALUE SPACE.          IC2334.2
+006500     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC2334.2
+006600     02 FILLER                   PIC X      VALUE SPACE.          IC2334.2
+006700     02  PAR-NAME.                                                IC2334.2
+006800       03 FILLER                 PIC X(19)  VALUE SPACE.          IC2334.2
+006900       03  PARDOT-X              PIC X      VALUE SPACE.          IC2334.2
+007000       03 DOTVALUE               PIC 99     VALUE ZERO.           IC2334.2
+007100     02 FILLER                   PIC X(8)   VALUE SPACE.          IC2334.2
+007200     02 RE-MARK                  PIC X(61).                       IC2334.2
+007300 01  TEST-COMPUTED.                                               IC2334.2
+007400     02 FILLER                   PIC X(30)  VALUE SPACE.          IC2334.2
+007500     02 FILLER                   PIC X(17)  VALUE                 IC2334.2
+007600            "       COMPUTED=".                                   IC2334.2
+007700     02 COMPUTED-X.                                               IC2334.2
+007800     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC2334.2
+007900     03 COMPUTED-N               REDEFINES COMPUTED-A             IC2334.2
+008000                                 PIC -9(9).9(9).                  IC2334.2
+008100     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC2334.2
+008200     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC2334.2
+008300     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC2334.2
+008400     03       CM-18V0 REDEFINES COMPUTED-A.                       IC2334.2
+008500         04 COMPUTED-18V0                    PIC -9(18).          IC2334.2
+008600         04 FILLER                           PIC X.               IC2334.2
+008700     03 FILLER PIC X(50) VALUE SPACE.                             IC2334.2
+008800 01  TEST-CORRECT.                                                IC2334.2
+008900     02 FILLER PIC X(30) VALUE SPACE.                             IC2334.2
+009000     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC2334.2
+009100     02 CORRECT-X.                                                IC2334.2
+009200     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC2334.2
+009300     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC2334.2
+009400     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC2334.2
+009500     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC2334.2
+009600     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC2334.2
+009700     03      CR-18V0 REDEFINES CORRECT-A.                         IC2334.2
+009800         04 CORRECT-18V0                     PIC -9(18).          IC2334.2
+009900         04 FILLER                           PIC X.               IC2334.2
+010000     03 FILLER PIC X(2) VALUE SPACE.                              IC2334.2
+010100     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC2334.2
+010200 01  CCVS-C-1.                                                    IC2334.2
+010300     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC2334.2
+010400-    "SS  PARAGRAPH-NAME                                          IC2334.2
+010500-    "       REMARKS".                                            IC2334.2
+010600     02 FILLER                     PIC X(20)    VALUE SPACE.      IC2334.2
+010700 01  CCVS-C-2.                                                    IC2334.2
+010800     02 FILLER                     PIC X        VALUE SPACE.      IC2334.2
+010900     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC2334.2
+011000     02 FILLER                     PIC X(15)    VALUE SPACE.      IC2334.2
+011100     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC2334.2
+011200     02 FILLER                     PIC X(94)    VALUE SPACE.      IC2334.2
+011300 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC2334.2
+011400 01  REC-CT                        PIC 99       VALUE ZERO.       IC2334.2
+011500 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC2334.2
+011600 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC2334.2
+011700 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC2334.2
+011800 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC2334.2
+011900 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC2334.2
+012000 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC2334.2
+012100 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC2334.2
+012200 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC2334.2
+012300 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC2334.2
+012400 01  CCVS-H-1.                                                    IC2334.2
+012500     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2334.2
+012600     02  FILLER                    PIC X(42)    VALUE             IC2334.2
+012700     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC2334.2
+012800     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2334.2
+012900 01  CCVS-H-2A.                                                   IC2334.2
+013000   02  FILLER                        PIC X(40)  VALUE SPACE.      IC2334.2
+013100   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC2334.2
+013200   02  FILLER                        PIC XXXX   VALUE             IC2334.2
+013300     "4.2 ".                                                      IC2334.2
+013400   02  FILLER                        PIC X(28)  VALUE             IC2334.2
+013500            " COPY - NOT FOR DISTRIBUTION".                       IC2334.2
+013600   02  FILLER                        PIC X(41)  VALUE SPACE.      IC2334.2
+013700                                                                  IC2334.2
+013800 01  CCVS-H-2B.                                                   IC2334.2
+013900   02  FILLER                        PIC X(15)  VALUE             IC2334.2
+014000            "TEST RESULT OF ".                                    IC2334.2
+014100   02  TEST-ID                       PIC X(9).                    IC2334.2
+014200   02  FILLER                        PIC X(4)   VALUE             IC2334.2
+014300            " IN ".                                               IC2334.2
+014400   02  FILLER                        PIC X(12)  VALUE             IC2334.2
+014500     " HIGH       ".                                              IC2334.2
+014600   02  FILLER                        PIC X(22)  VALUE             IC2334.2
+014700            " LEVEL VALIDATION FOR ".                             IC2334.2
+014800   02  FILLER                        PIC X(58)  VALUE             IC2334.2
+014900     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2334.2
+015000 01  CCVS-H-3.                                                    IC2334.2
+015100     02  FILLER                      PIC X(34)  VALUE             IC2334.2
+015200            " FOR OFFICIAL USE ONLY    ".                         IC2334.2
+015300     02  FILLER                      PIC X(58)  VALUE             IC2334.2
+015400     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2334.2
+015500     02  FILLER                      PIC X(28)  VALUE             IC2334.2
+015600            "  COPYRIGHT   1985 ".                                IC2334.2
+015700 01  CCVS-E-1.                                                    IC2334.2
+015800     02 FILLER                       PIC X(52)  VALUE SPACE.      IC2334.2
+015900     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC2334.2
+016000     02 ID-AGAIN                     PIC X(9).                    IC2334.2
+016100     02 FILLER                       PIC X(45)  VALUE SPACES.     IC2334.2
+016200 01  CCVS-E-2.                                                    IC2334.2
+016300     02  FILLER                      PIC X(31)  VALUE SPACE.      IC2334.2
+016400     02  FILLER                      PIC X(21)  VALUE SPACE.      IC2334.2
+016500     02 CCVS-E-2-2.                                               IC2334.2
+016600         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC2334.2
+016700         03 FILLER                   PIC X      VALUE SPACE.      IC2334.2
+016800         03 ENDER-DESC               PIC X(44)  VALUE             IC2334.2
+016900            "ERRORS ENCOUNTERED".                                 IC2334.2
+017000 01  CCVS-E-3.                                                    IC2334.2
+017100     02  FILLER                      PIC X(22)  VALUE             IC2334.2
+017200            " FOR OFFICIAL USE ONLY".                             IC2334.2
+017300     02  FILLER                      PIC X(12)  VALUE SPACE.      IC2334.2
+017400     02  FILLER                      PIC X(58)  VALUE             IC2334.2
+017500     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2334.2
+017600     02  FILLER                      PIC X(13)  VALUE SPACE.      IC2334.2
+017700     02 FILLER                       PIC X(15)  VALUE             IC2334.2
+017800             " COPYRIGHT 1985".                                   IC2334.2
+017900 01  CCVS-E-4.                                                    IC2334.2
+018000     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC2334.2
+018100     02 FILLER                       PIC X(4)   VALUE " OF ".     IC2334.2
+018200     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC2334.2
+018300     02 FILLER                       PIC X(40)  VALUE             IC2334.2
+018400      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC2334.2
+018500 01  XXINFO.                                                      IC2334.2
+018600     02 FILLER                       PIC X(19)  VALUE             IC2334.2
+018700            "*** INFORMATION ***".                                IC2334.2
+018800     02 INFO-TEXT.                                                IC2334.2
+018900       04 FILLER                     PIC X(8)   VALUE SPACE.      IC2334.2
+019000       04 XXCOMPUTED                 PIC X(20).                   IC2334.2
+019100       04 FILLER                     PIC X(5)   VALUE SPACE.      IC2334.2
+019200       04 XXCORRECT                  PIC X(20).                   IC2334.2
+019300     02 INF-ANSI-REFERENCE           PIC X(48).                   IC2334.2
+019400 01  HYPHEN-LINE.                                                 IC2334.2
+019500     02 FILLER  PIC IS X VALUE IS SPACE.                          IC2334.2
+019600     02 FILLER  PIC IS X(65)    VALUE IS "************************IC2334.2
+019700-    "*****************************************".                 IC2334.2
+019800     02 FILLER  PIC IS X(54)    VALUE IS "************************IC2334.2
+019900-    "******************************".                            IC2334.2
+020000 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC2334.2
+020100     "IC233A".                                                    IC2334.2
+020200 PROCEDURE DIVISION.                                              IC2334.2
+020300 DECLARATIVES.                                                    IC2334.2
+020400 SECT-IC233A-001 SECTION.                                         IC2334.2
+020500     USE GLOBAL AFTER ERROR PROCEDURE ON INPUT.                   IC2334.2
+020600 USE-TEST-2.                                                      IC2334.2
+020700     PERFORM D1-PASS.                                             IC2334.2
+020800     PERFORM D1-PRINT-DETAIL.                                     IC2334.2
+020900     MOVE    1 TO DILFRAP.                                        IC2334.2
+021000     GO TO EXIT-USE-TEST-2.                                       IC2334.2
+021100 D1-PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.        IC2334.2
+021200 D1-PRINT-DETAIL.                                                 IC2334.2
+021300     IF REC-CT NOT EQUAL TO ZERO                                  IC2334.2
+021400             MOVE "." TO PARDOT-X                                 IC2334.2
+021500             MOVE REC-CT TO DOTVALUE.                             IC2334.2
+021600     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM D1-WRITE-LINE.   IC2334.2
+021700     IF P-OR-F EQUAL TO "FAIL*"  PERFORM D1-WRITE-LINE            IC2334.2
+021800        PERFORM D1-FAIL-ROUTINE THRU D1-FAIL-ROUTINE-EX           IC2334.2
+021900          ELSE PERFORM D1-BAIL-OUT THRU D1-BAIL-OUT-EX.           IC2334.2
+022000     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC2334.2
+022100     MOVE SPACE TO CORRECT-X.                                     IC2334.2
+022200     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC2334.2
+022300     MOVE     SPACE TO RE-MARK.                                   IC2334.2
+022400 D1-WRITE-LINE.                                                   IC2334.2
+022500     ADD 1 TO RECORD-COUNT.                                       IC2334.2
+022600Y    IF RECORD-COUNT GREATER 50                                   IC2334.2
+022700Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC2334.2
+022800Y        MOVE SPACE TO DUMMY-RECORD                               IC2334.2
+022900Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC2334.2
+023000Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM D1-WRT-LN          IC2334.2
+023100Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM D1-WRT-LN 2 TIMES  IC2334.2
+023200Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM D1-WRT-LN       IC2334.2
+023300Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC2334.2
+023400Y        MOVE ZERO TO RECORD-COUNT.                               IC2334.2
+023500     PERFORM D1-WRT-LN.                                           IC2334.2
+023600 D1-WRT-LN.                                                       IC2334.2
+023700     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC2334.2
+023800     MOVE SPACE TO DUMMY-RECORD.                                  IC2334.2
+023900 D1-FAIL-ROUTINE.                                                 IC2334.2
+024000     IF COMPUTED-X NOT EQUAL TO SPACE GO TO D1-FAIL-ROUTINE-WRITE.IC2334.2
+024100     IF CORRECT-X NOT EQUAL TO SPACE GO TO D1-FAIL-ROUTINE-WRITE. IC2334.2
+024200     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2334.2
+024300     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC2334.2
+024400     MOVE   XXINFO TO DUMMY-RECORD. PERFORM D1-WRITE-LINE 2 TIMES.IC2334.2
+024500     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2334.2
+024600     GO TO  D1-FAIL-ROUTINE-EX.                                   IC2334.2
+024700 D1-FAIL-ROUTINE-WRITE.                                           IC2334.2
+024800     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM D1-WRITE-LINE      IC2334.2
+024900     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC2334.2
+025000     MOVE TEST-CORRECT TO PRINT-REC PERFORM D1-WRITE-LINE 2 TIMES.IC2334.2
+025100     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC2334.2
+025200 D1-FAIL-ROUTINE-EX. EXIT.                                        IC2334.2
+025300 D1-BAIL-OUT.                                                     IC2334.2
+025400     IF  COMPUTED-A NOT EQUAL TO SPACE GO TO D1-BAIL-OUT-WRITE.   IC2334.2
+025500     IF  CORRECT-A EQUAL TO SPACE GO TO D1-BAIL-OUT-EX.           IC2334.2
+025600 D1-BAIL-OUT-WRITE.                                               IC2334.2
+025700     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC2334.2
+025800     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2334.2
+025900     MOVE   XXINFO TO DUMMY-RECORD.                               IC2334.2
+026000     PERFORM D1-WRITE-LINE 2 TIMES.                               IC2334.2
+026100     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2334.2
+026200 D1-BAIL-OUT-EX. EXIT.                                            IC2334.2
+026300 EXIT-USE-TEST-2.                                                 IC2334.2
+026400     EXIT.                                                        IC2334.2
+026500 END DECLARATIVES.                                                IC2334.2
+026600 CCVS1 SECTION.                                                   IC2334.2
+026700 OPEN-FILES.                                                      IC2334.2
+026800     OPEN     OUTPUT PRINT-FILE.                                  IC2334.2
+026900     MOVE CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.   IC2334.2
+027000     MOVE    SPACE TO TEST-RESULTS.                               IC2334.2
+027100     PERFORM  HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.             IC2334.2
+027200     GO TO CCVS1-EXIT.                                            IC2334.2
+027300 CLOSE-FILES.                                                     IC2334.2
+027400     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC2334.2
+027500 TERMINATE-CCVS.                                                  IC2334.2
+027600S    EXIT PROGRAM.                                                IC2334.2
+027700STERMINATE-CALL.                                                  IC2334.2
+027800     STOP     RUN.                                                IC2334.2
+027900 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         IC2334.2
+028000 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           IC2334.2
+028100 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          IC2334.2
+028200 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      IC2334.2
+028300     MOVE "****TEST DELETED****" TO RE-MARK.                      IC2334.2
+028400 PRINT-DETAIL.                                                    IC2334.2
+028500     IF REC-CT NOT EQUAL TO ZERO                                  IC2334.2
+028600             MOVE "." TO PARDOT-X                                 IC2334.2
+028700             MOVE REC-CT TO DOTVALUE.                             IC2334.2
+028800     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      IC2334.2
+028900     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               IC2334.2
+029000        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 IC2334.2
+029100          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 IC2334.2
+029200     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC2334.2
+029300     MOVE SPACE TO CORRECT-X.                                     IC2334.2
+029400     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC2334.2
+029500     MOVE     SPACE TO RE-MARK.                                   IC2334.2
+029600 HEAD-ROUTINE.                                                    IC2334.2
+029700     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2334.2
+029800     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2334.2
+029900     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2334.2
+030000     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2334.2
+030100 COLUMN-NAMES-ROUTINE.                                            IC2334.2
+030200     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2334.2
+030300     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2334.2
+030400     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC2334.2
+030500 END-ROUTINE.                                                     IC2334.2
+030600     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.IC2334.2
+030700 END-RTN-EXIT.                                                    IC2334.2
+030800     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2334.2
+030900 END-ROUTINE-1.                                                   IC2334.2
+031000      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      IC2334.2
+031100      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               IC2334.2
+031200      ADD PASS-COUNTER TO ERROR-HOLD.                             IC2334.2
+031300*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC2334.2
+031400      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC2334.2
+031500      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC2334.2
+031600      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC2334.2
+031700      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC2334.2
+031800  END-ROUTINE-12.                                                 IC2334.2
+031900      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC2334.2
+032000     IF       ERROR-COUNTER IS EQUAL TO ZERO                      IC2334.2
+032100         MOVE "NO " TO ERROR-TOTAL                                IC2334.2
+032200         ELSE                                                     IC2334.2
+032300         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC2334.2
+032400     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC2334.2
+032500     PERFORM WRITE-LINE.                                          IC2334.2
+032600 END-ROUTINE-13.                                                  IC2334.2
+032700     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC2334.2
+032800         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC2334.2
+032900         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC2334.2
+033000     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC2334.2
+033100     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2334.2
+033200      IF   INSPECT-COUNTER EQUAL TO ZERO                          IC2334.2
+033300          MOVE "NO " TO ERROR-TOTAL                               IC2334.2
+033400      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   IC2334.2
+033500      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            IC2334.2
+033600      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          IC2334.2
+033700     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2334.2
+033800 WRITE-LINE.                                                      IC2334.2
+033900     ADD 1 TO RECORD-COUNT.                                       IC2334.2
+034000Y    IF RECORD-COUNT GREATER 50                                   IC2334.2
+034100Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC2334.2
+034200Y        MOVE SPACE TO DUMMY-RECORD                               IC2334.2
+034300Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC2334.2
+034400Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC2334.2
+034500Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC2334.2
+034600Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC2334.2
+034700Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC2334.2
+034800Y        MOVE ZERO TO RECORD-COUNT.                               IC2334.2
+034900     PERFORM WRT-LN.                                              IC2334.2
+035000 WRT-LN.                                                          IC2334.2
+035100     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC2334.2
+035200     MOVE SPACE TO DUMMY-RECORD.                                  IC2334.2
+035300 BLANK-LINE-PRINT.                                                IC2334.2
+035400     PERFORM WRT-LN.                                              IC2334.2
+035500 FAIL-ROUTINE.                                                    IC2334.2
+035600     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC2334.2
+035700     IF     CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.IC2334.2
+035800     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2334.2
+035900     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC2334.2
+036000     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2334.2
+036100     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2334.2
+036200     GO TO  FAIL-ROUTINE-EX.                                      IC2334.2
+036300 FAIL-ROUTINE-WRITE.                                              IC2334.2
+036400     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC2334.2
+036500     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC2334.2
+036600     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC2334.2
+036700     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC2334.2
+036800 FAIL-ROUTINE-EX. EXIT.                                           IC2334.2
+036900 BAIL-OUT.                                                        IC2334.2
+037000     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC2334.2
+037100     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC2334.2
+037200 BAIL-OUT-WRITE.                                                  IC2334.2
+037300     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC2334.2
+037400     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2334.2
+037500     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2334.2
+037600     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2334.2
+037700 BAIL-OUT-EX. EXIT.                                               IC2334.2
+037800 CCVS1-EXIT.                                                      IC2334.2
+037900     EXIT.                                                        IC2334.2
+038000 SECT-IC233A-1R-001 SECTION.                                      IC2334.2
+038100 USE-INIT-1.                                                      IC2334.2
+038200     MOVE   "USE-TEST-1" TO PAR-NAME.                             IC2334.2
+038300     MOVE   "X-34 5.5.4 GR(1)B" TO ANSI-REFERENCE.                IC2334.2
+038400     MOVE    ZERO TO DILFRAP.                                     IC2334.2
+038500 USE-TEST-0.                                                      IC2334.2
+038600     CALL   "IC233A1".                                            IC2334.2
+038700     IF      DILFRAP = 1                                          IC2334.2
+038800             GO TO   CCVS-EXIT.                                   IC2334.2
+038900 USE-FAIL-1.                                                      IC2334.2
+039000     MOVE   "USE PROCEDURE NOT INVOKED" TO RE-MARK.               IC2334.2
+039100     PERFORM FAIL.                                                IC2334.2
+039200     GO TO   USE-WRITE-1.                                         IC2334.2
+039300 USE-DELETE-1.                                                    IC2334.2
+039400     PERFORM DE-LETE.                                             IC2334.2
+039500 USE-WRITE-1.                                                     IC2334.2
+039600     PERFORM PRINT-DETAIL.                                        IC2334.2
+039700*                                                                 IC2334.2
+039800 CCVS-EXIT SECTION.                                               IC2334.2
+039900 CCVS-999999.                                                     IC2334.2
+040000     GO TO CLOSE-FILES.                                           IC2334.2
+040100*                                                                 IC2334.2
+051300 END PROGRAM IC233A.                                              IC2334.2

--- a/z390/IC233A1.CBL
+++ b/z390/IC233A1.CBL
@@ -1,0 +1,117 @@
+040200 IDENTIFICATION DIVISION.                                         IC2334.2
+      *
+      * This is the z390 version of IC233A-1
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC233A1
+      * IC233A has been modified to call IC233A1 instead of IC233A-1.
+      *
+040300 PROGRAM-ID.                                                      IC2334.2
+040400     IC233A1.                                                     IC2334.2
+040500****************************************************************  IC2334.2
+040600*                                                              *  IC2334.2
+040700*    THIS PROGRAM FORMS PART OF THE COBOL COMPILER VALIDATION  *  IC2334.2
+040800*    SYSTEM (CCVS) USED TO TEST COBOL COMPILERS FOR            *  IC2334.2
+040900*    CONFORMANCE WITH THE AMERICAN NATIONAL STANDARD           *  IC2334.2
+041000*    (ANSI DOCUMENT REFERENCE: X3.23-1985) AND THE STANDARD OF *  IC2334.2
+041100*    THE INTERNATIONAL ORGANIZATION FOR STANDARDISATION        *  IC2334.2
+041200*    (ISO DOCUMENT REFERENCE: ISO-1989-1985).                  *  IC2334.2
+041300*                                                              *  IC2334.2
+041400*    THIS CCVS INCORPORATES ENHANCEMENTS TO THE CCVS FOR THE   *  IC2334.2
+041500*    1974 STANDARD (ANSI DOCUMENT REFERENCE: X3.23-1974; ISO   *  IC2334.2
+041600*    DOCUMENT REFERENCE: ISO-1989-1978).                       *  IC2334.2
+041700*                                                              *  IC2334.2
+041800*    THESE ENHANCEMENTS WERE SPECIFIED BY A PROJECT TEAM WHICH *  IC2334.2
+041900*    WAS FUNDED BY THE COMMISSION FOR EUROPEAN COMMUNITIES AND *  IC2334.2
+042000*    WHICH WAS RESPONSIBLE FOR TECHNICAL ISSUES TO:            *  IC2334.2
+042100*                                                              *  IC2334.2
+042200*          THE FEDERAL SOFTWARE TESTING CENTER                 *  IC2334.2
+042300*          OFFICE OF SOFTWARE DEVELOPMENT                      *  IC2334.2
+042400*                & INFORMATION TECHNOLOGY                      *  IC2334.2
+042500*          TWO SKYLINE PLACE                                   *  IC2334.2
+042600*          SUITE 1100                                          *  IC2334.2
+042700*          5203 LEESBURG PIKE                                  *  IC2334.2
+042800*          FALLS CHURCH                                        *  IC2334.2
+042900*          VA 22041                                            *  IC2334.2
+043000*          U.S.A.                                              *  IC2334.2
+043100*                                                              *  IC2334.2
+043200*    THE PROJECT TEAM MEMBERS WERE:                            *  IC2334.2
+043300*                                                              *  IC2334.2
+043400*          BIADI (BUREAU INTER ADMINISTRATION                  *  IC2334.2
+043500*                 DE DOCUMENTATION INFORMATIQUE)               *  IC2334.2
+043600*          21 RUE BARA                                         *  IC2334.2
+043700*          F-92132 ISSY                                        *  IC2334.2
+043800*          FRANCE                                              *  IC2334.2
+043900*                                                              *  IC2334.2
+044000*                                                              *  IC2334.2
+044100*          GMD (GESELLSCHAFT FUR MATHEMATIK                    *  IC2334.2
+044200*               UND DATENVERARBEITUNG MBH)                     *  IC2334.2
+044300*          SCHLOSS BIRLINGHOVEN                                *  IC2334.2
+044400*          POSTFACH 12 40                                      *  IC2334.2
+044500*          D-5205 ST. AUGUSTIN 1                               *  IC2334.2
+044600*          GERMANY FR                                          *  IC2334.2
+044700*                                                              *  IC2334.2
+044800*                                                              *  IC2334.2
+044900*          NCC (THE NATIONAL COMPUTING CENTRE LTD)             *  IC2334.2
+045000*          OXFORD ROAD                                         *  IC2334.2
+045100*          MANCHESTER                                          *  IC2334.2
+045200*          M1 7ED                                              *  IC2334.2
+045300*          UNITED KINGDOM                                      *  IC2334.2
+045400*                                                              *  IC2334.2
+045500*                                                              *  IC2334.2
+045600*    THIS TEST SUITE WAS PRODUCED BY THE NATIONAL COMPUTING    *  IC2334.2
+045700*    CENTRE IN ENGLAND AND IS THE OFFICIAL CCVS TEST SUITE     *  IC2334.2
+045800*    USED THROUGHOUT EUROPE AND THE UNITED STATES OF AMERICA.  *  IC2334.2
+045900*                                                              *  IC2334.2
+046000****************************************************************  IC2334.2
+046100*                                                              *  IC2334.2
+046200*    VALIDATION FOR:-                                          *  IC2334.2
+046300*                                                              *  IC2334.2
+046400*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2334.2
+046500*                                                              *  IC2334.2
+046600*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2334.2
+046700*                                                              *  IC2334.2
+046800****************************************************************  IC2334.2
+046900*                                                              *  IC2334.2
+047000*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2334.2
+047100*                                                              *  IC2334.2
+047200*        X-55  - SYSTEM PRINTER NAME.                          *  IC2334.2
+047300*        X-82  - SOURCE COMPUTER NAME.                         *  IC2334.2
+047400*        X-83  - OBJECT COMPUTER NAME.                         *  IC2334.2
+047500*        X-92  - TEST-FILE.                                    *  IC2334.2
+047600*                                                              *  IC2334.2
+047700****************************************************************  IC2334.2
+047800*                                                              *  IC2334.2
+047900*    PROGRAMS IC233A AND IC233A-1 TEST THAT A "USE" PROCEDURE  *  IC2334.2
+048000*    IN A CALLING PROGRAM IS INVOKED BY A QUALIFYING CONDITION *  IC2334.2
+048100*    OCCURRING IN A CONTAINED PROGRAM.                         *  IC2334.2
+048200*                                                              *  IC2334.2
+048300*    BOTH PROGRAMS WILL BE COMPILED IN ONE INVOCATION OF THE   *  IC2334.2
+048400*    COMPILER AS SHOWN BELOW:                                  *  IC2334.2
+048500*    IDENTIFICATION DIVISION.                                  *  IC2334.2
+048600*    PROGRAM-ID. IC233A.                                       *  IC2334.2
+048700*              .                                               *  IC2334.2
+048800*              .                                               *  IC2334.2
+048900*              .                                               *  IC2334.2
+049000*    IDENTIFICATION DIVISION.                                  *  IC2334.2
+049100*    PROGRAM-ID. IC233A-1.                                     *  IC2334.2
+049200*              .                                               *  IC2334.2
+049300*              .                                               *  IC2334.2
+049400*    END PROGRAM IC233A-1.                                     *  IC2334.2
+049500*    END PROGRAM IC233A.                                       *  IC2334.2
+049600****************************************************************  IC2334.2
+049700*ENVIRONMENT DIVISION.                                            IC2334.2
+049800*INPUT-OUTPUT SECTION.                                            IC2334.2
+049900*FILE-CONTROL.                                                    IC2334.2
+050000*    SELECT TEST-FILE ASSIGN TO                                   IC2334.2
+050100*    XXXXX018.                                                    IC2334.2
+050200 DATA DIVISION.                                                   IC2334.2
+050300 FILE SECTION.                                                    IC2334.2
+050400 WORKING-STORAGE SECTION.                                         IC2334.2
+050500 PROCEDURE DIVISION.                                              IC2334.2
+050600 SECT-IC233A-1-001 SECTION.                                       IC2334.2
+050700 USE-INIT-1.                                                      IC2334.2
+050800     OPEN    INPUT TEST-FILE.                                     IC2334.2
+050900     READ    TEST-FILE.                                           IC2334.2
+051000 END-PROG.                                                        IC2334.2
+051100     EXIT PROGRAM.                                                IC2334.2
+051200 END PROGRAM IC233A1.                                             IC2334.2

--- a/z390/IC234A.CBL
+++ b/z390/IC234A.CBL
@@ -1,0 +1,373 @@
+000100 IDENTIFICATION DIVISION.                                         IC2344.2
+      *
+      * This is the z390 version of IC234A
+      * z390 cannot handle multiple programs in a single source file
+      * The subprograms have been extracted and saved as IC234A1-3
+      * IC234A has been modified to call IC234A1 instead of IC234A-1.
+      *
+000200 PROGRAM-ID.                                                      IC2344.2
+000300     IC234A.                                                      IC2344.2
+000400****************************************************************  IC2344.2
+000500*                                                              *  IC2344.2
+000600*    VALIDATION FOR:-                                          *  IC2344.2
+000700*                                                              *  IC2344.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2344.2
+000900*                                                              *  IC2344.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2344.2
+001100*                                                              *  IC2344.2
+001200****************************************************************  IC2344.2
+001300*                                                              *  IC2344.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2344.2
+001500*                                                              *  IC2344.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC2344.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC2344.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC2344.2
+001900*        X-14  - TEST-FILE.                                    *  IC2344.2
+002000*                                                              *  IC2344.2
+002100****************************************************************  IC2344.2
+002200*                                                              *  IC2344.2
+002300*    PROGRAMS IC234A, IC234A-1, IC234A-2 AND IC234A-3 TEST     *  IC2344.2
+002400*    TEST THAT A "USE" PROCEDURE IN A CALLING PROGRAM IS       *  IC2344.2
+002500*    INVOKED BY A QUALIFYING CONDITION OCURRING IN A CONTAINED *  IC2344.2
+002600*    PROGRAM NESTED TO FOUR LEVELS.                            *  IC2344.2
+002700*                                                              *  IC2344.2
+002800*    ALL PROGRAMS WILL BE COMPILED IN ONE INVOCATION OF THE    *  IC2344.2
+002900*    COMPILER AS SHOWN BELOW:                                  *  IC2344.2
+003000*    IDENTIFICATION DIVISION.                                  *  IC2344.2
+003100*    PROGRAM-ID. IC234A.                                       *  IC2344.2
+003200*              .                                               *  IC2344.2
+003300*              .                                               *  IC2344.2
+003400*              .                                               *  IC2344.2
+003500*    IDENTIFICATION DIVISION.                                  *  IC2344.2
+003600*    PROGRAM-ID. IC234A-1.                                     *  IC2344.2
+003700*              .                                               *  IC2344.2
+003800*              .                                               *  IC2344.2
+003900*    IDENTIFICATION DIVISION.                                  *  IC2344.2
+004000*    PROGRAM-ID. IC234A-2.                                     *  IC2344.2
+004100*              .                                               *  IC2344.2
+004200*              .                                               *  IC2344.2
+004300*              .                                               *  IC2344.2
+004400*    IDENTIFICATION DIVISION.                                  *  IC2344.2
+004500*    PROGRAM-ID. IC234A-3.                                     *  IC2344.2
+004600*              .                                               *  IC2344.2
+004700*              .                                               *  IC2344.2
+004800*    END PROGRAM IC234A-3.                                     *  IC2344.2
+004900*    END PROGRAM IC234A-2.                                     *  IC2344.2
+005000*    END PROGRAM IC234A-1.                                     *  IC2344.2
+005100*    END PROGRAM IC234A.                                       *  IC2344.2
+005200****************************************************************  IC2344.2
+005300 ENVIRONMENT DIVISION.                                            IC2344.2
+005400 CONFIGURATION SECTION.                                           IC2344.2
+005500 SOURCE-COMPUTER.                                                 IC2344.2
+005600     XXXXX082.                                                    IC2344.2
+005700 OBJECT-COMPUTER.                                                 IC2344.2
+005800     XXXXX083.                                                    IC2344.2
+005900 INPUT-OUTPUT SECTION.                                            IC2344.2
+006000 FILE-CONTROL.                                                    IC2344.2
+006100     SELECT PRINT-FILE ASSIGN TO                                  IC2344.2
+006200     XXXXX055.                                                    IC2344.2
+006300     SELECT TEST-FILE  ASSIGN TO                                  IC2344.2
+006400     XXXXX014.                                                    IC2344.2
+006500 DATA DIVISION.                                                   IC2344.2
+006600 FILE SECTION.                                                    IC2344.2
+006700 FD  PRINT-FILE.                                                  IC2344.2
+006800 01  PRINT-REC                   PIC X(120).                      IC2344.2
+006900 01  DUMMY-RECORD                PIC X(120).                      IC2344.2
+007000 FD  TEST-FILE GLOBAL.                                            IC2344.2
+007100 01  TEST-RECORD                 PIC X(20).                       IC2344.2
+007200 WORKING-STORAGE SECTION.                                         IC2344.2
+007300 01  DILFRAP   GLOBAL            PIC 9.                           IC2344.2
+007400 01  TEST-RESULTS.                                                IC2344.2
+007500     02 FILLER                   PIC X      VALUE SPACE.          IC2344.2
+007600     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC2344.2
+007700     02 FILLER                   PIC X      VALUE SPACE.          IC2344.2
+007800     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC2344.2
+007900     02 FILLER                   PIC X      VALUE SPACE.          IC2344.2
+008000     02  PAR-NAME.                                                IC2344.2
+008100       03 FILLER                 PIC X(19)  VALUE SPACE.          IC2344.2
+008200       03  PARDOT-X              PIC X      VALUE SPACE.          IC2344.2
+008300       03 DOTVALUE               PIC 99     VALUE ZERO.           IC2344.2
+008400     02 FILLER                   PIC X(8)   VALUE SPACE.          IC2344.2
+008500     02 RE-MARK                  PIC X(61).                       IC2344.2
+008600 01  TEST-COMPUTED.                                               IC2344.2
+008700     02 FILLER                   PIC X(30)  VALUE SPACE.          IC2344.2
+008800     02 FILLER                   PIC X(17)  VALUE                 IC2344.2
+008900            "       COMPUTED=".                                   IC2344.2
+009000     02 COMPUTED-X.                                               IC2344.2
+009100     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC2344.2
+009200     03 COMPUTED-N               REDEFINES COMPUTED-A             IC2344.2
+009300                                 PIC -9(9).9(9).                  IC2344.2
+009400     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC2344.2
+009500     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC2344.2
+009600     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC2344.2
+009700     03       CM-18V0 REDEFINES COMPUTED-A.                       IC2344.2
+009800         04 COMPUTED-18V0                    PIC -9(18).          IC2344.2
+009900         04 FILLER                           PIC X.               IC2344.2
+010000     03 FILLER PIC X(50) VALUE SPACE.                             IC2344.2
+010100 01  TEST-CORRECT.                                                IC2344.2
+010200     02 FILLER PIC X(30) VALUE SPACE.                             IC2344.2
+010300     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC2344.2
+010400     02 CORRECT-X.                                                IC2344.2
+010500     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC2344.2
+010600     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC2344.2
+010700     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC2344.2
+010800     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC2344.2
+010900     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC2344.2
+011000     03      CR-18V0 REDEFINES CORRECT-A.                         IC2344.2
+011100         04 CORRECT-18V0                     PIC -9(18).          IC2344.2
+011200         04 FILLER                           PIC X.               IC2344.2
+011300     03 FILLER PIC X(2) VALUE SPACE.                              IC2344.2
+011400     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC2344.2
+011500 01  CCVS-C-1.                                                    IC2344.2
+011600     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC2344.2
+011700-    "SS  PARAGRAPH-NAME                                          IC2344.2
+011800-    "       REMARKS".                                            IC2344.2
+011900     02 FILLER                     PIC X(20)    VALUE SPACE.      IC2344.2
+012000 01  CCVS-C-2.                                                    IC2344.2
+012100     02 FILLER                     PIC X        VALUE SPACE.      IC2344.2
+012200     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC2344.2
+012300     02 FILLER                     PIC X(15)    VALUE SPACE.      IC2344.2
+012400     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC2344.2
+012500     02 FILLER                     PIC X(94)    VALUE SPACE.      IC2344.2
+012600 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC2344.2
+012700 01  REC-CT                        PIC 99       VALUE ZERO.       IC2344.2
+012800 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC2344.2
+012900 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC2344.2
+013000 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC2344.2
+013100 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC2344.2
+013200 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC2344.2
+013300 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC2344.2
+013400 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC2344.2
+013500 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC2344.2
+013600 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC2344.2
+013700 01  CCVS-H-1.                                                    IC2344.2
+013800     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2344.2
+013900     02  FILLER                    PIC X(42)    VALUE             IC2344.2
+014000     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC2344.2
+014100     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2344.2
+014200 01  CCVS-H-2A.                                                   IC2344.2
+014300   02  FILLER                        PIC X(40)  VALUE SPACE.      IC2344.2
+014400   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC2344.2
+014500   02  FILLER                        PIC XXXX   VALUE             IC2344.2
+014600     "4.2 ".                                                      IC2344.2
+014700   02  FILLER                        PIC X(28)  VALUE             IC2344.2
+014800            " COPY - NOT FOR DISTRIBUTION".                       IC2344.2
+014900   02  FILLER                        PIC X(41)  VALUE SPACE.      IC2344.2
+015000                                                                  IC2344.2
+015100 01  CCVS-H-2B.                                                   IC2344.2
+015200   02  FILLER                        PIC X(15)  VALUE             IC2344.2
+015300            "TEST RESULT OF ".                                    IC2344.2
+015400   02  TEST-ID                       PIC X(9).                    IC2344.2
+015500   02  FILLER                        PIC X(4)   VALUE             IC2344.2
+015600            " IN ".                                               IC2344.2
+015700   02  FILLER                        PIC X(12)  VALUE             IC2344.2
+015800     " HIGH       ".                                              IC2344.2
+015900   02  FILLER                        PIC X(22)  VALUE             IC2344.2
+016000            " LEVEL VALIDATION FOR ".                             IC2344.2
+016100   02  FILLER                        PIC X(58)  VALUE             IC2344.2
+016200     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2344.2
+016300 01  CCVS-H-3.                                                    IC2344.2
+016400     02  FILLER                      PIC X(34)  VALUE             IC2344.2
+016500            " FOR OFFICIAL USE ONLY    ".                         IC2344.2
+016600     02  FILLER                      PIC X(58)  VALUE             IC2344.2
+016700     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2344.2
+016800     02  FILLER                      PIC X(28)  VALUE             IC2344.2
+016900            "  COPYRIGHT   1985 ".                                IC2344.2
+017000 01  CCVS-E-1.                                                    IC2344.2
+017100     02 FILLER                       PIC X(52)  VALUE SPACE.      IC2344.2
+017200     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC2344.2
+017300     02 ID-AGAIN                     PIC X(9).                    IC2344.2
+017400     02 FILLER                       PIC X(45)  VALUE SPACES.     IC2344.2
+017500 01  CCVS-E-2.                                                    IC2344.2
+017600     02  FILLER                      PIC X(31)  VALUE SPACE.      IC2344.2
+017700     02  FILLER                      PIC X(21)  VALUE SPACE.      IC2344.2
+017800     02 CCVS-E-2-2.                                               IC2344.2
+017900         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC2344.2
+018000         03 FILLER                   PIC X      VALUE SPACE.      IC2344.2
+018100         03 ENDER-DESC               PIC X(44)  VALUE             IC2344.2
+018200            "ERRORS ENCOUNTERED".                                 IC2344.2
+018300 01  CCVS-E-3.                                                    IC2344.2
+018400     02  FILLER                      PIC X(22)  VALUE             IC2344.2
+018500            " FOR OFFICIAL USE ONLY".                             IC2344.2
+018600     02  FILLER                      PIC X(12)  VALUE SPACE.      IC2344.2
+018700     02  FILLER                      PIC X(58)  VALUE             IC2344.2
+018800     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2344.2
+018900     02  FILLER                      PIC X(13)  VALUE SPACE.      IC2344.2
+019000     02 FILLER                       PIC X(15)  VALUE             IC2344.2
+019100             " COPYRIGHT 1985".                                   IC2344.2
+019200 01  CCVS-E-4.                                                    IC2344.2
+019300     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC2344.2
+019400     02 FILLER                       PIC X(4)   VALUE " OF ".     IC2344.2
+019500     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC2344.2
+019600     02 FILLER                       PIC X(40)  VALUE             IC2344.2
+019700      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC2344.2
+019800 01  XXINFO.                                                      IC2344.2
+019900     02 FILLER                       PIC X(19)  VALUE             IC2344.2
+020000            "*** INFORMATION ***".                                IC2344.2
+020100     02 INFO-TEXT.                                                IC2344.2
+020200       04 FILLER                     PIC X(8)   VALUE SPACE.      IC2344.2
+020300       04 XXCOMPUTED                 PIC X(20).                   IC2344.2
+020400       04 FILLER                     PIC X(5)   VALUE SPACE.      IC2344.2
+020500       04 XXCORRECT                  PIC X(20).                   IC2344.2
+020600     02 INF-ANSI-REFERENCE           PIC X(48).                   IC2344.2
+020700 01  HYPHEN-LINE.                                                 IC2344.2
+020800     02 FILLER  PIC IS X VALUE IS SPACE.                          IC2344.2
+020900     02 FILLER  PIC IS X(65)    VALUE IS "************************IC2344.2
+021000-    "*****************************************".                 IC2344.2
+021100     02 FILLER  PIC IS X(54)    VALUE IS "************************IC2344.2
+021200-    "******************************".                            IC2344.2
+021300 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC2344.2
+021400     "IC234A".                                                    IC2344.2
+021500 PROCEDURE DIVISION.                                              IC2344.2
+021600 DECLARATIVES.                                                    IC2344.2
+021700 SECT-IC234A-001 SECTION.                                         IC2344.2
+021800     USE GLOBAL AFTER ERROR PROCEDURE ON INPUT.                   IC2344.2
+021900 USE-TEST-2.                                                      IC2344.2
+022000     ADD 1 TO DILFRAP.                                            IC2344.2
+022100 END DECLARATIVES.                                                IC2344.2
+022200 CCVS1 SECTION.                                                   IC2344.2
+022300 OPEN-FILES.                                                      IC2344.2
+022400     OPEN     OUTPUT PRINT-FILE.                                  IC2344.2
+022500     MOVE CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.   IC2344.2
+022600     MOVE    SPACE TO TEST-RESULTS.                               IC2344.2
+022700     PERFORM  HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.             IC2344.2
+022800     GO TO CCVS1-EXIT.                                            IC2344.2
+022900 CLOSE-FILES.                                                     IC2344.2
+023000     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC2344.2
+023100 TERMINATE-CCVS.                                                  IC2344.2
+023200S    EXIT PROGRAM.                                                IC2344.2
+023300STERMINATE-CALL.                                                  IC2344.2
+023400     STOP     RUN.                                                IC2344.2
+023500 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         IC2344.2
+023600 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           IC2344.2
+023700 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          IC2344.2
+023800 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      IC2344.2
+023900     MOVE "****TEST DELETED****" TO RE-MARK.                      IC2344.2
+024000 PRINT-DETAIL.                                                    IC2344.2
+024100     IF REC-CT NOT EQUAL TO ZERO                                  IC2344.2
+024200             MOVE "." TO PARDOT-X                                 IC2344.2
+024300             MOVE REC-CT TO DOTVALUE.                             IC2344.2
+024400     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      IC2344.2
+024500     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               IC2344.2
+024600        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 IC2344.2
+024700          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 IC2344.2
+024800     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC2344.2
+024900     MOVE SPACE TO CORRECT-X.                                     IC2344.2
+025000     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC2344.2
+025100     MOVE     SPACE TO RE-MARK.                                   IC2344.2
+025200 HEAD-ROUTINE.                                                    IC2344.2
+025300     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2344.2
+025400     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2344.2
+025500     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2344.2
+025600     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2344.2
+025700 COLUMN-NAMES-ROUTINE.                                            IC2344.2
+025800     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2344.2
+025900     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2344.2
+026000     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC2344.2
+026100 END-ROUTINE.                                                     IC2344.2
+026200     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.IC2344.2
+026300 END-RTN-EXIT.                                                    IC2344.2
+026400     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2344.2
+026500 END-ROUTINE-1.                                                   IC2344.2
+026600      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      IC2344.2
+026700      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               IC2344.2
+026800      ADD PASS-COUNTER TO ERROR-HOLD.                             IC2344.2
+026900*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC2344.2
+027000      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC2344.2
+027100      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC2344.2
+027200      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC2344.2
+027300      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC2344.2
+027400  END-ROUTINE-12.                                                 IC2344.2
+027500      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC2344.2
+027600     IF       ERROR-COUNTER IS EQUAL TO ZERO                      IC2344.2
+027700         MOVE "NO " TO ERROR-TOTAL                                IC2344.2
+027800         ELSE                                                     IC2344.2
+027900         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC2344.2
+028000     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC2344.2
+028100     PERFORM WRITE-LINE.                                          IC2344.2
+028200 END-ROUTINE-13.                                                  IC2344.2
+028300     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC2344.2
+028400         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC2344.2
+028500         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC2344.2
+028600     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC2344.2
+028700     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2344.2
+028800      IF   INSPECT-COUNTER EQUAL TO ZERO                          IC2344.2
+028900          MOVE "NO " TO ERROR-TOTAL                               IC2344.2
+029000      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   IC2344.2
+029100      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            IC2344.2
+029200      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          IC2344.2
+029300     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2344.2
+029400 WRITE-LINE.                                                      IC2344.2
+029500     ADD 1 TO RECORD-COUNT.                                       IC2344.2
+029600Y    IF RECORD-COUNT GREATER 50                                   IC2344.2
+029700Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC2344.2
+029800Y        MOVE SPACE TO DUMMY-RECORD                               IC2344.2
+029900Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC2344.2
+030000Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC2344.2
+030100Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC2344.2
+030200Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC2344.2
+030300Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC2344.2
+030400Y        MOVE ZERO TO RECORD-COUNT.                               IC2344.2
+030500     PERFORM WRT-LN.                                              IC2344.2
+030600 WRT-LN.                                                          IC2344.2
+030700     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC2344.2
+030800     MOVE SPACE TO DUMMY-RECORD.                                  IC2344.2
+030900 BLANK-LINE-PRINT.                                                IC2344.2
+031000     PERFORM WRT-LN.                                              IC2344.2
+031100 FAIL-ROUTINE.                                                    IC2344.2
+031200     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC2344.2
+031300     IF     CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.IC2344.2
+031400     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2344.2
+031500     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC2344.2
+031600     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2344.2
+031700     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2344.2
+031800     GO TO  FAIL-ROUTINE-EX.                                      IC2344.2
+031900 FAIL-ROUTINE-WRITE.                                              IC2344.2
+032000     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC2344.2
+032100     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC2344.2
+032200     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC2344.2
+032300     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC2344.2
+032400 FAIL-ROUTINE-EX. EXIT.                                           IC2344.2
+032500 BAIL-OUT.                                                        IC2344.2
+032600     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC2344.2
+032700     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC2344.2
+032800 BAIL-OUT-WRITE.                                                  IC2344.2
+032900     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC2344.2
+033000     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2344.2
+033100     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2344.2
+033200     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2344.2
+033300 BAIL-OUT-EX. EXIT.                                               IC2344.2
+033400 CCVS1-EXIT.                                                      IC2344.2
+033500     EXIT.                                                        IC2344.2
+033600 SECT-IC234A-1R-001 SECTION.                                      IC2344.2
+033700 USE-INIT-1.                                                      IC2344.2
+033800     OPEN    OUTPUT TEST-FILE.                                    IC2344.2
+033900     CLOSE   TEST-FILE.                                           IC2344.2
+034000     MOVE    1 TO REC-CT.                                         IC2344.2
+034100     MOVE "USE GLOBAL INPUT" TO FEATURE.                          IC2344.2
+034200     MOVE   "USE-TEST-1" TO PAR-NAME.                             IC2344.2
+034300     MOVE   "X-34 5.5.4 GR(1)C" TO ANSI-REFERENCE.                IC2344.2
+034400     MOVE    ZERO TO DILFRAP.                                     IC2344.2
+034500 USE-TEST-0.                                                      IC2344.2
+034600     CALL   "IC234A1".                                            IC2344.2
+034700     IF      DILFRAP = 1                                          IC2344.2
+034800             PERFORM PASS                                         IC2344.2
+034900             GO TO   USE-WRITE-1.                                 IC2344.2
+035000 USE-FAIL-1.                                                      IC2344.2
+035100     MOVE    1 TO CORRECT-N.                                      IC2344.2
+035200     MOVE    DILFRAP TO COMPUTED-N.                               IC2344.2
+035300     IF DILFRAP = 0                                               IC2344.2
+035400             MOVE   "USE PROCEDURE NOT INVOKED" TO RE-MARK        IC2344.2
+035500     ELSE MOVE "WRONG 'USE' PROCEDURE INVOKED" TO RE-MARK.        IC2344.2
+035600     PERFORM FAIL.                                                IC2344.2
+035700     GO TO   USE-WRITE-1.                                         IC2344.2
+035800 USE-DELETE-1.                                                    IC2344.2
+035900     PERFORM DE-LETE.                                             IC2344.2
+036000 USE-WRITE-1.                                                     IC2344.2
+036100     PERFORM PRINT-DETAIL.                                        IC2344.2
+036200*                                                                 IC2344.2
+036300 CCVS-EXIT SECTION.                                               IC2344.2
+036400 CCVS-999999.                                                     IC2344.2
+036500     GO TO CLOSE-FILES.                                           IC2344.2
+036600*                                                                 IC2344.2
+073700 END PROGRAM IC234A.                                              IC2344.2

--- a/z390/IC234A1.CBL
+++ b/z390/IC234A1.CBL
@@ -1,0 +1,132 @@
+036700 IDENTIFICATION DIVISION.                                         IC2344.2
+      *
+      * This is the z390 version of IC234A-1
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC234A1
+      * IC234A has been modified to call IC234A1 instead of IC234A-1.
+      * IC234A1 has been modified to call IC234A2 instead of IC234A-2.
+      *
+036800 PROGRAM-ID.                                                      IC2344.2
+036900     IC234A1.                                                     IC2344.2
+037000****************************************************************  IC2344.2
+037100*                                                              *  IC2344.2
+037200*    THIS PROGRAM FORMS PART OF THE COBOL COMPILER VALIDATION  *  IC2344.2
+037300*    SYSTEM (CCVS) USED TO TEST COBOL COMPILERS FOR            *  IC2344.2
+037400*    CONFORMANCE WITH THE AMERICAN NATIONAL STANDARD           *  IC2344.2
+037500*    (ANSI DOCUMENT REFERENCE: X3.23-1985) AND THE STANDARD OF *  IC2344.2
+037600*    THE INTERNATIONAL ORGANIZATION FOR STANDARDISATION        *  IC2344.2
+037700*    (ISO DOCUMENT REFERENCE: ISO-1989-1985).                  *  IC2344.2
+037800*                                                              *  IC2344.2
+037900*    THIS CCVS INCORPORATES ENHANCEMENTS TO THE CCVS FOR THE   *  IC2344.2
+038000*    1974 STANDARD (ANSI DOCUMENT REFERENCE: X3.23-1974; ISO   *  IC2344.2
+038100*    DOCUMENT REFERENCE: ISO-1989-1978).                       *  IC2344.2
+038200*                                                              *  IC2344.2
+038300*    THESE ENHANCEMENTS WERE SPECIFIED BY A PROJECT TEAM WHICH *  IC2344.2
+038400*    WAS FUNDED BY THE COMMISSION FOR EUROPEAN COMMUNITIES AND *  IC2344.2
+038500*    WHICH WAS RESPONSIBLE FOR TECHNICAL ISSUES TO:            *  IC2344.2
+038600*                                                              *  IC2344.2
+038700*          THE FEDERAL SOFTWARE TESTING CENTER                 *  IC2344.2
+038800*          OFFICE OF SOFTWARE DEVELOPMENT                      *  IC2344.2
+038900*                & INFORMATION TECHNOLOGY                      *  IC2344.2
+039000*          TWO SKYLINE PLACE                                   *  IC2344.2
+039100*          SUITE 1100                                          *  IC2344.2
+039200*          5203 LEESBURG PIKE                                  *  IC2344.2
+039300*          FALLS CHURCH                                        *  IC2344.2
+039400*          VA 22041                                            *  IC2344.2
+039500*          U.S.A.                                              *  IC2344.2
+039600*                                                              *  IC2344.2
+039700*    THE PROJECT TEAM MEMBERS WERE:                            *  IC2344.2
+039800*                                                              *  IC2344.2
+039900*          BIADI (BUREAU INTER ADMINISTRATION                  *  IC2344.2
+040000*                 DE DOCUMENTATION INFORMATIQUE)               *  IC2344.2
+040100*          21 RUE BARA                                         *  IC2344.2
+040200*          F-92132 ISSY                                        *  IC2344.2
+040300*          FRANCE                                              *  IC2344.2
+040400*                                                              *  IC2344.2
+040500*                                                              *  IC2344.2
+040600*          GMD (GESELLSCHAFT FUR MATHEMATIK                    *  IC2344.2
+040700*               UND DATENVERARBEITUNG MBH)                     *  IC2344.2
+040800*          SCHLOSS BIRLINGHOVEN                                *  IC2344.2
+040900*          POSTFACH 12 40                                      *  IC2344.2
+041000*          D-5205 ST. AUGUSTIN 1                               *  IC2344.2
+041100*          GERMANY FR                                          *  IC2344.2
+041200*                                                              *  IC2344.2
+041300*                                                              *  IC2344.2
+041400*          NCC (THE NATIONAL COMPUTING CENTRE LTD)             *  IC2344.2
+041500*          OXFORD ROAD                                         *  IC2344.2
+041600*          MANCHESTER                                          *  IC2344.2
+041700*          M1 7ED                                              *  IC2344.2
+041800*          UNITED KINGDOM                                      *  IC2344.2
+041900*                                                              *  IC2344.2
+042000*                                                              *  IC2344.2
+042100*    THIS TEST SUITE WAS PRODUCED BY THE NATIONAL COMPUTING    *  IC2344.2
+042200*    CENTRE IN ENGLAND AND IS THE OFFICIAL CCVS TEST SUITE     *  IC2344.2
+042300*    USED THROUGHOUT EUROPE AND THE UNITED STATES OF AMERICA.  *  IC2344.2
+042400*                                                              *  IC2344.2
+042500****************************************************************  IC2344.2
+042600*                                                              *  IC2344.2
+042700*    VALIDATION FOR:-                                          *  IC2344.2
+042800*                                                              *  IC2344.2
+042900*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2344.2
+043000*                                                              *  IC2344.2
+043100*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2344.2
+043200*                                                              *  IC2344.2
+043300****************************************************************  IC2344.2
+043400*                                                              *  IC2344.2
+043500*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2344.2
+043600*                                                              *  IC2344.2
+043700*        X-55  - SYSTEM PRINTER NAME.                          *  IC2344.2
+043800*        X-82  - SOURCE COMPUTER NAME.                         *  IC2344.2
+043900*        X-83  - OBJECT COMPUTER NAME.                         *  IC2344.2
+044000*                                                              *  IC2344.2
+044100****************************************************************  IC2344.2
+044200*                                                              *  IC2344.2
+044300*    PROGRAMS IC234A, IC234A-1, IC234A-2 AND IC234A-3 TEST     *  IC2344.2
+044400*    TEST THAT A "USE" PROCEDURE IN A CALLING PROGRAM IS       *  IC2344.2
+044500*    INVOKED BY A QUALIFYING CONDITION OCURRING IN A CONTAINED *  IC2344.2
+044600*    PROGRAM NESTED TO FOUR LEVELS.                            *  IC2344.2
+044700*                                                              *  IC2344.2
+044800*    ALL PROGRAMS WILL BE COMPILED IN ONE INVOCATION OF THE    *  IC2344.2
+044900*    COMPILER AS SHOWN BELOW:                                  *  IC2344.2
+045000*    IDENTIFICATION DIVISION.                                  *  IC2344.2
+045100*    PROGRAM-ID. IC234A.                                       *  IC2344.2
+045200*              .                                               *  IC2344.2
+045300*              .                                               *  IC2344.2
+045400*              .                                               *  IC2344.2
+045500*    IDENTIFICATION DIVISION.                                  *  IC2344.2
+045600*    PROGRAM-ID. IC234A-1.                                     *  IC2344.2
+045700*              .                                               *  IC2344.2
+045800*              .                                               *  IC2344.2
+045900*    IDENTIFICATION DIVISION.                                  *  IC2344.2
+046000*    PROGRAM-ID. IC234A-2.                                     *  IC2344.2
+046100*              .                                               *  IC2344.2
+046200*              .                                               *  IC2344.2
+046300*              .                                               *  IC2344.2
+046400*    IDENTIFICATION DIVISION.                                  *  IC2344.2
+046500*    PROGRAM-ID. IC234A-3.                                     *  IC2344.2
+046600*              .                                               *  IC2344.2
+046700*              .                                               *  IC2344.2
+046800*    END PROGRAM IC234A-3.                                     *  IC2344.2
+046900*    END PROGRAM IC234A-2.                                     *  IC2344.2
+047000*    END PROGRAM IC234A-1.                                     *  IC2344.2
+047100*    END PROGRAM IC234A.                                       *  IC2344.2
+047200****************************************************************  IC2344.2
+047300*ENVIRONMENT DIVISION.                                            IC2344.2
+047400*INPUT-OUTPUT SECTION.                                            IC2344.2
+047500*FILE-CONTROL.                                                    IC2344.2
+047600 DATA DIVISION.                                                   IC2344.2
+047700 FILE SECTION.                                                    IC2344.2
+047800 WORKING-STORAGE SECTION.                                         IC2344.2
+047900 PROCEDURE DIVISION.                                              IC2344.2
+048000 DECLARATIVES.                                                    IC2344.2
+048100 NON-GLOBAL-SECTION SECTION.                                      IC2344.2
+048200     USE AFTER STANDARD EXCEPTION PROCEDURE ON TEST-FILE.         IC2344.2
+048300 USE-PARA.                                                        IC2344.2
+048400     ADD 2 TO DILFRAP.                                            IC2344.2
+048500 END DECLARATIVES.                                                IC2344.2
+048600 SECT-IC234A-1-001 SECTION.                                       IC2344.2
+048700 USE-INIT-1.                                                      IC2344.2
+048800     CALL   "IC234A2".                                            IC2344.2
+048900     EXIT PROGRAM.                                                IC2344.2
+049000*                                                                 IC2344.2
+073600 END PROGRAM IC234A1.                                             IC2344.2

--- a/z390/IC234A2.CBL
+++ b/z390/IC234A2.CBL
@@ -1,0 +1,132 @@
+049100 IDENTIFICATION DIVISION.                                         IC2344.2
+      *
+      * This is the z390 version of IC234A-2
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC234A2
+      * IC234A has been modified to call IC234A1 instead of IC234A-1.
+      * IC234A2 has been modified to call IC234A3 instead of IC234A-3.
+      *
+049200 PROGRAM-ID.                                                      IC2344.2
+049300     IC234A2.                                                     IC2344.2
+049400****************************************************************  IC2344.2
+049500*                                                              *  IC2344.2
+049600*    THIS PROGRAM FORMS PART OF THE COBOL COMPILER VALIDATION  *  IC2344.2
+049700*    SYSTEM (CCVS) USED TO TEST COBOL COMPILERS FOR            *  IC2344.2
+049800*    CONFORMANCE WITH THE AMERICAN NATIONAL STANDARD           *  IC2344.2
+049900*    (ANSI DOCUMENT REFERENCE: X3.23-1985) AND THE STANDARD OF *  IC2344.2
+050000*    THE INTERNATIONAL ORGANIZATION FOR STANDARDISATION        *  IC2344.2
+050100*    (ISO DOCUMENT REFERENCE: ISO-1989-1985).                  *  IC2344.2
+050200*                                                              *  IC2344.2
+050300*    THIS CCVS INCORPORATES ENHANCEMENTS TO THE CCVS FOR THE   *  IC2344.2
+050400*    1974 STANDARD (ANSI DOCUMENT REFERENCE: X3.23-1974; ISO   *  IC2344.2
+050500*    DOCUMENT REFERENCE: ISO-1989-1978).                       *  IC2344.2
+050600*                                                              *  IC2344.2
+050700*    THESE ENHANCEMENTS WERE SPECIFIED BY A PROJECT TEAM WHICH *  IC2344.2
+050800*    WAS FUNDED BY THE COMMISSION FOR EUROPEAN COMMUNITIES AND *  IC2344.2
+050900*    WHICH WAS RESPONSIBLE FOR TECHNICAL ISSUES TO:            *  IC2344.2
+051000*                                                              *  IC2344.2
+051100*          THE FEDERAL SOFTWARE TESTING CENTER                 *  IC2344.2
+051200*          OFFICE OF SOFTWARE DEVELOPMENT                      *  IC2344.2
+051300*                & INFORMATION TECHNOLOGY                      *  IC2344.2
+051400*          TWO SKYLINE PLACE                                   *  IC2344.2
+051500*          SUITE 1100                                          *  IC2344.2
+051600*          5203 LEESBURG PIKE                                  *  IC2344.2
+051700*          FALLS CHURCH                                        *  IC2344.2
+051800*          VA 22041                                            *  IC2344.2
+051900*          U.S.A.                                              *  IC2344.2
+052000*                                                              *  IC2344.2
+052100*    THE PROJECT TEAM MEMBERS WERE:                            *  IC2344.2
+052200*                                                              *  IC2344.2
+052300*          BIADI (BUREAU INTER ADMINISTRATION                  *  IC2344.2
+052400*                 DE DOCUMENTATION INFORMATIQUE)               *  IC2344.2
+052500*          21 RUE BARA                                         *  IC2344.2
+052600*          F-92132 ISSY                                        *  IC2344.2
+052700*          FRANCE                                              *  IC2344.2
+052800*                                                              *  IC2344.2
+052900*                                                              *  IC2344.2
+053000*          GMD (GESELLSCHAFT FUR MATHEMATIK                    *  IC2344.2
+053100*               UND DATENVERARBEITUNG MBH)                     *  IC2344.2
+053200*          SCHLOSS BIRLINGHOVEN                                *  IC2344.2
+053300*          POSTFACH 12 40                                      *  IC2344.2
+053400*          D-5205 ST. AUGUSTIN 1                               *  IC2344.2
+053500*          GERMANY FR                                          *  IC2344.2
+053600*                                                              *  IC2344.2
+053700*                                                              *  IC2344.2
+053800*          NCC (THE NATIONAL COMPUTING CENTRE LTD)             *  IC2344.2
+053900*          OXFORD ROAD                                         *  IC2344.2
+054000*          MANCHESTER                                          *  IC2344.2
+054100*          M1 7ED                                              *  IC2344.2
+054200*          UNITED KINGDOM                                      *  IC2344.2
+054300*                                                              *  IC2344.2
+054400*                                                              *  IC2344.2
+054500*    THIS TEST SUITE WAS PRODUCED BY THE NATIONAL COMPUTING    *  IC2344.2
+054600*    CENTRE IN ENGLAND AND IS THE OFFICIAL CCVS TEST SUITE     *  IC2344.2
+054700*    USED THROUGHOUT EUROPE AND THE UNITED STATES OF AMERICA.  *  IC2344.2
+054800*                                                              *  IC2344.2
+054900****************************************************************  IC2344.2
+055000*                                                              *  IC2344.2
+055100*    VALIDATION FOR:-                                          *  IC2344.2
+055200*                                                              *  IC2344.2
+055300*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2344.2
+055400*                                                              *  IC2344.2
+055500*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2344.2
+055600*                                                              *  IC2344.2
+055700****************************************************************  IC2344.2
+055800*                                                              *  IC2344.2
+055900*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2344.2
+056000*                                                              *  IC2344.2
+056100*        X-55  - SYSTEM PRINTER NAME.                          *  IC2344.2
+056200*        X-82  - SOURCE COMPUTER NAME.                         *  IC2344.2
+056300*        X-83  - OBJECT COMPUTER NAME.                         *  IC2344.2
+056400*                                                              *  IC2344.2
+056500****************************************************************  IC2344.2
+056600*                                                              *  IC2344.2
+056700*    PROGRAMS IC234A, IC234A-1, IC234A-2 AND IC234A-3 TEST     *  IC2344.2
+056800*    TEST THAT A "USE" PROCEDURE IN A CALLING PROGRAM IS       *  IC2344.2
+056900*    INVOKED BY A QUALIFYING CONDITION OCURRING IN A CONTAINED *  IC2344.2
+057000*    PROGRAM NESTED TO FOUR LEVELS.                            *  IC2344.2
+057100*                                                              *  IC2344.2
+057200*    ALL PROGRAMS WILL BE COMPILED IN ONE INVOCATION OF THE    *  IC2344.2
+057300*    COMPILER AS SHOWN BELOW:                                  *  IC2344.2
+057400*    IDENTIFICATION DIVISION.                                  *  IC2344.2
+057500*    PROGRAM-ID. IC234A.                                       *  IC2344.2
+057600*              .                                               *  IC2344.2
+057700*              .                                               *  IC2344.2
+057800*              .                                               *  IC2344.2
+057900*    IDENTIFICATION DIVISION.                                  *  IC2344.2
+058000*    PROGRAM-ID. IC234A-1.                                     *  IC2344.2
+058100*              .                                               *  IC2344.2
+058200*              .                                               *  IC2344.2
+058300*    IDENTIFICATION DIVISION.                                  *  IC2344.2
+058400*    PROGRAM-ID. IC234A-2.                                     *  IC2344.2
+058500*              .                                               *  IC2344.2
+058600*              .                                               *  IC2344.2
+058700*              .                                               *  IC2344.2
+058800*    IDENTIFICATION DIVISION.                                  *  IC2344.2
+058900*    PROGRAM-ID. IC234A-3.                                     *  IC2344.2
+059000*              .                                               *  IC2344.2
+059100*              .                                               *  IC2344.2
+059200*    END PROGRAM IC234A-3.                                     *  IC2344.2
+059300*    END PROGRAM IC234A-2.                                     *  IC2344.2
+059400*    END PROGRAM IC234A-1.                                     *  IC2344.2
+059500*    END PROGRAM IC234A.                                       *  IC2344.2
+059600****************************************************************  IC2344.2
+059700*ENVIRONMENT DIVISION.                                            IC2344.2
+059800*INPUT-OUTPUT SECTION.                                            IC2344.2
+059900*FILE-CONTROL.                                                    IC2344.2
+060000 DATA DIVISION.                                                   IC2344.2
+060100 FILE SECTION.                                                    IC2344.2
+060200 WORKING-STORAGE SECTION.                                         IC2344.2
+060300 PROCEDURE DIVISION.                                              IC2344.2
+060400 DECLARATIVES.                                                    IC2344.2
+060500 USE-TEST SECTION.                                                IC2344.2
+060600     USE GLOBAL AFTER ERROR PROCEDURE ON OUTPUT.                  IC2344.2
+060700 USE-TEST-1.                                                      IC2344.2
+060800     ADD  4 TO DILFRAP.                                           IC2344.2
+060900 END DECLARATIVES.                                                IC2344.2
+061000 SECT-IC234A-2-001 SECTION.                                       IC2344.2
+061100 USE-INIT-1.                                                      IC2344.2
+061200     CALL   "IC234A3".                                            IC2344.2
+061300     EXIT PROGRAM.                                                IC2344.2
+061400*                                                                 IC2344.2
+073500 END PROGRAM IC234A2.                                             IC2344.2

--- a/z390/IC234A3.CBL
+++ b/z390/IC234A3.CBL
@@ -1,0 +1,126 @@
+061500 IDENTIFICATION DIVISION.                                         IC2344.2
+      *
+      * This is the z390 version of IC234A-3
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC234A3
+      * IC234A has been modified to call IC234A1 instead of IC234A-1.
+      *
+061600 PROGRAM-ID.                                                      IC2344.2
+061700     IC234A3.                                                     IC2344.2
+061800****************************************************************  IC2344.2
+061900*                                                              *  IC2344.2
+062000*    THIS PROGRAM FORMS PART OF THE COBOL COMPILER VALIDATION  *  IC2344.2
+062100*    SYSTEM (CCVS) USED TO TEST COBOL COMPILERS FOR            *  IC2344.2
+062200*    CONFORMANCE WITH THE AMERICAN NATIONAL STANDARD           *  IC2344.2
+062300*    (ANSI DOCUMENT REFERENCE: X3.23-1985) AND THE STANDARD OF *  IC2344.2
+062400*    THE INTERNATIONAL ORGANIZATION FOR STANDARDISATION        *  IC2344.2
+062500*    (ISO DOCUMENT REFERENCE: ISO-1989-1985).                  *  IC2344.2
+062600*                                                              *  IC2344.2
+062700*    THIS CCVS INCORPORATES ENHANCEMENTS TO THE CCVS FOR THE   *  IC2344.2
+062800*    1974 STANDARD (ANSI DOCUMENT REFERENCE: X3.23-1974; ISO   *  IC2344.2
+062900*    DOCUMENT REFERENCE: ISO-1989-1978).                       *  IC2344.2
+063000*                                                              *  IC2344.2
+063100*    THESE ENHANCEMENTS WERE SPECIFIED BY A PROJECT TEAM WHICH *  IC2344.2
+063200*    WAS FUNDED BY THE COMMISSION FOR EUROPEAN COMMUNITIES AND *  IC2344.2
+063300*    WHICH WAS RESPONSIBLE FOR TECHNICAL ISSUES TO:            *  IC2344.2
+063400*                                                              *  IC2344.2
+063500*          THE FEDERAL SOFTWARE TESTING CENTER                 *  IC2344.2
+063600*          OFFICE OF SOFTWARE DEVELOPMENT                      *  IC2344.2
+063700*                & INFORMATION TECHNOLOGY                      *  IC2344.2
+063800*          TWO SKYLINE PLACE                                   *  IC2344.2
+063900*          SUITE 1100                                          *  IC2344.2
+064000*          5203 LEESBURG PIKE                                  *  IC2344.2
+064100*          FALLS CHURCH                                        *  IC2344.2
+064200*          VA 22041                                            *  IC2344.2
+064300*          U.S.A.                                              *  IC2344.2
+064400*                                                              *  IC2344.2
+064500*    THE PROJECT TEAM MEMBERS WERE:                            *  IC2344.2
+064600*                                                              *  IC2344.2
+064700*          BIADI (BUREAU INTER ADMINISTRATION                  *  IC2344.2
+064800*                 DE DOCUMENTATION INFORMATIQUE)               *  IC2344.2
+064900*          21 RUE BARA                                         *  IC2344.2
+065000*          F-92132 ISSY                                        *  IC2344.2
+065100*          FRANCE                                              *  IC2344.2
+065200*                                                              *  IC2344.2
+065300*                                                              *  IC2344.2
+065400*          GMD (GESELLSCHAFT FUR MATHEMATIK                    *  IC2344.2
+065500*               UND DATENVERARBEITUNG MBH)                     *  IC2344.2
+065600*          SCHLOSS BIRLINGHOVEN                                *  IC2344.2
+065700*          POSTFACH 12 40                                      *  IC2344.2
+065800*          D-5205 ST. AUGUSTIN 1                               *  IC2344.2
+065900*          GERMANY FR                                          *  IC2344.2
+066000*                                                              *  IC2344.2
+066100*                                                              *  IC2344.2
+066200*          NCC (THE NATIONAL COMPUTING CENTRE LTD)             *  IC2344.2
+066300*          OXFORD ROAD                                         *  IC2344.2
+066400*          MANCHESTER                                          *  IC2344.2
+066500*          M1 7ED                                              *  IC2344.2
+066600*          UNITED KINGDOM                                      *  IC2344.2
+066700*                                                              *  IC2344.2
+066800*                                                              *  IC2344.2
+066900*    THIS TEST SUITE WAS PRODUCED BY THE NATIONAL COMPUTING    *  IC2344.2
+067000*    CENTRE IN ENGLAND AND IS THE OFFICIAL CCVS TEST SUITE     *  IC2344.2
+067100*    USED THROUGHOUT EUROPE AND THE UNITED STATES OF AMERICA.  *  IC2344.2
+067200*                                                              *  IC2344.2
+067300****************************************************************  IC2344.2
+067400*                                                              *  IC2344.2
+067500*    VALIDATION FOR:-                                          *  IC2344.2
+067600*                                                              *  IC2344.2
+067700*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2344.2
+067800*                                                              *  IC2344.2
+067900*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2344.2
+068000*                                                              *  IC2344.2
+068100****************************************************************  IC2344.2
+068200*                                                              *  IC2344.2
+068300*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2344.2
+068400*                                                              *  IC2344.2
+068500*        X-55  - SYSTEM PRINTER NAME.                          *  IC2344.2
+068600*        X-82  - SOURCE COMPUTER NAME.                         *  IC2344.2
+068700*        X-83  - OBJECT COMPUTER NAME.                         *  IC2344.2
+068800*                                                              *  IC2344.2
+068900****************************************************************  IC2344.2
+069000*                                                              *  IC2344.2
+069100*    PROGRAMS IC234A, IC234A-1, IC234A-2 AND IC234A-3 TEST     *  IC2344.2
+069200*    TEST THAT A "USE" PROCEDURE IN A CALLING PROGRAM IS       *  IC2344.2
+069300*    INVOKED BY A QUALIFYING CONDITION OCURRING IN A CONTAINED *  IC2344.2
+069400*    PROGRAM NESTED TO FOUR LEVELS.                            *  IC2344.2
+069500*                                                              *  IC2344.2
+069600*    ALL PROGRAMS WILL BE COMPILED IN ONE INVOCATION OF THE    *  IC2344.2
+069700*    COMPILER AS SHOWN BELOW:                                  *  IC2344.2
+069800*    IDENTIFICATION DIVISION.                                  *  IC2344.2
+069900*    PROGRAM-ID. IC234A.                                       *  IC2344.2
+070000*              .                                               *  IC2344.2
+070100*              .                                               *  IC2344.2
+070200*              .                                               *  IC2344.2
+070300*    IDENTIFICATION DIVISION.                                  *  IC2344.2
+070400*    PROGRAM-ID. IC234A-1.                                     *  IC2344.2
+070500*              .                                               *  IC2344.2
+070600*              .                                               *  IC2344.2
+070700*    IDENTIFICATION DIVISION.                                  *  IC2344.2
+070800*    PROGRAM-ID. IC234A-2.                                     *  IC2344.2
+070900*              .                                               *  IC2344.2
+071000*              .                                               *  IC2344.2
+071100*              .                                               *  IC2344.2
+071200*    IDENTIFICATION DIVISION.                                  *  IC2344.2
+071300*    PROGRAM-ID. IC234A-3.                                     *  IC2344.2
+071400*              .                                               *  IC2344.2
+071500*              .                                               *  IC2344.2
+071600*    END PROGRAM IC234A-3.                                     *  IC2344.2
+071700*    END PROGRAM IC234A-2.                                     *  IC2344.2
+071800*    END PROGRAM IC234A-1.                                     *  IC2344.2
+071900*    END PROGRAM IC234A.                                       *  IC2344.2
+072000****************************************************************  IC2344.2
+072100*ENVIRONMENT DIVISION.                                            IC2344.2
+072200*INPUT-OUTPUT SECTION.                                            IC2344.2
+072300*FILE-CONTROL.                                                    IC2344.2
+072400 DATA DIVISION.                                                   IC2344.2
+072500 FILE SECTION.                                                    IC2344.2
+072600 WORKING-STORAGE SECTION.                                         IC2344.2
+072700 PROCEDURE DIVISION.                                              IC2344.2
+072800 SECT-IC234A-3-001 SECTION.                                       IC2344.2
+072900 USE-INIT-1.                                                      IC2344.2
+073000     OPEN    INPUT TEST-FILE.                                     IC2344.2
+073100     READ    TEST-FILE.                                           IC2344.2
+073200     EXIT PROGRAM.                                                IC2344.2
+073300*                                                                 IC2344.2
+073400 END PROGRAM IC234A3.                                             IC2344.2

--- a/z390/IC235A.CBL
+++ b/z390/IC235A.CBL
@@ -1,0 +1,547 @@
+000100 IDENTIFICATION DIVISION.                                         IC2354.2
+      *
+      * This is the z390 version of IC235A
+      * z390 cannot handle multiple programs in a single source file
+      * The subprograms have been extracted and saved as IC235A1-2
+      * IC235A has been modified to call IC235A1 instead of IC235A-1.
+      * IC235A has been modified to call IC235A2 instead of IC235A-2.
+      *
+000200 PROGRAM-ID.                                                      IC2354.2
+000300     IC235A.                                                      IC2354.2
+000400****************************************************************  IC2354.2
+000500*                                                              *  IC2354.2
+000600*    VALIDATION FOR:-                                          *  IC2354.2
+000700*                                                              *  IC2354.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2354.2
+000900*                                                              *  IC2354.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2354.2
+001100*                                                              *  IC2354.2
+001200****************************************************************  IC2354.2
+001300*                                                              *  IC2354.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2354.2
+001500*                                                              *  IC2354.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC2354.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC2354.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC2354.2
+001900*                                                              *  IC2354.2
+002000****************************************************************  IC2354.2
+002100*        THIS PROGRAM TESTS THE USE OF MULTIPLE DATA-NAMES        IC2354.2
+002200*    IN THE USING PHRASE OF THE CALL STATEMENT.  TWO 01 GROUP     IC2354.2
+002300*    ITEMS AND AN ELEMENTARY 77 ITEM ARE THE PARAMETERS.  THE     IC2354.2
+002400*    DATA DEFINITIONS FOR THE GROUP ITEM PARAMETERS ARE NOT       IC2354.2
+002500*    THE SAME AS IN THE SUBPROGRAM BUT THE NUMBER OF CHARACTERS   IC2354.2
+002600*    ARE IDENTICAL.                                               IC2354.2
+002700*        THIS PROGRAM ALSO CALLS A SUBPROGRAM WITH MORE           IC2354.2
+002800*    THAN ONE EXIT PROGRAM STATEMENT.                             IC2354.2
+002900*         REFERENCE:  AMERICAN NATIONAL STANDARD                  IC2354.2
+003000*                     PROGRAMMING LANGUAGE COBOL, X3.23-1985.     IC2354.2
+003100 ENVIRONMENT DIVISION.                                            IC2354.2
+003200 CONFIGURATION SECTION.                                           IC2354.2
+003300 SOURCE-COMPUTER.                                                 IC2354.2
+003400     XXXXX082.                                                    IC2354.2
+003500 OBJECT-COMPUTER.                                                 IC2354.2
+003600     XXXXX083.                                                    IC2354.2
+003700 INPUT-OUTPUT SECTION.                                            IC2354.2
+003800 FILE-CONTROL.                                                    IC2354.2
+003900     SELECT PRINT-FILE ASSIGN TO                                  IC2354.2
+004000     XXXXX055.                                                    IC2354.2
+004100 DATA DIVISION.                                                   IC2354.2
+004200 FILE SECTION.                                                    IC2354.2
+004300 FD  PRINT-FILE.                                                  IC2354.2
+004400 01  PRINT-REC PICTURE X(120).                                    IC2354.2
+004500 01  DUMMY-RECORD PICTURE X(120).                                 IC2354.2
+004600 WORKING-STORAGE SECTION.                                         IC2354.2
+004700 77  MAIN-DN1 PICTURE 999.                                        IC2354.2
+004800 77  MAIN-DN2 PICTURE S99 COMPUTATIONAL.                          IC2354.2
+004900 77  ELEM-77   PICTURE V9(4) COMPUTATIONAL.                       IC2354.2
+005000 01  GROUP-01.                                                    IC2354.2
+005100     02 ALPHA-NUM-FIELD  PIC X(8).                                IC2354.2
+005200     02 GROUP-LEV2.                                               IC2354.2
+005300        03 NUMER-FIELD PIC 99.                                    IC2354.2
+005400        03 ALPHA-FIELD PIC A(3).                                  IC2354.2
+005500 01  GROUP-02.                                                    IC2354.2
+005600     02  NUM-ITEM PIC S99.                                        IC2354.2
+005700     02  ALPHA-EDITED PICTURE X(6).                               IC2354.2
+005800 01  GROUP-03.                                                    IC2354.2
+005900     02  ALPHA-NUM-FIELD-3 PIC X(5).                              IC2354.2
+006000     02  GROUP-LEV2-3.                                            IC2354.2
+006100       03  NUMER-FIELD-3   PIC 99.                                IC2354.2
+006200       03  ALPHA-FIELD-3   PIC A(3).                              IC2354.2
+006300 01  GROUP-04.                                                    IC2354.2
+006400   03  FILLER              PIC XX.                                IC2354.2
+006500   03  ELEM-NON-01         PIC XX.                                IC2354.2
+006600 01  FILLER.                                                      IC2354.2
+006700   03  SUBSCRIPTED-DATA    OCCURS 10                              IC2354.2
+006800                           PIC XX.                                IC2354.2
+006900 01  TEST-RESULTS.                                                IC2354.2
+007000     02 FILLER                   PIC X      VALUE SPACE.          IC2354.2
+007100     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC2354.2
+007200     02 FILLER                   PIC X      VALUE SPACE.          IC2354.2
+007300     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC2354.2
+007400     02 FILLER                   PIC X      VALUE SPACE.          IC2354.2
+007500     02  PAR-NAME.                                                IC2354.2
+007600       03 FILLER                 PIC X(19)  VALUE SPACE.          IC2354.2
+007700       03  PARDOT-X              PIC X      VALUE SPACE.          IC2354.2
+007800       03 DOTVALUE               PIC 99     VALUE ZERO.           IC2354.2
+007900     02 FILLER                   PIC X(8)   VALUE SPACE.          IC2354.2
+008000     02 RE-MARK                  PIC X(61).                       IC2354.2
+008100 01  TEST-COMPUTED.                                               IC2354.2
+008200     02 FILLER                   PIC X(30)  VALUE SPACE.          IC2354.2
+008300     02 FILLER                   PIC X(17)  VALUE                 IC2354.2
+008400            "       COMPUTED=".                                   IC2354.2
+008500     02 COMPUTED-X.                                               IC2354.2
+008600     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC2354.2
+008700     03 COMPUTED-N               REDEFINES COMPUTED-A             IC2354.2
+008800                                 PIC -9(9).9(9).                  IC2354.2
+008900     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC2354.2
+009000     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC2354.2
+009100     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC2354.2
+009200     03       CM-18V0 REDEFINES COMPUTED-A.                       IC2354.2
+009300         04 COMPUTED-18V0                    PIC -9(18).          IC2354.2
+009400         04 FILLER                           PIC X.               IC2354.2
+009500     03 FILLER PIC X(50) VALUE SPACE.                             IC2354.2
+009600 01  TEST-CORRECT.                                                IC2354.2
+009700     02 FILLER PIC X(30) VALUE SPACE.                             IC2354.2
+009800     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC2354.2
+009900     02 CORRECT-X.                                                IC2354.2
+010000     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC2354.2
+010100     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC2354.2
+010200     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC2354.2
+010300     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC2354.2
+010400     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC2354.2
+010500     03      CR-18V0 REDEFINES CORRECT-A.                         IC2354.2
+010600         04 CORRECT-18V0                     PIC -9(18).          IC2354.2
+010700         04 FILLER                           PIC X.               IC2354.2
+010800     03 FILLER PIC X(2) VALUE SPACE.                              IC2354.2
+010900     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC2354.2
+011000 01  CCVS-C-1.                                                    IC2354.2
+011100     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC2354.2
+011200-    "SS  PARAGRAPH-NAME                                          IC2354.2
+011300-    "       REMARKS".                                            IC2354.2
+011400     02 FILLER                     PIC X(20)    VALUE SPACE.      IC2354.2
+011500 01  CCVS-C-2.                                                    IC2354.2
+011600     02 FILLER                     PIC X        VALUE SPACE.      IC2354.2
+011700     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC2354.2
+011800     02 FILLER                     PIC X(15)    VALUE SPACE.      IC2354.2
+011900     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC2354.2
+012000     02 FILLER                     PIC X(94)    VALUE SPACE.      IC2354.2
+012100 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC2354.2
+012200 01  REC-CT                        PIC 99       VALUE ZERO.       IC2354.2
+012300 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC2354.2
+012400 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC2354.2
+012500 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC2354.2
+012600 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC2354.2
+012700 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC2354.2
+012800 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC2354.2
+012900 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC2354.2
+013000 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC2354.2
+013100 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC2354.2
+013200 01  CCVS-H-1.                                                    IC2354.2
+013300     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2354.2
+013400     02  FILLER                    PIC X(42)    VALUE             IC2354.2
+013500     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC2354.2
+013600     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2354.2
+013700 01  CCVS-H-2A.                                                   IC2354.2
+013800   02  FILLER                        PIC X(40)  VALUE SPACE.      IC2354.2
+013900   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC2354.2
+014000   02  FILLER                        PIC XXXX   VALUE             IC2354.2
+014100     "4.2 ".                                                      IC2354.2
+014200   02  FILLER                        PIC X(28)  VALUE             IC2354.2
+014300            " COPY - NOT FOR DISTRIBUTION".                       IC2354.2
+014400   02  FILLER                        PIC X(41)  VALUE SPACE.      IC2354.2
+014500                                                                  IC2354.2
+014600 01  CCVS-H-2B.                                                   IC2354.2
+014700   02  FILLER                        PIC X(15)  VALUE             IC2354.2
+014800            "TEST RESULT OF ".                                    IC2354.2
+014900   02  TEST-ID                       PIC X(9).                    IC2354.2
+015000   02  FILLER                        PIC X(4)   VALUE             IC2354.2
+015100            " IN ".                                               IC2354.2
+015200   02  FILLER                        PIC X(12)  VALUE             IC2354.2
+015300     " HIGH       ".                                              IC2354.2
+015400   02  FILLER                        PIC X(22)  VALUE             IC2354.2
+015500            " LEVEL VALIDATION FOR ".                             IC2354.2
+015600   02  FILLER                        PIC X(58)  VALUE             IC2354.2
+015700     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2354.2
+015800 01  CCVS-H-3.                                                    IC2354.2
+015900     02  FILLER                      PIC X(34)  VALUE             IC2354.2
+016000            " FOR OFFICIAL USE ONLY    ".                         IC2354.2
+016100     02  FILLER                      PIC X(58)  VALUE             IC2354.2
+016200     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2354.2
+016300     02  FILLER                      PIC X(28)  VALUE             IC2354.2
+016400            "  COPYRIGHT   1985 ".                                IC2354.2
+016500 01  CCVS-E-1.                                                    IC2354.2
+016600     02 FILLER                       PIC X(52)  VALUE SPACE.      IC2354.2
+016700     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC2354.2
+016800     02 ID-AGAIN                     PIC X(9).                    IC2354.2
+016900     02 FILLER                       PIC X(45)  VALUE SPACES.     IC2354.2
+017000 01  CCVS-E-2.                                                    IC2354.2
+017100     02  FILLER                      PIC X(31)  VALUE SPACE.      IC2354.2
+017200     02  FILLER                      PIC X(21)  VALUE SPACE.      IC2354.2
+017300     02 CCVS-E-2-2.                                               IC2354.2
+017400         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC2354.2
+017500         03 FILLER                   PIC X      VALUE SPACE.      IC2354.2
+017600         03 ENDER-DESC               PIC X(44)  VALUE             IC2354.2
+017700            "ERRORS ENCOUNTERED".                                 IC2354.2
+017800 01  CCVS-E-3.                                                    IC2354.2
+017900     02  FILLER                      PIC X(22)  VALUE             IC2354.2
+018000            " FOR OFFICIAL USE ONLY".                             IC2354.2
+018100     02  FILLER                      PIC X(12)  VALUE SPACE.      IC2354.2
+018200     02  FILLER                      PIC X(58)  VALUE             IC2354.2
+018300     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2354.2
+018400     02  FILLER                      PIC X(13)  VALUE SPACE.      IC2354.2
+018500     02 FILLER                       PIC X(15)  VALUE             IC2354.2
+018600             " COPYRIGHT 1985".                                   IC2354.2
+018700 01  CCVS-E-4.                                                    IC2354.2
+018800     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC2354.2
+018900     02 FILLER                       PIC X(4)   VALUE " OF ".     IC2354.2
+019000     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC2354.2
+019100     02 FILLER                       PIC X(40)  VALUE             IC2354.2
+019200      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC2354.2
+019300 01  XXINFO.                                                      IC2354.2
+019400     02 FILLER                       PIC X(19)  VALUE             IC2354.2
+019500            "*** INFORMATION ***".                                IC2354.2
+019600     02 INFO-TEXT.                                                IC2354.2
+019700       04 FILLER                     PIC X(8)   VALUE SPACE.      IC2354.2
+019800       04 XXCOMPUTED                 PIC X(20).                   IC2354.2
+019900       04 FILLER                     PIC X(5)   VALUE SPACE.      IC2354.2
+020000       04 XXCORRECT                  PIC X(20).                   IC2354.2
+020100     02 INF-ANSI-REFERENCE           PIC X(48).                   IC2354.2
+020200 01  HYPHEN-LINE.                                                 IC2354.2
+020300     02 FILLER  PIC IS X VALUE IS SPACE.                          IC2354.2
+020400     02 FILLER  PIC IS X(65)    VALUE IS "************************IC2354.2
+020500-    "*****************************************".                 IC2354.2
+020600     02 FILLER  PIC IS X(54)    VALUE IS "************************IC2354.2
+020700-    "******************************".                            IC2354.2
+020800 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC2354.2
+020900     "IC235A".                                                    IC2354.2
+021000 PROCEDURE DIVISION.                                              IC2354.2
+021100 CCVS1 SECTION.                                                   IC2354.2
+021200 OPEN-FILES.                                                      IC2354.2
+021300     OPEN     OUTPUT PRINT-FILE.                                  IC2354.2
+021400     MOVE CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.   IC2354.2
+021500     MOVE    SPACE TO TEST-RESULTS.                               IC2354.2
+021600     PERFORM  HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.             IC2354.2
+021700     GO TO CCVS1-EXIT.                                            IC2354.2
+021800 CLOSE-FILES.                                                     IC2354.2
+021900     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC2354.2
+022000 TERMINATE-CCVS.                                                  IC2354.2
+022100S    EXIT PROGRAM.                                                IC2354.2
+022200STERMINATE-CALL.                                                  IC2354.2
+022300     STOP     RUN.                                                IC2354.2
+022400 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         IC2354.2
+022500 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           IC2354.2
+022600 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          IC2354.2
+022700 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      IC2354.2
+022800     MOVE "****TEST DELETED****" TO RE-MARK.                      IC2354.2
+022900 PRINT-DETAIL.                                                    IC2354.2
+023000     IF REC-CT NOT EQUAL TO ZERO                                  IC2354.2
+023100             MOVE "." TO PARDOT-X                                 IC2354.2
+023200             MOVE REC-CT TO DOTVALUE.                             IC2354.2
+023300     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      IC2354.2
+023400     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               IC2354.2
+023500        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 IC2354.2
+023600          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 IC2354.2
+023700     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC2354.2
+023800     MOVE SPACE TO CORRECT-X.                                     IC2354.2
+023900     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC2354.2
+024000     MOVE     SPACE TO RE-MARK.                                   IC2354.2
+024100 HEAD-ROUTINE.                                                    IC2354.2
+024200     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2354.2
+024300     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2354.2
+024400     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2354.2
+024500     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2354.2
+024600 COLUMN-NAMES-ROUTINE.                                            IC2354.2
+024700     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2354.2
+024800     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2354.2
+024900     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC2354.2
+025000 END-ROUTINE.                                                     IC2354.2
+025100     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.IC2354.2
+025200 END-RTN-EXIT.                                                    IC2354.2
+025300     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2354.2
+025400 END-ROUTINE-1.                                                   IC2354.2
+025500      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      IC2354.2
+025600      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               IC2354.2
+025700      ADD PASS-COUNTER TO ERROR-HOLD.                             IC2354.2
+025800*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC2354.2
+025900      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC2354.2
+026000      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC2354.2
+026100      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC2354.2
+026200      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC2354.2
+026300  END-ROUTINE-12.                                                 IC2354.2
+026400      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC2354.2
+026500     IF       ERROR-COUNTER IS EQUAL TO ZERO                      IC2354.2
+026600         MOVE "NO " TO ERROR-TOTAL                                IC2354.2
+026700         ELSE                                                     IC2354.2
+026800         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC2354.2
+026900     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC2354.2
+027000     PERFORM WRITE-LINE.                                          IC2354.2
+027100 END-ROUTINE-13.                                                  IC2354.2
+027200     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC2354.2
+027300         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC2354.2
+027400         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC2354.2
+027500     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC2354.2
+027600     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2354.2
+027700      IF   INSPECT-COUNTER EQUAL TO ZERO                          IC2354.2
+027800          MOVE "NO " TO ERROR-TOTAL                               IC2354.2
+027900      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   IC2354.2
+028000      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            IC2354.2
+028100      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          IC2354.2
+028200     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2354.2
+028300 WRITE-LINE.                                                      IC2354.2
+028400     ADD 1 TO RECORD-COUNT.                                       IC2354.2
+028500Y    IF RECORD-COUNT GREATER 50                                   IC2354.2
+028600Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC2354.2
+028700Y        MOVE SPACE TO DUMMY-RECORD                               IC2354.2
+028800Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC2354.2
+028900Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC2354.2
+029000Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC2354.2
+029100Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC2354.2
+029200Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC2354.2
+029300Y        MOVE ZERO TO RECORD-COUNT.                               IC2354.2
+029400     PERFORM WRT-LN.                                              IC2354.2
+029500 WRT-LN.                                                          IC2354.2
+029600     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC2354.2
+029700     MOVE SPACE TO DUMMY-RECORD.                                  IC2354.2
+029800 BLANK-LINE-PRINT.                                                IC2354.2
+029900     PERFORM WRT-LN.                                              IC2354.2
+030000 FAIL-ROUTINE.                                                    IC2354.2
+030100     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC2354.2
+030200     IF     CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.IC2354.2
+030300     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2354.2
+030400     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC2354.2
+030500     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2354.2
+030600     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2354.2
+030700     GO TO  FAIL-ROUTINE-EX.                                      IC2354.2
+030800 FAIL-ROUTINE-WRITE.                                              IC2354.2
+030900     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC2354.2
+031000     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC2354.2
+031100     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC2354.2
+031200     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC2354.2
+031300 FAIL-ROUTINE-EX. EXIT.                                           IC2354.2
+031400 BAIL-OUT.                                                        IC2354.2
+031500     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC2354.2
+031600     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC2354.2
+031700 BAIL-OUT-WRITE.                                                  IC2354.2
+031800     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC2354.2
+031900     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2354.2
+032000     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2354.2
+032100     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2354.2
+032200 BAIL-OUT-EX. EXIT.                                               IC2354.2
+032300 CCVS1-EXIT.                                                      IC2354.2
+032400     EXIT.                                                        IC2354.2
+032500 SECT-IC235-0001 SECTION.                                         IC2354.2
+032600*        THE TESTS IN THIS SECTION CALL A SUBPROGRAM WHICH        IC2354.2
+032700*    HAS FOUR EXIT PROGRAM STATEMENTS.  A DIFFERENT EXIT IS       IC2354.2
+032800*    TAKEN FOR EACH CALL TO THE SUBPROGRAM.                       IC2354.2
+032900 EXIT-INIT.                                                       IC2354.2
+033000     MOVE "MULTIPLE EXIT PROGRM" TO FEATURE.                      IC2354.2
+033100 EXIT-INIT-001.                                                   IC2354.2
+033200     MOVE 0 TO MAIN-DN2.                                          IC2354.2
+033300     MOVE 1 TO MAIN-DN1.                                          IC2354.2
+033400 EXIT-TEST-001.                                                   IC2354.2
+033500     CALL "IC235A2" USING MAIN-DN1 MAIN-DN2.                      IC2354.2
+033600     IF MAIN-DN2 EQUAL TO 1                                       IC2354.2
+033700         PERFORM PASS                                             IC2354.2
+033800         GO TO EXIT-WRITE-001.                                    IC2354.2
+033900 EXIT-FAIL-001.                                                   IC2354.2
+034000     MOVE MAIN-DN1 TO CORRECT-18V0.                               IC2354.2
+034100     MOVE MAIN-DN2 TO COMPUTED-18V0.                              IC2354.2
+034200     MOVE "FIRST EXIT FROM SUBPROGRAM" TO RE-MARK.                IC2354.2
+034300     PERFORM FAIL.                                                IC2354.2
+034400 EXIT-WRITE-001.                                                  IC2354.2
+034500     MOVE "EXIT-TEST-01" TO PAR-NAME.                             IC2354.2
+034600     PERFORM PRINT-DETAIL.                                        IC2354.2
+034700 EXIT-INIT-002.                                                   IC2354.2
+034800     MOVE 0 TO MAIN-DN2.                                          IC2354.2
+034900     MOVE 2 TO MAIN-DN1.                                          IC2354.2
+035000 EXIT-TEST-002.                                                   IC2354.2
+035100     CALL "IC235A2" USING MAIN-DN1 MAIN-DN2.                      IC2354.2
+035200     IF MAIN-DN2 EQUAL TO 2                                       IC2354.2
+035300          PERFORM PASS                                            IC2354.2
+035400          GO TO EXIT-WRITE-002.                                   IC2354.2
+035500 EXIT-FAIL-002.                                                   IC2354.2
+035600     MOVE MAIN-DN1 TO CORRECT-18V0.                               IC2354.2
+035700     MOVE MAIN-DN2 TO COMPUTED-18V0.                              IC2354.2
+035800     MOVE "SECOND EXIT FROM SUBPROGRAM" TO RE-MARK.               IC2354.2
+035900     PERFORM FAIL.                                                IC2354.2
+036000 EXIT-WRITE-002.                                                  IC2354.2
+036100     MOVE "EXIT-TEST-02" TO PAR-NAME.                             IC2354.2
+036200     PERFORM PRINT-DETAIL.                                        IC2354.2
+036300 EXIT-INIT-003.                                                   IC2354.2
+036400     MOVE 0 TO MAIN-DN2.                                          IC2354.2
+036500     MOVE 3 TO MAIN-DN1.                                          IC2354.2
+036600 EXIT-TEST-003.                                                   IC2354.2
+036700     CALL "IC235A2" USING MAIN-DN1 MAIN-DN2.                      IC2354.2
+036800     IF MAIN-DN2 NOT EQUAL TO 3                                   IC2354.2
+036900         GO TO EXIT-FAIL-003.                                     IC2354.2
+037000     PERFORM PASS.                                                IC2354.2
+037100     GO TO EXIT-WRITE-003.                                        IC2354.2
+037200 EXIT-FAIL-003.                                                   IC2354.2
+037300     MOVE MAIN-DN1 TO CORRECT-18V0.                               IC2354.2
+037400     MOVE MAIN-DN2 TO COMPUTED-18V0.                              IC2354.2
+037500     MOVE "THIRD EXIT FROM SUBPROGRAM" TO RE-MARK.                IC2354.2
+037600     PERFORM FAIL.                                                IC2354.2
+037700 EXIT-WRITE-003.                                                  IC2354.2
+037800     MOVE "EXIT-TEST-03" TO PAR-NAME.                             IC2354.2
+037900     PERFORM PRINT-DETAIL.                                        IC2354.2
+038000 EXIT-INIT-004.                                                   IC2354.2
+038100     MOVE 0 TO MAIN-DN2.                                          IC2354.2
+038200     MOVE 4 TO MAIN-DN1.                                          IC2354.2
+038300 EXIT-TEST-004.                                                   IC2354.2
+038400     CALL "IC235A2" USING MAIN-DN1 MAIN-DN2.                      IC2354.2
+038500     IF MAIN-DN2 NOT EQUAL TO 4                                   IC2354.2
+038600         GO TO EXIT-FAIL-004.                                     IC2354.2
+038700     PERFORM PASS.                                                IC2354.2
+038800     GO TO EXIT-WRITE-004.                                        IC2354.2
+038900 EXIT-FAIL-004.                                                   IC2354.2
+039000     MOVE MAIN-DN1 TO CORRECT-18V0.                               IC2354.2
+039100     MOVE MAIN-DN2 TO COMPUTED-18V0.                              IC2354.2
+039200     MOVE "FOURTH EXIT FROM SUBPROGRAM" TO RE-MARK.               IC2354.2
+039300     PERFORM FAIL.                                                IC2354.2
+039400 EXIT-WRITE-004.                                                  IC2354.2
+039500     MOVE "EXIT-TEST-04" TO PAR-NAME.                             IC2354.2
+039600     PERFORM PRINT-DETAIL.                                        IC2354.2
+039700     GO TO SECT-IC235-0002.                                       IC2354.2
+039800 EXIT-DELETES.                                                    IC2354.2
+039900*        IF THE SUBPROGRAM WITH MULTIPLE EXIT PROGRAM             IC2354.2
+040000*    STATEMENTS CANNOT BE INCLUDED IN THE RUN UNIT                IC2354.2
+040100*    DELETE PARAGRAPH EXIT-INIT-001 THRU EXIT-WRITE-004.          IC2354.2
+040200     PERFORM DE-LETE.                                             IC2354.2
+040300     MOVE "EXIT-TEST-01" TO PAR-NAME.                             IC2354.2
+040400     PERFORM PRINT-DETAIL.                                        IC2354.2
+040500     PERFORM DE-LETE.                                             IC2354.2
+040600     MOVE "EXIT-TEST-02" TO PAR-NAME.                             IC2354.2
+040700     PERFORM PRINT-DETAIL.                                        IC2354.2
+040800     PERFORM DE-LETE.                                             IC2354.2
+040900     MOVE "EXIT-TEST-03" TO PAR-NAME.                             IC2354.2
+041000     PERFORM PRINT-DETAIL.                                        IC2354.2
+041100     PERFORM DE-LETE.                                             IC2354.2
+041200     MOVE "EXIT-TEST-04" TO PAR-NAME.                             IC2354.2
+041300     PERFORM PRINT-DETAIL.                                        IC2354.2
+041400 SECT-IC235-0002 SECTION.                                         IC2354.2
+041500*        THIS SECTION CALLS A SUBPROGRAM WITH TWO GROUP ITEMS     IC2354.2
+041600*    AND ONE ELEMENTARY ITEM IN THE USING PHRASE. THE ITEM        IC2354.2
+041700*    DESCRIPTIONS ARE DIFFERENT IN THE SUBPROGRAM FROM THE MAIN   IC2354.2
+041800*    PROGRAM, BUT THE NUMBER OF CHARACTERS IS IDENTICAL.          IC2354.2
+041900 CALL-INIT-06.                                                    IC2354.2
+042000     MOVE "CALL-TEST-06" TO PAR-NAME.                             IC2354.2
+042100     MOVE 0 TO NUMER-FIELD  ELEM-77 NUM-ITEM.                     IC2354.2
+042200     MOVE SPACE TO ALPHA-NUM-FIELD ALPHA-FIELD ALPHA-EDITED.      IC2354.2
+042300     MOVE  11    TO ELEM-NON-01.                                  IC2354.2
+042400     MOVE  99    TO SUBSCRIPTED-DATA (4).                         IC2354.2
+042500     MOVE "CALL USING DN SERIES" TO FEATURE.                      IC2354.2
+042600 CALL-TEST-06.                                                    IC2354.2
+042700     CALL "IC235A1"  USING GROUP-01 ELEM-77 GROUP-02              IC2354.2
+042800                           ELEM-NON-01 SUBSCRIPTED-DATA (4).      IC2354.2
+042900     GO TO CALL-TEST-06-01.                                       IC2354.2
+043000 CALL-DELETE-06.                                                  IC2354.2
+043100     PERFORM DE-LETE.                                             IC2354.2
+043200     PERFORM PRINT-DETAIL.                                        IC2354.2
+043300     GO TO CCVS-EXIT.                                             IC2354.2
+043400*       IF IC235A-1 CANNOT BE INCLUDED IN THE RUN UNIT            IC2354.2
+043500*    DELETE THE PARAGRAPH CALL-TEST-06.                           IC2354.2
+043600 CALL-TEST-06-01.                                                 IC2354.2
+043700     IF ALPHA-NUM-FIELD NOT EQUAL TO "IC235A-1"                   IC2354.2
+043800         GO TO CALL-FAIL-06-01.                                   IC2354.2
+043900     PERFORM PASS.                                                IC2354.2
+044000     GO TO CALL-WRITE-06-01.                                      IC2354.2
+044100 CALL-FAIL-06-01.                                                 IC2354.2
+044200     MOVE ALPHA-NUM-FIELD TO COMPUTED-A.                          IC2354.2
+044300     MOVE "IC235A-1" TO CORRECT-A.                                IC2354.2
+044400     PERFORM FAIL.                                                IC2354.2
+044500     MOVE "ALPHANUMERIC PARAMETER" TO RE-MARK.                    IC2354.2
+044600 CALL-WRITE-06-01.                                                IC2354.2
+044700     ADD 1 TO REC-CT.                                             IC2354.2
+044800     PERFORM PRINT-DETAIL.                                        IC2354.2
+044900 CALL-TEST-06-02.                                                 IC2354.2
+045000     IF NUMER-FIELD EQUAL TO 25                                   IC2354.2
+045100         PERFORM PASS                                             IC2354.2
+045200         GO TO CALL-WRITE-06-02.                                  IC2354.2
+045300 CALL-FAIL-06-02.                                                 IC2354.2
+045400     PERFORM FAIL.                                                IC2354.2
+045500     MOVE NUMER-FIELD TO COMPUTED-18V0.                           IC2354.2
+045600     MOVE 25 TO CORRECT-18V0.                                     IC2354.2
+045700     MOVE "NUMERIC DISPLAY PARAMETER" TO RE-MARK.                 IC2354.2
+045800 CALL-WRITE-06-02.                                                IC2354.2
+045900     ADD 1 TO REC-CT.                                             IC2354.2
+046000     PERFORM PRINT-DETAIL.                                        IC2354.2
+046100 CALL-TEST-06-03.                                                 IC2354.2
+046200     IF ALPHA-FIELD EQUAL TO "YES"                                IC2354.2
+046300         PERFORM PASS                                             IC2354.2
+046400         GO TO CALL-WRITE-06-03.                                  IC2354.2
+046500 CALL-FAIL-06-03.                                                 IC2354.2
+046600     PERFORM FAIL.                                                IC2354.2
+046700     MOVE ALPHA-FIELD TO COMPUTED-A.                              IC2354.2
+046800     MOVE "YES" TO CORRECT-A.                                     IC2354.2
+046900     MOVE "ALPHABETIC PARAMETER" TO RE-MARK.                      IC2354.2
+047000 CALL-WRITE-06-03.                                                IC2354.2
+047100     ADD 1 TO REC-CT.                                             IC2354.2
+047200     PERFORM PRINT-DETAIL.                                        IC2354.2
+047300 CALL-TEST-06-04.                                                 IC2354.2
+047400     IF ELEM-77 EQUAL TO 0.7654                                   IC2354.2
+047500         PERFORM PASS                                             IC2354.2
+047600         GO TO CALL-WRITE-06-04.                                  IC2354.2
+047700 CALL-FAIL-06-04.                                                 IC2354.2
+047800     PERFORM FAIL.                                                IC2354.2
+047900     MOVE ELEM-77 TO COMPUTED-4V14.                               IC2354.2
+048000     MOVE 0.7654 TO CORRECT-4V14.                                 IC2354.2
+048100     MOVE "COMPUTATIONAL PARAMETER" TO RE-MARK.                   IC2354.2
+048200 CALL-WRITE-06-04.                                                IC2354.2
+048300     ADD 1 TO REC-CT.                                             IC2354.2
+048400     PERFORM PRINT-DETAIL.                                        IC2354.2
+048500 CALL-TEST-06-05.                                                 IC2354.2
+048600     IF NUM-ITEM EQUAL TO 25                                      IC2354.2
+048700         PERFORM PASS                                             IC2354.2
+048800         GO TO CALL-WRITE-06-05.                                  IC2354.2
+048900 CALL-FAIL-06-05.                                                 IC2354.2
+049000     PERFORM FAIL.                                                IC2354.2
+049100     MOVE NUM-ITEM TO COMPUTED-18V0.                              IC2354.2
+049200     MOVE 25 TO CORRECT-18V0.                                     IC2354.2
+049300     MOVE "SIGNED NUMERIC PARAMETER" TO RE-MARK.                  IC2354.2
+049400 CALL-WRITE-06-05.                                                IC2354.2
+049500     ADD 1 TO REC-CT.                                             IC2354.2
+049600     PERFORM PRINT-DETAIL.                                        IC2354.2
+049700 CALL-TEST-06-06.                                                 IC2354.2
+049800     IF ALPHA-EDITED EQUAL TO "AB C0D"                            IC2354.2
+049900         PERFORM PASS                                             IC2354.2
+050000         GO TO CALL-WRITE-06-06.                                  IC2354.2
+050100 CALL-FAIL-06-06.                                                 IC2354.2
+050200     PERFORM FAIL.                                                IC2354.2
+050300     MOVE ALPHA-EDITED TO COMPUTED-A.                             IC2354.2
+050400     MOVE "AB C0D" TO CORRECT-A.                                  IC2354.2
+050500     MOVE "ALPHANUMERIC EDITED" TO RE-MARK.                       IC2354.2
+050600 CALL-WRITE-06-06.                                                IC2354.2
+050700     ADD 1 TO REC-CT.                                             IC2354.2
+050800     PERFORM PRINT-DETAIL.                                        IC2354.2
+050900 CALL-TEST-06-07.                                                 IC2354.2
+051000     IF      ELEM-NON-01 = "ZZ"                                   IC2354.2
+051100             PERFORM PASS                                         IC2354.2
+051200             GO TO CALL-WRITE-06-07.                              IC2354.2
+051300 CALL-FAIL-06-07.                                                 IC2354.2
+051400     PERFORM FAIL.                                                IC2354.2
+051500     MOVE    ELEM-NON-01 TO COMPUTED-A.                           IC2354.2
+051600     MOVE   "ZZ"        TO CORRECT-A.                             IC2354.2
+051700     MOVE   "ELEMENTARY NON LEVEL-01 DATA ITEM" TO RE-MARK.       IC2354.2
+051800 CALL-WRITE-06-07.                                                IC2354.2
+051900     MOVE   "X-27 5.2.3 SR3" TO ANSI-REFERENCE.                   IC2354.2
+052000     ADD 1 TO REC-CT.                                             IC2354.2
+052100     PERFORM PRINT-DETAIL.                                        IC2354.2
+052200 CALL-TEST-06-08.                                                 IC2354.2
+052300     IF      SUBSCRIPTED-DATA (4) = "1A"                          IC2354.2
+052400             PERFORM PASS                                         IC2354.2
+052500             GO TO CALL-WRITE-06-08.                              IC2354.2
+052600 CALL-FAIL-06-08.                                                 IC2354.2
+052700     PERFORM FAIL.                                                IC2354.2
+052800     MOVE    SUBSCRIPTED-DATA (4) TO COMPUTED-A.                  IC2354.2
+052900     MOVE   "1A"        TO CORRECT-A.                             IC2354.2
+053000     MOVE   "SUBSCRIPTED LINKAGE DATA ITEM" TO RE-MARK.           IC2354.2
+053100 CALL-WRITE-06-08.                                                IC2354.2
+053200     MOVE   "XVII-46 (59)" TO ANSI-REFERENCE.                     IC2354.2
+053300     ADD 1 TO REC-CT.                                             IC2354.2
+053400     PERFORM PRINT-DETAIL.                                        IC2354.2
+053500*                                                                 IC2354.2
+053600     GO TO CCVS-EXIT.                                             IC2354.2
+053700 CCVS-EXIT SECTION.                                               IC2354.2
+053800 CCVS-999999.                                                     IC2354.2
+053900     GO TO CLOSE-FILES.                                           IC2354.2
+066800 END PROGRAM IC235A.                                              IC2354.2

--- a/z390/IC235A1.CBL
+++ b/z390/IC235A1.CBL
@@ -1,0 +1,79 @@
+054000 IDENTIFICATION DIVISION.                                         IC2354.2
+      *
+      * This is the z390 version of IC235A-1
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC235A1
+      * IC235A has been modified to call IC235A1 instead of IC235A-1.
+      * IC235A has been modified to call IC235A2 instead of IC235A-2.
+      *
+054100 PROGRAM-ID.                                                      IC2354.2
+054200     IC235A1.                                                     IC2354.2
+054300****************************************************************  IC2354.2
+054400*                                                              *  IC2354.2
+054500*    VALIDATION FOR:-                                          *  IC2354.2
+054600*                                                              *  IC2354.2
+054700*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2354.2
+054800*                                                              *  IC2354.2
+054900*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2354.2
+055000*                                                              *  IC2354.2
+055100****************************************************************  IC2354.2
+055200*                                                              *  IC2354.2
+055300*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2354.2
+055400*                                                              *  IC2354.2
+055500*        X-55  - SYSTEM PRINTER NAME.                          *  IC2354.2
+055600*        X-82  - SOURCE COMPUTER NAME.                         *  IC2354.2
+055700*        X-83  - OBJECT COMPUTER NAME.                         *  IC2354.2
+055800*                                                              *  IC2354.2
+055900****************************************************************  IC2354.2
+056000*        THE SUBPROGRAM IC235A-1 HAS THREE OPERANDS IN THE        IC2354.2
+056100*    USING PHRASE OF THE PROCEDURE DIVISION HEADER.  TWO          IC2354.2
+056200*    OPERANDS ARE 01 GROUP ITEMS AND THE THIRD OPERAND IS         IC2354.2
+056300*    AN ELEMENTARY 77 ITEM.  THE DATA DESCRIPTIONS OF THESE       IC2354.2
+056400*    OPERANDS IN THE LINKAGE SECTION ARE NOT THE SAME AS THE      IC2354.2
+056500*    DATA DESCRIPTIONS IN THE WORKING-STORAGE SECTION OF THE      IC2354.2
+056600*    CALLING PROGRAM, BUT AN EQUAL NUMBER OF CHARACTER            IC2354.2
+056700*    POSITIONS ARE DEFINED.  THE CALLING PROGRAM IS IC235.        IC2354.2
+056800 ENVIRONMENT DIVISION.                                            IC2354.2
+056900 INPUT-OUTPUT SECTION.                                            IC2354.2
+057000 FILE-CONTROL.                                                    IC2354.2
+057100     SELECT PRINT-FILE ASSIGN TO                                  IC2354.2
+057200     XXXXX055.                                                    IC2354.2
+057300 DATA DIVISION.                                                   IC2354.2
+057400 FILE SECTION.                                                    IC2354.2
+057500 FD  PRINT-FILE.                                                  IC2354.2
+057600 01  PRINT-REC PICTURE X(120).                                    IC2354.2
+057700 01  DUMMY-RECORD PICTURE X(120).                                 IC2354.2
+057800 WORKING-STORAGE SECTION.                                         IC2354.2
+057900 01  CONSTANT-VALUES.                                             IC2354.2
+058000     02  AN-CONSTANT PIC X(8) VALUE "IC235A-1".                   IC2354.2
+058100     02  NUM-CONSTANT PIC 99V9999 VALUE 0.7654.                   IC2354.2
+058200 LINKAGE SECTION.                                                 IC2354.2
+058300 01  GRP-01.                                                      IC2354.2
+058400     02  AN-FIELD PICTURE X(8).                                   IC2354.2
+058500     02  NUM-DISPLAY PIC 99.                                      IC2354.2
+058600     02  GRP-LEVEL.                                               IC2354.2
+058700         03  A-FIELD PICTURE A(3).                                IC2354.2
+058800 77  ELEM-01 PIC  V9(4) COMPUTATIONAL.                            IC2354.2
+058900 01  GRP-02.                                                      IC2354.2
+059000     02  GRP-03.                                                  IC2354.2
+059100         03  NUM-ITEM PICTURE S99.                                IC2354.2
+059200         03  EDITED-FIELD  PIC XXBX0X.                            IC2354.2
+059300 01  ELEM-NON-01           PIC XX.                                IC2354.2
+059400 01  SUBSCRIPTED-DATA PIC XX.                                     IC2354.2
+059500 PROCEDURE DIVISION USING GRP-01 ELEM-01 GRP-02                   IC2354.2
+059600                          ELEM-NON-01 SUBSCRIPTED-DATA.           IC2354.2
+059700 SECT-IC235A-1-001 SECTION.                                       IC2354.2
+059800*        THIS SECTION SETS THE PARAMETER FIELDS REFERRED TO       IC2354.2
+059900*    IN THE USING PHRASE AND DEFINED IN THE LINKAGE SECTION.      IC2354.2
+060000 CALL-TEST-06.                                                    IC2354.2
+060100     MOVE AN-CONSTANT TO AN-FIELD.                                IC2354.2
+060200     ADD 25 TO NUM-DISPLAY.                                       IC2354.2
+060300     MOVE "YES" TO A-FIELD.                                       IC2354.2
+060400     MOVE NUM-CONSTANT TO ELEM-01.                                IC2354.2
+060500     MOVE NUM-DISPLAY TO NUM-ITEM.                                IC2354.2
+060600     MOVE "ABCD" TO EDITED-FIELD.                                 IC2354.2
+060700     MOVE "ZZ"   TO ELEM-NON-01.                                  IC2354.2
+060800     MOVE "1A"   TO SUBSCRIPTED-DATA.                             IC2354.2
+060900 CALL-EXIT-06.                                                    IC2354.2
+061000     EXIT PROGRAM.                                                IC2354.2
+061100 END PROGRAM IC235A1.                                             IC2354.2

--- a/z390/IC235A2.CBL
+++ b/z390/IC235A2.CBL
@@ -1,0 +1,63 @@
+061200 IDENTIFICATION DIVISION.                                         IC2354.2
+      *
+      * This is the z390 version of IC235A-2
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC235A2
+      * IC235A has been modified to call IC235A1 instead of IC235A-1.
+      * IC235A has been modified to call IC235A2 instead of IC235A-2.
+      *
+061300 PROGRAM-ID.                                                      IC2354.2
+061400     IC235A2.                                                     IC2354.2
+061500****************************************************************  IC2354.2
+061600*                                                              *  IC2354.2
+061700*    VALIDATION FOR:-                                          *  IC2354.2
+061800*                                                              *  IC2354.2
+061900*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2354.2
+062000*                                                              *  IC2354.2
+062100*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2354.2
+062200*                                                              *  IC2354.2
+062300****************************************************************  IC2354.2
+062400*                                                              *  IC2354.2
+062500*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2354.2
+062600*                                                              *  IC2354.2
+062700*        X-55  - SYSTEM PRINTER NAME.                          *  IC2354.2
+062800*        X-82  - SOURCE COMPUTER NAME.                         *  IC2354.2
+062900*        X-83  - OBJECT COMPUTER NAME.                         *  IC2354.2
+063000*                                                              *  IC2354.2
+063100****************************************************************  IC2354.2
+063200*        THE SUBPROGRAM IC235A-2 HAS TWO OPERANDS IN THE          IC2354.2
+063300*    PROCEDURE DIVISION HEADER AND THE ROUTINE CONTAINS           IC2354.2
+063400*    FOUR EXIT PROGRAM STATEMENTS.  THE CALLING PROGRAM           IC2354.2
+063500*    IS IC235.                                                    IC2354.2
+063600 ENVIRONMENT DIVISION.                                            IC2354.2
+063700 DATA DIVISION.                                                   IC2354.2
+063800 LINKAGE SECTION.                                                 IC2354.2
+063900 77  DN1 PICTURE 999.                                             IC2354.2
+064000 77  DN2 PICTURE S99 COMPUTATIONAL.                               IC2354.2
+064100 PROCEDURE DIVISION  USING DN1 DN2.                               IC2354.2
+064200*        THIS SUBPROGRAM CONTANS FOUR EXIT PROGRAM STATEMENTS.    IC2354.2
+064300 SECT-IC235A-2-0001 SECTION.                                      IC2354.2
+064400 EXIT-TEST-001.                                                   IC2354.2
+064500     IF DN1 IS NOT EQUAL TO 1                                     IC2354.2
+064600          GO TO EXIT-TEST-002.                                    IC2354.2
+064700     MOVE 1 TO DN2.                                               IC2354.2
+064800     EXIT PROGRAM.                                                IC2354.2
+064900 EXIT-TEST-002.                                                   IC2354.2
+065000     IF DN1 IS NOT EQUAL TO 2                                     IC2354.2
+065100          GO TO EXIT-TEST-003.                                    IC2354.2
+065200     MOVE 2 TO DN2.                                               IC2354.2
+065300     EXIT PROGRAM.                                                IC2354.2
+065400 EXIT-TEST-003.                                                   IC2354.2
+065500     IF DN1 NOT EQUAL TO 3                                        IC2354.2
+065600          GO TO EXIT-TEST-004.                                    IC2354.2
+065700     MOVE 3 TO DN2.                                               IC2354.2
+065800     EXIT PROGRAM.                                                IC2354.2
+065900 EXIT-TEST-004.                                                   IC2354.2
+066000     MOVE 4 TO DN2.                                               IC2354.2
+066100     GO TO EXIT-STATEMENT-004.                                    IC2354.2
+066200 EXTRANEOUS-PARAGRAPH.                                            IC2354.2
+066300*        THIS PARAGRAPH IS NEVER EXECUTED.                        IC2354.2
+066400     MOVE 5 TO DN2.                                               IC2354.2
+066500 EXIT-STATEMENT-004.                                              IC2354.2
+066600     EXIT PROGRAM.                                                IC2354.2
+066700 END PROGRAM IC235A2.                                             IC2354.2

--- a/z390/IC237A.CBL
+++ b/z390/IC237A.CBL
@@ -1,0 +1,332 @@
+000100 IDENTIFICATION DIVISION.                                         IC2374.2
+      *
+      * This is the z390 version of IC237A
+      * z390 cannot handle multiple programs in a single source file
+      * The subprograms have been extracted and saved as IC237A1
+      * IC237A has been modified to call IC237A1 instead of IC237A-1.
+      *
+000200 PROGRAM-ID.                                                      IC2374.2
+000300     IC237A.                                                      IC2374.2
+000400****************************************************************  IC2374.2
+000500*                                                              *  IC2374.2
+000600*    VALIDATION FOR:-                                          *  IC2374.2
+000700*                                                              *  IC2374.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2374.2
+000900*                                                              *  IC2374.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2374.2
+001100*                                                              *  IC2374.2
+001200****************************************************************  IC2374.2
+001300*                                                              *  IC2374.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2374.2
+001500*                                                              *  IC2374.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  IC2374.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  IC2374.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  IC2374.2
+001900*                                                              *  IC2374.2
+002000****************************************************************  IC2374.2
+002100*                                                              *  IC2374.2
+002200*    PROGRAMS IC237A AND IC237A-1 TEST THE ACCESSING OF A      *  IC2374.2
+002300*    LINKAGE SECTION ITEM.                                     *  IC2374.2
+002400*                                                              *  IC2374.2
+002500****************************************************************  IC2374.2
+002600 ENVIRONMENT DIVISION.                                            IC2374.2
+002700 CONFIGURATION SECTION.                                           IC2374.2
+002800 SOURCE-COMPUTER.                                                 IC2374.2
+002900     XXXXX082.                                                    IC2374.2
+003000 OBJECT-COMPUTER.                                                 IC2374.2
+003100     XXXXX083.                                                    IC2374.2
+003200 INPUT-OUTPUT SECTION.                                            IC2374.2
+003300 FILE-CONTROL.                                                    IC2374.2
+003400     SELECT PRINT-FILE ASSIGN TO                                  IC2374.2
+003500     XXXXX055.                                                    IC2374.2
+003600 DATA DIVISION.                                                   IC2374.2
+003700 FILE SECTION.                                                    IC2374.2
+003800 FD  PRINT-FILE.                                                  IC2374.2
+003900 01  PRINT-REC PICTURE X(120).                                    IC2374.2
+004000 01  DUMMY-RECORD PICTURE X(120).                                 IC2374.2
+004100 WORKING-STORAGE SECTION.                                         IC2374.2
+004200 01  WS-A                        PIC 9 VALUE ZERO.                IC2374.2
+004300 01  WS-B                        PIC 9 VALUE ZERO.                IC2374.2
+004400 01  WS-C                        PIC 9 VALUE ZERO.                IC2374.2
+004500*                                                                 IC2374.2
+004600 01  TEST-RESULTS.                                                IC2374.2
+004700     02 FILLER                   PIC X      VALUE SPACE.          IC2374.2
+004800     02 FEATURE                  PIC X(20)  VALUE SPACE.          IC2374.2
+004900     02 FILLER                   PIC X      VALUE SPACE.          IC2374.2
+005000     02 P-OR-F                   PIC X(5)   VALUE SPACE.          IC2374.2
+005100     02 FILLER                   PIC X      VALUE SPACE.          IC2374.2
+005200     02  PAR-NAME.                                                IC2374.2
+005300       03 FILLER                 PIC X(19)  VALUE SPACE.          IC2374.2
+005400       03  PARDOT-X              PIC X      VALUE SPACE.          IC2374.2
+005500       03 DOTVALUE               PIC 99     VALUE ZERO.           IC2374.2
+005600     02 FILLER                   PIC X(8)   VALUE SPACE.          IC2374.2
+005700     02 RE-MARK                  PIC X(61).                       IC2374.2
+005800 01  TEST-COMPUTED.                                               IC2374.2
+005900     02 FILLER                   PIC X(30)  VALUE SPACE.          IC2374.2
+006000     02 FILLER                   PIC X(17)  VALUE                 IC2374.2
+006100            "       COMPUTED=".                                   IC2374.2
+006200     02 COMPUTED-X.                                               IC2374.2
+006300     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          IC2374.2
+006400     03 COMPUTED-N               REDEFINES COMPUTED-A             IC2374.2
+006500                                 PIC -9(9).9(9).                  IC2374.2
+006600     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         IC2374.2
+006700     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     IC2374.2
+006800     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     IC2374.2
+006900     03       CM-18V0 REDEFINES COMPUTED-A.                       IC2374.2
+007000         04 COMPUTED-18V0                    PIC -9(18).          IC2374.2
+007100         04 FILLER                           PIC X.               IC2374.2
+007200     03 FILLER PIC X(50) VALUE SPACE.                             IC2374.2
+007300 01  TEST-CORRECT.                                                IC2374.2
+007400     02 FILLER PIC X(30) VALUE SPACE.                             IC2374.2
+007500     02 FILLER PIC X(17) VALUE "       CORRECT =".                IC2374.2
+007600     02 CORRECT-X.                                                IC2374.2
+007700     03 CORRECT-A                  PIC X(20) VALUE SPACE.         IC2374.2
+007800     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      IC2374.2
+007900     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         IC2374.2
+008000     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     IC2374.2
+008100     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     IC2374.2
+008200     03      CR-18V0 REDEFINES CORRECT-A.                         IC2374.2
+008300         04 CORRECT-18V0                     PIC -9(18).          IC2374.2
+008400         04 FILLER                           PIC X.               IC2374.2
+008500     03 FILLER PIC X(2) VALUE SPACE.                              IC2374.2
+008600     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     IC2374.2
+008700 01  CCVS-C-1.                                                    IC2374.2
+008800     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PAIC2374.2
+008900-    "SS  PARAGRAPH-NAME                                          IC2374.2
+009000-    "       REMARKS".                                            IC2374.2
+009100     02 FILLER                     PIC X(20)    VALUE SPACE.      IC2374.2
+009200 01  CCVS-C-2.                                                    IC2374.2
+009300     02 FILLER                     PIC X        VALUE SPACE.      IC2374.2
+009400     02 FILLER                     PIC X(6)     VALUE "TESTED".   IC2374.2
+009500     02 FILLER                     PIC X(15)    VALUE SPACE.      IC2374.2
+009600     02 FILLER                     PIC X(4)     VALUE "FAIL".     IC2374.2
+009700     02 FILLER                     PIC X(94)    VALUE SPACE.      IC2374.2
+009800 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       IC2374.2
+009900 01  REC-CT                        PIC 99       VALUE ZERO.       IC2374.2
+010000 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       IC2374.2
+010100 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       IC2374.2
+010200 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       IC2374.2
+010300 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       IC2374.2
+010400 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       IC2374.2
+010500 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       IC2374.2
+010600 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      IC2374.2
+010700 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       IC2374.2
+010800 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     IC2374.2
+010900 01  CCVS-H-1.                                                    IC2374.2
+011000     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2374.2
+011100     02  FILLER                    PIC X(42)    VALUE             IC2374.2
+011200     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 IC2374.2
+011300     02  FILLER                    PIC X(39)    VALUE SPACES.     IC2374.2
+011400 01  CCVS-H-2A.                                                   IC2374.2
+011500   02  FILLER                        PIC X(40)  VALUE SPACE.      IC2374.2
+011600   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  IC2374.2
+011700   02  FILLER                        PIC XXXX   VALUE             IC2374.2
+011800     "4.2 ".                                                      IC2374.2
+011900   02  FILLER                        PIC X(28)  VALUE             IC2374.2
+012000            " COPY - NOT FOR DISTRIBUTION".                       IC2374.2
+012100   02  FILLER                        PIC X(41)  VALUE SPACE.      IC2374.2
+012200                                                                  IC2374.2
+012300 01  CCVS-H-2B.                                                   IC2374.2
+012400   02  FILLER                        PIC X(15)  VALUE             IC2374.2
+012500            "TEST RESULT OF ".                                    IC2374.2
+012600   02  TEST-ID                       PIC X(9).                    IC2374.2
+012700   02  FILLER                        PIC X(4)   VALUE             IC2374.2
+012800            " IN ".                                               IC2374.2
+012900   02  FILLER                        PIC X(12)  VALUE             IC2374.2
+013000     " HIGH       ".                                              IC2374.2
+013100   02  FILLER                        PIC X(22)  VALUE             IC2374.2
+013200            " LEVEL VALIDATION FOR ".                             IC2374.2
+013300   02  FILLER                        PIC X(58)  VALUE             IC2374.2
+013400     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2374.2
+013500 01  CCVS-H-3.                                                    IC2374.2
+013600     02  FILLER                      PIC X(34)  VALUE             IC2374.2
+013700            " FOR OFFICIAL USE ONLY    ".                         IC2374.2
+013800     02  FILLER                      PIC X(58)  VALUE             IC2374.2
+013900     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2374.2
+014000     02  FILLER                      PIC X(28)  VALUE             IC2374.2
+014100            "  COPYRIGHT   1985 ".                                IC2374.2
+014200 01  CCVS-E-1.                                                    IC2374.2
+014300     02 FILLER                       PIC X(52)  VALUE SPACE.      IC2374.2
+014400     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              IC2374.2
+014500     02 ID-AGAIN                     PIC X(9).                    IC2374.2
+014600     02 FILLER                       PIC X(45)  VALUE SPACES.     IC2374.2
+014700 01  CCVS-E-2.                                                    IC2374.2
+014800     02  FILLER                      PIC X(31)  VALUE SPACE.      IC2374.2
+014900     02  FILLER                      PIC X(21)  VALUE SPACE.      IC2374.2
+015000     02 CCVS-E-2-2.                                               IC2374.2
+015100         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      IC2374.2
+015200         03 FILLER                   PIC X      VALUE SPACE.      IC2374.2
+015300         03 ENDER-DESC               PIC X(44)  VALUE             IC2374.2
+015400            "ERRORS ENCOUNTERED".                                 IC2374.2
+015500 01  CCVS-E-3.                                                    IC2374.2
+015600     02  FILLER                      PIC X(22)  VALUE             IC2374.2
+015700            " FOR OFFICIAL USE ONLY".                             IC2374.2
+015800     02  FILLER                      PIC X(12)  VALUE SPACE.      IC2374.2
+015900     02  FILLER                      PIC X(58)  VALUE             IC2374.2
+016000     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2374.2
+016100     02  FILLER                      PIC X(13)  VALUE SPACE.      IC2374.2
+016200     02 FILLER                       PIC X(15)  VALUE             IC2374.2
+016300             " COPYRIGHT 1985".                                   IC2374.2
+016400 01  CCVS-E-4.                                                    IC2374.2
+016500     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      IC2374.2
+016600     02 FILLER                       PIC X(4)   VALUE " OF ".     IC2374.2
+016700     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      IC2374.2
+016800     02 FILLER                       PIC X(40)  VALUE             IC2374.2
+016900      "  TESTS WERE EXECUTED SUCCESSFULLY".                       IC2374.2
+017000 01  XXINFO.                                                      IC2374.2
+017100     02 FILLER                       PIC X(19)  VALUE             IC2374.2
+017200            "*** INFORMATION ***".                                IC2374.2
+017300     02 INFO-TEXT.                                                IC2374.2
+017400       04 FILLER                     PIC X(8)   VALUE SPACE.      IC2374.2
+017500       04 XXCOMPUTED                 PIC X(20).                   IC2374.2
+017600       04 FILLER                     PIC X(5)   VALUE SPACE.      IC2374.2
+017700       04 XXCORRECT                  PIC X(20).                   IC2374.2
+017800     02 INF-ANSI-REFERENCE           PIC X(48).                   IC2374.2
+017900 01  HYPHEN-LINE.                                                 IC2374.2
+018000     02 FILLER  PIC IS X VALUE IS SPACE.                          IC2374.2
+018100     02 FILLER  PIC IS X(65)    VALUE IS "************************IC2374.2
+018200-    "*****************************************".                 IC2374.2
+018300     02 FILLER  PIC IS X(54)    VALUE IS "************************IC2374.2
+018400-    "******************************".                            IC2374.2
+018500 01  CCVS-PGM-ID                     PIC X(9)   VALUE             IC2374.2
+018600     "IC237A".                                                    IC2374.2
+018700 PROCEDURE DIVISION.                                              IC2374.2
+018800 CCVS1 SECTION.                                                   IC2374.2
+018900 OPEN-FILES.                                                      IC2374.2
+019000     OPEN     OUTPUT PRINT-FILE.                                  IC2374.2
+019100     MOVE CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.   IC2374.2
+019200     MOVE    SPACE TO TEST-RESULTS.                               IC2374.2
+019300     PERFORM  HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.             IC2374.2
+019400     GO TO CCVS1-EXIT.                                            IC2374.2
+019500 CLOSE-FILES.                                                     IC2374.2
+019600     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   IC2374.2
+019700 TERMINATE-CCVS.                                                  IC2374.2
+019800S    EXIT PROGRAM.                                                IC2374.2
+019900STERMINATE-CALL.                                                  IC2374.2
+020000     STOP     RUN.                                                IC2374.2
+020100 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         IC2374.2
+020200 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           IC2374.2
+020300 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          IC2374.2
+020400 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      IC2374.2
+020500     MOVE "****TEST DELETED****" TO RE-MARK.                      IC2374.2
+020600 PRINT-DETAIL.                                                    IC2374.2
+020700     IF REC-CT NOT EQUAL TO ZERO                                  IC2374.2
+020800             MOVE "." TO PARDOT-X                                 IC2374.2
+020900             MOVE REC-CT TO DOTVALUE.                             IC2374.2
+021000     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      IC2374.2
+021100     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               IC2374.2
+021200        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 IC2374.2
+021300          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 IC2374.2
+021400     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              IC2374.2
+021500     MOVE SPACE TO CORRECT-X.                                     IC2374.2
+021600     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         IC2374.2
+021700     MOVE     SPACE TO RE-MARK.                                   IC2374.2
+021800 HEAD-ROUTINE.                                                    IC2374.2
+021900     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2374.2
+022000     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  IC2374.2
+022100     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2374.2
+022200     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  IC2374.2
+022300 COLUMN-NAMES-ROUTINE.                                            IC2374.2
+022400     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2374.2
+022500     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2374.2
+022600     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        IC2374.2
+022700 END-ROUTINE.                                                     IC2374.2
+022800     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.IC2374.2
+022900 END-RTN-EXIT.                                                    IC2374.2
+023000     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2374.2
+023100 END-ROUTINE-1.                                                   IC2374.2
+023200      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      IC2374.2
+023300      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               IC2374.2
+023400      ADD PASS-COUNTER TO ERROR-HOLD.                             IC2374.2
+023500*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   IC2374.2
+023600      MOVE PASS-COUNTER TO CCVS-E-4-1.                            IC2374.2
+023700      MOVE ERROR-HOLD TO CCVS-E-4-2.                              IC2374.2
+023800      MOVE CCVS-E-4 TO CCVS-E-2-2.                                IC2374.2
+023900      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           IC2374.2
+024000  END-ROUTINE-12.                                                 IC2374.2
+024100      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        IC2374.2
+024200     IF       ERROR-COUNTER IS EQUAL TO ZERO                      IC2374.2
+024300         MOVE "NO " TO ERROR-TOTAL                                IC2374.2
+024400         ELSE                                                     IC2374.2
+024500         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       IC2374.2
+024600     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           IC2374.2
+024700     PERFORM WRITE-LINE.                                          IC2374.2
+024800 END-ROUTINE-13.                                                  IC2374.2
+024900     IF DELETE-COUNTER IS EQUAL TO ZERO                           IC2374.2
+025000         MOVE "NO " TO ERROR-TOTAL  ELSE                          IC2374.2
+025100         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      IC2374.2
+025200     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   IC2374.2
+025300     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2374.2
+025400      IF   INSPECT-COUNTER EQUAL TO ZERO                          IC2374.2
+025500          MOVE "NO " TO ERROR-TOTAL                               IC2374.2
+025600      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   IC2374.2
+025700      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            IC2374.2
+025800      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          IC2374.2
+025900     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           IC2374.2
+026000 WRITE-LINE.                                                      IC2374.2
+026100     ADD 1 TO RECORD-COUNT.                                       IC2374.2
+026200Y    IF RECORD-COUNT GREATER 50                                   IC2374.2
+026300Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          IC2374.2
+026400Y        MOVE SPACE TO DUMMY-RECORD                               IC2374.2
+026500Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  IC2374.2
+026600Y        MOVE CCVS-C-1 TO DUMMY-RECORD PERFORM WRT-LN             IC2374.2
+026700Y        MOVE CCVS-C-2 TO DUMMY-RECORD PERFORM WRT-LN 2 TIMES     IC2374.2
+026800Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          IC2374.2
+026900Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          IC2374.2
+027000Y        MOVE ZERO TO RECORD-COUNT.                               IC2374.2
+027100     PERFORM WRT-LN.                                              IC2374.2
+027200 WRT-LN.                                                          IC2374.2
+027300     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               IC2374.2
+027400     MOVE SPACE TO DUMMY-RECORD.                                  IC2374.2
+027500 BLANK-LINE-PRINT.                                                IC2374.2
+027600     PERFORM WRT-LN.                                              IC2374.2
+027700 FAIL-ROUTINE.                                                    IC2374.2
+027800     IF   COMPUTED-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE. IC2374.2
+027900     IF     CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.IC2374.2
+028000     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2374.2
+028100     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   IC2374.2
+028200     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2374.2
+028300     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2374.2
+028400     GO TO  FAIL-ROUTINE-EX.                                      IC2374.2
+028500 FAIL-ROUTINE-WRITE.                                              IC2374.2
+028600     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         IC2374.2
+028700     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 IC2374.2
+028800     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. IC2374.2
+028900     MOVE   SPACES TO COR-ANSI-REFERENCE.                         IC2374.2
+029000 FAIL-ROUTINE-EX. EXIT.                                           IC2374.2
+029100 BAIL-OUT.                                                        IC2374.2
+029200     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   IC2374.2
+029300     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           IC2374.2
+029400 BAIL-OUT-WRITE.                                                  IC2374.2
+029500     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  IC2374.2
+029600     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 IC2374.2
+029700     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   IC2374.2
+029800     MOVE   SPACES TO INF-ANSI-REFERENCE.                         IC2374.2
+029900 BAIL-OUT-EX. EXIT.                                               IC2374.2
+030000 CCVS1-EXIT.                                                      IC2374.2
+030100     EXIT.                                                        IC2374.2
+030200 SECT-IC237A-001 SECTION.                                         IC2374.2
+030300*                                                                 IC2374.2
+030400 CALL-INIT-1.                                                     IC2374.2
+030500     MOVE   "CALL-TEST-1" TO PAR-NAME.                            IC2374.2
+030600     MOVE    1 TO WS-A.                                           IC2374.2
+030700     MOVE    3 TO WS-B.                                           IC2374.2
+030800     MOVE    5 TO WS-C.                                           IC2374.2
+030900 CALL-TEST-0.                                                     IC2374.2
+031000     CALL   "IC237A1"  USING WS-A WS-B WS-C.                      IC2374.2
+031100 CALL-TEST-1.                                                     IC2374.2
+031200     IF      WS-C = WS-A                                          IC2374.2
+031300             PERFORM PASS                                         IC2374.2
+031400             PERFORM PRINT-DETAIL                                 IC2374.2
+031500     ELSE                                                         IC2374.2
+031600             MOVE    1 TO CORRECT-N                               IC2374.2
+031700             MOVE    WS-A TO COMPUTED-N                           IC2374.2
+031800             MOVE   "WRONG VALUE RETURNED FROM CALL TO IC237A-1"  IC2374.2
+031900                  TO RE-MARK                                      IC2374.2
+032000             PERFORM FAIL                                         IC2374.2
+032100             PERFORM PRINT-DETAIL.                                IC2374.2
+032200*                                                                 IC2374.2
+032300 CCVS-EXIT SECTION.                                               IC2374.2
+032400 CCVS-999999.                                                     IC2374.2
+032500     GO TO CLOSE-FILES.                                           IC2374.2
+032600 END PROGRAM IC237A.                                              IC2374.2

--- a/z390/IC237A1.CBL
+++ b/z390/IC237A1.CBL
@@ -1,0 +1,113 @@
+032700 IDENTIFICATION DIVISION.                                         IC2374.2
+      *
+      * This is the z390 version of IC237A-1
+      * z390 cannot handle multiple programs in a single source file
+      * The subprogram has been extracted and saved as IC237A1
+      * IC237A has been modified to call IC237A1 instead of IC237A-1.
+      *
+032800 PROGRAM-ID.                                                      IC2374.2
+032900     IC237A1.                                                     IC2374.2
+033000****************************************************************  IC2374.2
+033100*                                                              *  IC2374.2
+033200*    THIS PROGRAM FORMS PART OF THE COBOL COMPILER VALIDATION  *  IC2374.2
+033300*    SYSTEM (CCVS) USED TO TEST COBOL COMPILERS FOR            *  IC2374.2
+033400*    CONFORMANCE WITH THE AMERICAN NATIONAL STANDARD           *  IC2374.2
+033500*    (ANSI DOCUMENT REFERENCE: X3.23-1985) AND THE STANDARD OF *  IC2374.2
+033600*    THE INTERNATIONAL ORGANIZATION FOR STANDARDISATION        *  IC2374.2
+033700*    (ISO DOCUMENT REFERENCE: ISO-1989-1985).                  *  IC2374.2
+033800*                                                              *  IC2374.2
+033900*    THIS CCVS INCORPORATES ENHANCEMENTS TO THE CCVS FOR THE   *  IC2374.2
+034000*    1974 STANDARD (ANSI DOCUMENT REFERENCE: X3.23-1974; ISO   *  IC2374.2
+034100*    DOCUMENT REFERENCE: ISO-1989-1978).                       *  IC2374.2
+034200*                                                              *  IC2374.2
+034300*    THESE ENHANCEMENTS WERE SPECIFIED BY A PROJECT TEAM WHICH *  IC2374.2
+034400*    WAS FUNDED BY THE COMMISSION FOR EUROPEAN COMMUNITIES AND *  IC2374.2
+034500*    WHICH WAS RESPONSIBLE FOR TECHNICAL ISSUES TO:            *  IC2374.2
+034600*                                                              *  IC2374.2
+034700*          THE FEDERAL SOFTWARE TESTING CENTER                 *  IC2374.2
+034800*          OFFICE OF SOFTWARE DEVELOPMENT                      *  IC2374.2
+034900*                & INFORMATION TECHNOLOGY                      *  IC2374.2
+035000*          TWO SKYLINE PLACE                                   *  IC2374.2
+035100*          SUITE 1100                                          *  IC2374.2
+035200*          5203 LEESBURG PIKE                                  *  IC2374.2
+035300*          FALLS CHURCH                                        *  IC2374.2
+035400*          VA 22041                                            *  IC2374.2
+035500*          U.S.A.                                              *  IC2374.2
+035600*                                                              *  IC2374.2
+035700*    THE PROJECT TEAM MEMBERS WERE:                            *  IC2374.2
+035800*                                                              *  IC2374.2
+035900*          BIADI (BUREAU INTER ADMINISTRATION                  *  IC2374.2
+036000*                 DE DOCUMENTATION INFORMATIQUE)               *  IC2374.2
+036100*          21 RUE BARA                                         *  IC2374.2
+036200*          F-92132 ISSY                                        *  IC2374.2
+036300*          FRANCE                                              *  IC2374.2
+036400*                                                              *  IC2374.2
+036500*                                                              *  IC2374.2
+036600*          GMD (GESELLSCHAFT FUR MATHEMATIK                    *  IC2374.2
+036700*               UND DATENVERARBEITUNG MBH)                     *  IC2374.2
+036800*          SCHLOSS BIRLINGHOVEN                                *  IC2374.2
+036900*          POSTFACH 12 40                                      *  IC2374.2
+037000*          D-5205 ST. AUGUSTIN 1                               *  IC2374.2
+037100*          GERMANY FR                                          *  IC2374.2
+037200*                                                              *  IC2374.2
+037300*                                                              *  IC2374.2
+037400*          NCC (THE NATIONAL COMPUTING CENTRE LTD)             *  IC2374.2
+037500*          OXFORD ROAD                                         *  IC2374.2
+037600*          MANCHESTER                                          *  IC2374.2
+037700*          M1 7ED                                              *  IC2374.2
+037800*          UNITED KINGDOM                                      *  IC2374.2
+037900*                                                              *  IC2374.2
+038000*                                                              *  IC2374.2
+038100*    THIS TEST SUITE WAS PRODUCED BY THE NATIONAL COMPUTING    *  IC2374.2
+038200*    CENTRE IN ENGLAND AND IS THE OFFICIAL CCVS TEST SUITE     *  IC2374.2
+038300*    USED THROUGHOUT EUROPE AND THE UNITED STATES OF AMERICA.  *  IC2374.2
+038400*                                                              *  IC2374.2
+038500****************************************************************  IC2374.2
+038600*                                                              *  IC2374.2
+038700*    VALIDATION FOR:-                                          *  IC2374.2
+038800*                                                              *  IC2374.2
+038900*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".IC2374.2
+039000*                                                              *  IC2374.2
+039100*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".IC2374.2
+039200*                                                              *  IC2374.2
+039300****************************************************************  IC2374.2
+039400*                                                              *  IC2374.2
+039500*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  IC2374.2
+039600*                                                              *  IC2374.2
+039700*        X-55  - SYSTEM PRINTER NAME.                          *  IC2374.2
+039800*        X-82  - SOURCE COMPUTER NAME.                         *  IC2374.2
+039900*        X-83  - OBJECT COMPUTER NAME.                         *  IC2374.2
+040000*                                                              *  IC2374.2
+040100****************************************************************  IC2374.2
+040200 ENVIRONMENT DIVISION.                                            IC2374.2
+040300 CONFIGURATION SECTION.                                           IC2374.2
+040400 SOURCE-COMPUTER.                                                 IC2374.2
+040500     XXXXX082.                                                    IC2374.2
+040600 OBJECT-COMPUTER.                                                 IC2374.2
+040700     XXXXX083.                                                    IC2374.2
+040800 INPUT-OUTPUT SECTION.                                            IC2374.2
+040900 FILE-CONTROL.                                                    IC2374.2
+041000     SELECT PRINT-FILE ASSIGN TO                                  IC2374.2
+041100     XXXXX055.                                                    IC2374.2
+041200 DATA DIVISION.                                                   IC2374.2
+041300 FILE SECTION.                                                    IC2374.2
+041400 FD  PRINT-FILE.                                                  IC2374.2
+041500 01  PRINT-REC PICTURE X(120).                                    IC2374.2
+041600 01  DUMMY-RECORD PICTURE X(120).                                 IC2374.2
+041700 WORKING-STORAGE SECTION.                                         IC2374.2
+041800*                                                                 IC2374.2
+041900 LINKAGE SECTION.                                                 IC2374.2
+042000 01  L-A                   PIC 9.                                 IC2374.2
+042100 01  L-A1 REDEFINES L-A    PIC 9.                                 IC2374.2
+042200 01  L-B                   PIC 9.                                 IC2374.2
+042300 01  L-C                   PIC 9.                                 IC2374.2
+042400 PROCEDURE DIVISION USING L-A L-B L-C.                            IC2374.2
+042500*                                                                 IC2374.2
+042600 SECT-IC237A-1-001 SECTION.                                       IC2374.2
+042700*                                                                 IC2374.2
+042800 CALLED-FROM-NC121A-FUNCTION.                                     IC2374.2
+042900     MOVE    L-A1 TO L-C.                                         IC2374.2
+043000 IC237A-EXIT.                                                     IC2374.2
+043100     EXIT PROGRAM.                                                IC2374.2
+043200 END-OF-PROGRAM.                                                  IC2374.2
+043300 END PROGRAM IC237A1.                                             IC2374.2

--- a/z390/NC103AX.CBL
+++ b/z390/NC103AX.CBL
@@ -1,0 +1,2143 @@
+000100 IDENTIFICATION DIVISION.                                         NC1034.2
+000200 PROGRAM-ID.                                                      NC1034.2
+000300     NC103A.                                                      NC1034.2
+      *
+      * This program is a copy of NC103A with a few minor fixes
+      * by James Francis Cray. The validuty of these fixes is uncertain
+      *
+000400****************************************************************  NC1034.2
+000500*                                                              *  NC1034.2
+000600*    VALIDATION FOR:-                                          *  NC1034.2
+000700*                                                              *  NC1034.2
+000800*    "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".NC1034.2
+000900*                                                              *  NC1034.2
+001000*    "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".NC1034.2
+001100*                                                              *  NC1034.2
+001200****************************************************************  NC1034.2
+001300*                                                              *  NC1034.2
+001400*      X-CARDS USED BY THIS PROGRAM ARE :-                     *  NC1034.2
+001500*                                                              *  NC1034.2
+001600*        X-55  - SYSTEM PRINTER NAME.                          *  NC1034.2
+001700*        X-82  - SOURCE COMPUTER NAME.                         *  NC1034.2
+001800*        X-83  - OBJECT COMPUTER NAME.                         *  NC1034.2
+001900*                                                              *  NC1034.2
+002000****************************************************************  NC1034.2
+002100*                                                                 NC1034.2
+002200*    PROGRAM NC103A TESTS THE GENERAL FORMAT OF THE "IF"          NC1034.2
+002300*    STATEMENT AND  "NEXT SENTENCE".                              NC1034.2
+002400*                                                                 NC1034.2
+002500 ENVIRONMENT DIVISION.                                            NC1034.2
+002600 CONFIGURATION SECTION.                                           NC1034.2
+002700 SOURCE-COMPUTER.                                                 NC1034.2
+002800     XXXXX082.                                                    NC1034.2
+002900 OBJECT-COMPUTER.                                                 NC1034.2
+003000     XXXXX083.                                                    NC1034.2
+003100 INPUT-OUTPUT SECTION.                                            NC1034.2
+003200 FILE-CONTROL.                                                    NC1034.2
+003300     SELECT PRINT-FILE ASSIGN TO                                  NC1034.2
+003400     NC103AXX.                                                    NC1034.2
+003500 DATA DIVISION.                                                   NC1034.2
+003600 FILE SECTION.                                                    NC1034.2
+003700 FD  PRINT-FILE.                                                  NC1034.2
+003800 01  PRINT-REC PICTURE X(120).                                    NC1034.2
+003900 01  DUMMY-RECORD PICTURE X(120).                                 NC1034.2
+004000 WORKING-STORAGE SECTION.                                         NC1034.2
+004100 01  TEST-RESULTS.                                                NC1034.2
+004200     02 FILLER                   PIC X      VALUE SPACE.          NC1034.2
+004300     02 FEATURE                  PIC X(20)  VALUE SPACE.          NC1034.2
+004400     02 FILLER                   PIC X      VALUE SPACE.          NC1034.2
+004500     02 P-OR-F                   PIC X(5)   VALUE SPACE.          NC1034.2
+004600     02 FILLER                   PIC X      VALUE SPACE.          NC1034.2
+004700     02  PAR-NAME.                                                NC1034.2
+004800       03 FILLER                 PIC X(19)  VALUE SPACE.          NC1034.2
+004900       03  PARDOT-X              PIC X      VALUE SPACE.          NC1034.2
+005000       03 DOTVALUE               PIC 99     VALUE ZERO.           NC1034.2
+005100     02 FILLER                   PIC X(8)   VALUE SPACE.          NC1034.2
+005200     02 RE-MARK                  PIC X(61).                       NC1034.2
+005300 01  TEST-COMPUTED.                                               NC1034.2
+005400     02 FILLER                   PIC X(30)  VALUE SPACE.          NC1034.2
+005500     02 FILLER                   PIC X(17)  VALUE                 NC1034.2
+005600            "       COMPUTED=".                                   NC1034.2
+005700     02 COMPUTED-X.                                               NC1034.2
+005800     03 COMPUTED-A               PIC X(20)  VALUE SPACE.          NC1034.2
+005900     03 COMPUTED-N               REDEFINES COMPUTED-A             NC1034.2
+006000                                 PIC -9(9).9(9).                  NC1034.2
+006100     03 COMPUTED-0V18 REDEFINES COMPUTED-A   PIC -.9(18).         NC1034.2
+006200     03 COMPUTED-4V14 REDEFINES COMPUTED-A   PIC -9(4).9(14).     NC1034.2
+006300     03 COMPUTED-14V4 REDEFINES COMPUTED-A   PIC -9(14).9(4).     NC1034.2
+006400     03       CM-18V0 REDEFINES COMPUTED-A.                       NC1034.2
+006500         04 COMPUTED-18V0                    PIC -9(18).          NC1034.2
+006600         04 FILLER                           PIC X.               NC1034.2
+006700     03 FILLER PIC X(50) VALUE SPACE.                             NC1034.2
+006800 01  TEST-CORRECT.                                                NC1034.2
+006900     02 FILLER PIC X(30) VALUE SPACE.                             NC1034.2
+007000     02 FILLER PIC X(17) VALUE "       CORRECT =".                NC1034.2
+007100     02 CORRECT-X.                                                NC1034.2
+007200     03 CORRECT-A                  PIC X(20) VALUE SPACE.         NC1034.2
+007300     03 CORRECT-N    REDEFINES CORRECT-A     PIC -9(9).9(9).      NC1034.2
+007400     03 CORRECT-0V18 REDEFINES CORRECT-A     PIC -.9(18).         NC1034.2
+007500     03 CORRECT-4V14 REDEFINES CORRECT-A     PIC -9(4).9(14).     NC1034.2
+007600     03 CORRECT-14V4 REDEFINES CORRECT-A     PIC -9(14).9(4).     NC1034.2
+007700     03      CR-18V0 REDEFINES CORRECT-A.                         NC1034.2
+007800         04 CORRECT-18V0                     PIC -9(18).          NC1034.2
+007900         04 FILLER                           PIC X.               NC1034.2
+008000     03 FILLER PIC X(2) VALUE SPACE.                              NC1034.2
+008100     03 COR-ANSI-REFERENCE             PIC X(48) VALUE SPACE.     NC1034.2
+008200 01  CCVS-C-1.                                                    NC1034.2
+008300     02 FILLER  PIC IS X(99)    VALUE IS " FEATURE              PANC1034.2
+008400-    "SS  PARAGRAPH-NAME                                          NC1034.2
+008500-    "       REMARKS".                                            NC1034.2
+008600     02 FILLER                     PIC X(20)    VALUE SPACE.      NC1034.2
+008700 01  CCVS-C-2.                                                    NC1034.2
+008800     02 FILLER                     PIC X        VALUE SPACE.      NC1034.2
+008900     02 FILLER                     PIC X(6)     VALUE "TESTED".   NC1034.2
+009000     02 FILLER                     PIC X(15)    VALUE SPACE.      NC1034.2
+009100     02 FILLER                     PIC X(4)     VALUE "FAIL".     NC1034.2
+009200     02 FILLER                     PIC X(94)    VALUE SPACE.      NC1034.2
+009300 01  REC-SKL-SUB                   PIC 9(2)     VALUE ZERO.       NC1034.2
+009400 01  REC-CT                        PIC 99       VALUE ZERO.       NC1034.2
+009500 01  DELETE-COUNTER                PIC 999      VALUE ZERO.       NC1034.2
+009600 01  ERROR-COUNTER                 PIC 999      VALUE ZERO.       NC1034.2
+009700 01  INSPECT-COUNTER               PIC 999      VALUE ZERO.       NC1034.2
+009800 01  PASS-COUNTER                  PIC 999      VALUE ZERO.       NC1034.2
+009900 01  TOTAL-ERROR                   PIC 999      VALUE ZERO.       NC1034.2
+010000 01  ERROR-HOLD                    PIC 999      VALUE ZERO.       NC1034.2
+010100 01  DUMMY-HOLD                    PIC X(120)   VALUE SPACE.      NC1034.2
+010200 01  RECORD-COUNT                  PIC 9(5)     VALUE ZERO.       NC1034.2
+010300 01  ANSI-REFERENCE                PIC X(48)    VALUE SPACES.     NC1034.2
+010400 01  CCVS-H-1.                                                    NC1034.2
+010500     02  FILLER                    PIC X(39)    VALUE SPACES.     NC1034.2
+010600     02  FILLER                    PIC X(42)    VALUE             NC1034.2
+010700     "OFFICIAL COBOL COMPILER VALIDATION SYSTEM".                 NC1034.2
+010800     02  FILLER                    PIC X(39)    VALUE SPACES.     NC1034.2
+010900 01  CCVS-H-2A.                                                   NC1034.2
+011000   02  FILLER                        PIC X(40)  VALUE SPACE.      NC1034.2
+011100   02  FILLER                        PIC X(7)   VALUE "CCVS85 ".  NC1034.2
+011200   02  FILLER                        PIC XXXX   VALUE             NC1034.2
+011300     "4.2 ".                                                      NC1034.2
+011400   02  FILLER                        PIC X(28)  VALUE             NC1034.2
+011500            " COPY - NOT FOR DISTRIBUTION".                       NC1034.2
+011600   02  FILLER                        PIC X(41)  VALUE SPACE.      NC1034.2
+011700                                                                  NC1034.2
+011800 01  CCVS-H-2B.                                                   NC1034.2
+011900   02  FILLER                        PIC X(15)  VALUE             NC1034.2
+012000            "TEST RESULT OF ".                                    NC1034.2
+012100   02  TEST-ID                       PIC X(9).                    NC1034.2
+012200   02  FILLER                        PIC X(4)   VALUE             NC1034.2
+012300            " IN ".                                               NC1034.2
+012400   02  FILLER                        PIC X(12)  VALUE             NC1034.2
+012500     " HIGH       ".                                              NC1034.2
+012600   02  FILLER                        PIC X(22)  VALUE             NC1034.2
+012700            " LEVEL VALIDATION FOR ".                             NC1034.2
+012800   02  FILLER                        PIC X(58)  VALUE             NC1034.2
+012900     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".NC1034.2
+013000 01  CCVS-H-3.                                                    NC1034.2
+013100     02  FILLER                      PIC X(34)  VALUE             NC1034.2
+013200            " FOR OFFICIAL USE ONLY    ".                         NC1034.2
+013300     02  FILLER                      PIC X(58)  VALUE             NC1034.2
+013400     "COBOL 85 VERSION 4.2, Apr  1993 SSVG                      ".NC1034.2
+013500     02  FILLER                      PIC X(28)  VALUE             NC1034.2
+013600            "  COPYRIGHT   1985 ".                                NC1034.2
+013700 01  CCVS-E-1.                                                    NC1034.2
+013800     02 FILLER                       PIC X(52)  VALUE SPACE.      NC1034.2
+013900     02 FILLER  PIC X(14) VALUE IS "END OF TEST-  ".              NC1034.2
+014000     02 ID-AGAIN                     PIC X(9).                    NC1034.2
+014100     02 FILLER                       PIC X(45)  VALUE SPACES.     NC1034.2
+014200 01  CCVS-E-2.                                                    NC1034.2
+014300     02  FILLER                      PIC X(31)  VALUE SPACE.      NC1034.2
+014400     02  FILLER                      PIC X(21)  VALUE SPACE.      NC1034.2
+014500     02 CCVS-E-2-2.                                               NC1034.2
+014600         03 ERROR-TOTAL              PIC XXX    VALUE SPACE.      NC1034.2
+014700         03 FILLER                   PIC X      VALUE SPACE.      NC1034.2
+014800         03 ENDER-DESC               PIC X(44)  VALUE             NC1034.2
+014900            "ERRORS ENCOUNTERED".                                 NC1034.2
+015000 01  CCVS-E-3.                                                    NC1034.2
+015100     02  FILLER                      PIC X(22)  VALUE             NC1034.2
+015200            " FOR OFFICIAL USE ONLY".                             NC1034.2
+015300     02  FILLER                      PIC X(12)  VALUE SPACE.      NC1034.2
+015400     02  FILLER                      PIC X(58)  VALUE             NC1034.2
+015500     "ON-SITE VALIDATION, NATIONAL INSTITUTE OF STD & TECH.     ".NC1034.2
+015600     02  FILLER                      PIC X(13)  VALUE SPACE.      NC1034.2
+015700     02 FILLER                       PIC X(15)  VALUE             NC1034.2
+015800             " COPYRIGHT 1985".                                   NC1034.2
+015900 01  CCVS-E-4.                                                    NC1034.2
+016000     02 CCVS-E-4-1                   PIC XXX    VALUE SPACE.      NC1034.2
+016100     02 FILLER                       PIC X(4)   VALUE " OF ".     NC1034.2
+016200     02 CCVS-E-4-2                   PIC XXX    VALUE SPACE.      NC1034.2
+016300     02 FILLER                       PIC X(40)  VALUE             NC1034.2
+016400      "  TESTS WERE EXECUTED SUCCESSFULLY".                       NC1034.2
+016500 01  XXINFO.                                                      NC1034.2
+016600     02 FILLER                       PIC X(19)  VALUE             NC1034.2
+016700            "*** INFORMATION ***".                                NC1034.2
+016800     02 INFO-TEXT.                                                NC1034.2
+016900       04 FILLER                     PIC X(8)   VALUE SPACE.      NC1034.2
+017000       04 XXCOMPUTED                 PIC X(20).                   NC1034.2
+017100       04 FILLER                     PIC X(5)   VALUE SPACE.      NC1034.2
+017200       04 XXCORRECT                  PIC X(20).                   NC1034.2
+017300     02 INF-ANSI-REFERENCE           PIC X(48).                   NC1034.2
+017400 01  HYPHEN-LINE.                                                 NC1034.2
+017500     02 FILLER  PIC IS X VALUE IS SPACE.                          NC1034.2
+017600     02 FILLER  PIC IS X(65)    VALUE IS "************************NC1034.2
+017700-    "*****************************************".                 NC1034.2
+017800     02 FILLER  PIC IS X(54)    VALUE IS "************************NC1034.2
+017900-    "******************************".                            NC1034.2
+018000 01  CCVS-PGM-ID                     PIC X(9)   VALUE             NC1034.2
+018100     "NC103A".                                                    NC1034.2
+018200 01  IF-D1                              PICTURE IS S9(4)V9(2)     NC1034.2
+018300     VALUE IS 0.                                                  NC1034.2
+018400 01  IF-D2                              PICTURE IS S9(4)V9(2)     NC1034.2
+018500     VALUE IS ZERO.                                               NC1034.2
+018600 01  IF-D3                              PICTURE IS X(10)          NC1034.2
+018700     VALUE IS "0000000000".                                       NC1034.2
+018800 01  IF-D4                              PICTURE IS X(15)          NC1034.2
+018900     VALUE IS "               ".                                  NC1034.2
+019000 01  IF-D6                              PICTURE IS A(10)          NC1034.2
+019100     VALUE IS "BABABABABA".                                       NC1034.2
+019200 01  IF-D7                              PICTURE IS S9(6)V9(4)     NC1034.2
+019300     VALUE IS +123.45.                                            NC1034.2
+019400 01  IF-D8                              PICTURE IS 9(6)V9(4)      NC1034.2
+019500     VALUE IS 12300.                                              NC1034.2
+019600 01  IF-D9                              PICTURE IS X(3)           NC1034.2
+019700     VALUE IS "123".                                              NC1034.2
+019800 01  IF-D11                             PICTURE IS X(6)           NC1034.2
+019900     VALUE IS "ABCDEF".                                           NC1034.2
+020000 01  IF-D13                             PICTURE IS 9(6)V9(4)      NC1034.2
+020100     VALUE IS 12300.                                              NC1034.2
+020200 01  IF-D14                             PICTURE IS S9(4)V9(2)     NC1034.2
+020300     VALUE IS +123.45.                                            NC1034.2
+020400 01  IF-D15                             PICTURE IS S999PP         NC1034.2
+020500     VALUE IS 12300.                                              NC1034.2
+020600 01  IF-D16                             PICTURE IS PP99           NC1034.2
+020700     VALUE IS .0012.                                              NC1034.2
+020800 01  IF-D17                             PICTURE IS SV9(4)         NC1034.2
+020900     VALUE IS .0012.                                              NC1034.2
+021000 01  IF-D18                             PICTURE IS X(10)          NC1034.2
+021100     VALUE IS "BABABABABA".                                       NC1034.2
+021200 01  IF-D19                             PICTURE IS X(10)          NC1034.2
+021300     VALUE IS "ABCDEF    ".                                       NC1034.2
+021400 01  IF-D23                             PICTURE IS $9,9B9.90+.    NC1034.2
+021500 01  IF-D24                             PICTURE IS X(10)          NC1034.2
+021600     VALUE IS "$1,2 3.40+".                                       NC1034.2
+021700 01  IF-D25                             PICTURE IS ABABX0A.       NC1034.2
+021800 01  IF-D26  PIC X(7)                                             NC1034.2
+021900     VALUE IS "A C D0E".                                          NC1034.2
+022000 01  IF-D27             PICTURE 9(6)V9(4)  VALUE 2137.45          NC1034.2
+022100     USAGE IS COMPUTATIONAL.                                      NC1034.2
+022200 01  IF-D28                             PICTURE IS 999999V9999    NC1034.2
+022300     VALUE IS 2137.45.                                            NC1034.2
+022400 01  IF-D32                             PICTURE IS 9 VALUE IS 0.  NC1034.2
+022500 01  IF-D33 PICTURE S9 VALUE -0.                                  NC1034.2
+022600 01  IF-D34 PICTURE S9 VALUE +0.                                  NC1034.2
+022700 01  IF-D37             PICTURE 9(5)  VALUE 0001234.              NC1034.2
+022800 01  IF-D38             PICTURE X(20) VALUE " BABBAGE".           NC1034.2
+022900 01  ALPHA-UPPER        PIC X(20)     VALUE " UPPERCASE CHARS".   NC1034.2
+023000 01  ALPHA-LOWER        PIC X(20)     VALUE " lowercase chars".   NC1034.2
+023100 01  NON-COBOL-CHARACTERS  PICTURE X(8) VALUE                     NC1034.2
+023200     "XXXXX081".                                                  NC1034.2
+023300 01  AZERO-DS-05V05              PICTURE S9(5)V9(5) VALUE ZERO.   NC1034.2
+023400 01  A18ONES-DS-18V00            PICTURE S9(18)                   NC1034.2
+023500                                 VALUE 111111111111111111.        NC1034.2
+023600 01  ONES-XN-00018               PICTURE X(18)                    NC1034.2
+023700     VALUE "111111111111111111".                                  NC1034.2
+023800 01  A99-DS-02V00                PICTURE S99  VALUE 99.           NC1034.2
+023900 01  WRK-DU-02V00                PICTURE 99.                      NC1034.2
+024000 01  TWOS-XN-00002               PICTURE XX   VALUE "22".         NC1034.2
+024100 01  A18ONES-DS-09V09            PICTURE S9(9)V9(9)               NC1034.2
+024200                                 VALUE 111111111.111111111.       NC1034.2
+024300 01  ONES-XN-00002               PICTURE XX   VALUE "11".         NC1034.2
+024400 01  A02TWOS-DU-02V00            PICTURE 99   VALUE 22.           NC1034.2
+024500 01  A01ONE-DS-P0801             PICTURE SP(8)9 VALUE .000000001. NC1034.2
+024600 01  A990-DS-0201P               PICTURE S99P  VALUE +990.        NC1034.2
+024700 01  XDATA-XN-00018              PICTURE X(18)                    NC1034.2
+024800                                 VALUE "00ABCDEFGHI  4321 ".      NC1034.2
+024900 01  XDATA-DS-18V00-S REDEFINES XDATA-XN-00018 PICTURE S9(18).    NC1034.2
+025000 01  YADATA-XN-00010             PICTURE X(10) VALUE "ABCDEFGHIJ".NC1034.2
+025100 01  YADATA-XN-00010-U-AND-L     PICTURE X(10) VALUE "AbCdEfGhIj".NC1034.2
+025200 01  DUMMY-DS-00001     PICTURE S9 VALUE -1.                      NC1034.2
+025300 01  A02TWOS-DS-03V02            PICTURE S999V99  VALUE +022.00.  NC1034.2
+025400 01  WRK-DS-18V0-1               PIC S9(18)     VALUE             NC1034.2
+025500            -123456789012345678.                                  NC1034.2
+025600 01  WRK-XN-18-2                 PIC  X(18)     VALUE             NC1034.2
+025700            "123456789012345678".                                 NC1034.2
+025800                                                                  NC1034.2
+025900 01  IF-D10.                                                      NC1034.2
+026000     02 FILLER          PICTURE XX VALUE "01".                    NC1034.2
+026100     02 FILLER          PICTURE XX VALUE "23".                    NC1034.2
+026200     02 IF-D10A.                                                  NC1034.2
+026300       03 FILLER        PICTURE XXXX VALUE "4567".                NC1034.2
+026400       03 FILLER        PICTURE XXXX VALUE "8912".                NC1034.2
+026500 01  IF-D12.                                                      NC1034.2
+026600     02 FILLER          PICTURE XXX VALUE "ABC".                  NC1034.2
+026700     02 IF-D12A.                                                  NC1034.2
+026800       03 IF-D12B.                                                NC1034.2
+026900         04 FILLER      PICTURE XX VALUE "DE".                    NC1034.2
+027000         04 FILLER      PICTURE X  VALUE "F".                     NC1034.2
+027100 01  IF-D20.                                                      NC1034.2
+027200     02 FILLER          PICTURE 9(5) VALUE ZERO.                  NC1034.2
+027300     02 FILLER          PICTURE 99   VALUE 12.                    NC1034.2
+027400     02 FILLER          PICTURE 9    VALUE 3.                     NC1034.2
+027500     02 FILLER          PICTURE 99   VALUE 45.                    NC1034.2
+027600 01  IF-D21.                                                      NC1034.2
+027700     02 FILLER          PICTURE 9(5) VALUE ZERO.                  NC1034.2
+027800     02 FILLER          PICTURE 9(5) VALUE 12345.                 NC1034.2
+027900 01  IF-D22.                                                      NC1034.2
+028000     02 FILLER          PICTURE AA   VALUE "AB".                  NC1034.2
+028100     02 FILLER          PICTURE AAAA VALUE "CDEF".                NC1034.2
+028200 01  IF-D35.                                                      NC1034.2
+028300     02 IF-D35A                             VALUE "*ASTERISK".    NC1034.2
+028400       03 FILLER        PICTURE A(6).                             NC1034.2
+028500       03 FILLER        PICTURE AAA.                              NC1034.2
+028600     02 IF-D35B                            VALUE "/SLASH".        NC1034.2
+028700       03 FILLER        PICTURE 9(6).                             NC1034.2
+028800 01  IF-D36 REDEFINES IF-D35.                                     NC1034.2
+028900     02 IF-D36A         PICTURE X(6).                             NC1034.2
+029000     02 IF-D36B         PICTURE XXX.                              NC1034.2
+029100     02 IF-D36C         PICTURE X(6).                             NC1034.2
+029200 01  IF-D39.                                                      NC1034.2
+029300     02  FILLER   PICTURE A(6) VALUE "ABCDEF".                    NC1034.2
+029400     02  FILLER  PICTURE A(4) VALUE SPACE.                        NC1034.2
+029500 01  LEVEL-01.                                                    NC1034.2
+029600     02 LEVEL-02.                                                 NC1034.2
+029700     03 LEVEL-03.                                                 NC1034.2
+029800     04 LEVEL-04.                                                 NC1034.2
+029900     05 LEVEL-05.                                                 NC1034.2
+030000     06 LEVEL-06.                                                 NC1034.2
+030100     07 LEVEL-07.                                                 NC1034.2
+030200     08 LEVEL-08.                                                 NC1034.2
+030300     09 LEVEL-09.                                                 NC1034.2
+030400     10 LEVEL-10                        PICTURE IS X VALUE IS "R".NC1034.2
+030500 01  LEVEL-RECEIVER                     PICTURE IS X VALUE IS     NC1034.2
+030600     SPACE.                                                       NC1034.2
+030700 01  LEVEL-SENDER PICTURE X VALUE "S".                            NC1034.2
+030800 01  VAL                                PICTURE IS 9 VALUE IS 0.  NC1034.2
+030900 01  A-2                                PICTURE IS A VALUE IS "A".NC1034.2
+031000 01  N-27                               PICTURE IS 9999V9         NC1034.2
+031100     VALUE IS 9999.9.                                             NC1034.2
+031200 01  N-30                               PICTURE IS 9V9            NC1034.2
+031300     VALUE IS 2.                                                  NC1034.2
+031400 01  N-31                               PICTURE IS 9(6).          NC1034.2
+031500 01  X-32 REDEFINES N-31                PICTURE IS X(6).          NC1034.2
+031600 01  N-33                               PICTURE IS 9(5)           NC1034.2
+031700     VALUE IS 29.                                                 NC1034.2
+031800 01  A-37                               PICTURE IS A VALUE IS "X".NC1034.2
+031900 01  X-38 REDEFINES A-37                PICTURE IS X.             NC1034.2
+032000 01  X-43 PIC X(10) VALUE "    l75.63".                           NC1034.2
+032100 01  N-84                               PICTURE IS 9999999999.    NC1034.2
+032200 01  NUMERIC-GRP-TEST.                                            NC1034.2
+032300     02  NUMERIC-1                PICTURE 9 VALUE 0.              NC1034.2
+032400     02  NUMERIC-2.                                               NC1034.2
+032500         03  NUMERIC-3            PICTURE 9(1)V9(1) VALUE ZERO.   NC1034.2
+032600         03  NUMERIC-4.                                           NC1034.2
+032700             04  NUMERIC-5       PICTURE 9(18) VALUE 1.           NC1034.2
+032800     02  NUMERIC-6.                                               NC1034.2
+032900         03  NUMERIC-7            PICTURE X VALUE "7".            NC1034.2
+033000         03  NUMERIC-8            PICTURE 9  VALUE 8.             NC1034.2
+033100 01  NUM-GRP.                                                     NC1034.2
+033200     02  NUM-SUB-GRP  PIC 9.                                      NC1034.2
+033300 01  GROUP-1000.                                                  NC1034.2
+033400     02  FILLER  PIC X.                                           NC1034.2
+033500     02  GROUP-X1000.                                             NC1034.2
+033600         03  GROUP-1000-1 PIC X(500) VALUE ZERO.                  NC1034.2
+033700         03  XNAME        PICTURE X(100) VALUE QUOTE.             NC1034.2
+033800         03  GROUP-1000-2 PICTURE X(399) VALUE SPACE.             NC1034.2
+033900         03  GROUP-1000-3 PICTURE X VALUE ".".                    NC1034.2
+034000     02  GROUP-X500-2.                                            NC1034.2
+034100         03  GROUP-X500-A        PICTURE X(500) VALUE ZERO.       NC1034.2
+034200         03  GROUP-X500-1.                                        NC1034.2
+034300             04  GROUP-X500-1-1  PICTURE X(50) VALUE QUOTE.       NC1034.2
+034400             04  GROUP-X500-1-2  PICTURE X(50) VALUE QUOTE.       NC1034.2
+034500             04  GROUP-X500-1-3  PICTURE X(398) VALUE SPACE.      NC1034.2
+034600             04  GROUP-X500-1-4  PICTURE XX VALUE " .".           NC1034.2
+034700 01  HI-LO-VALUES.                                                NC1034.2
+034800     02  LOW-VAL  PIC X VALUE LOW-VALUE.                          NC1034.2
+034900     02 ZERO-01  PICTURE 9(18) VALUE 1.                           NC1034.2
+035000     02  ABC      PICTURE XXX VALUE "ABC".                        NC1034.2
+035100     02  NINE-17-8 PICTURE 9(18) VALUE 999999999999999998.        NC1034.2
+035200     02  ZERO-NULL PIC 9(9) VALUE 0.                              NC1034.2
+035300     02  ZERO-ZERO PICTURE 9(9)V9(9) VALUE 0.0.                   NC1034.2
+035400 01  COMP-DATA.                                                   NC1034.2
+035500     02  COMP-DATA1 PICTURE 9(18) COMPUTATIONAL VALUE 300.        NC1034.2
+035600     02  COMP-DATA2  PICTURE 9(10) COMPUTATIONAL VALUE  100000.   NC1034.2
+035700     02  COMP-DATA3  PICTURE 9     COMPUTATIONAL VALUE 9.         NC1034.2
+035800     02  COMP-DATA4  PICTURE 9(9)V9(7) COMPUTATIONAL VALUE 3.3.   NC1034.2
+035900     02  COMP-DATA5  PICTURE 9(5)V9(2) COMPUTATIONAL VALUE 52.25. NC1034.2
+036000     02  COMP-DATA6  PICTURE 9V9       COMPUTATIONAL VALUE 8.8.   NC1034.2
+036100     02  COMP-DATA7  PICTURE 9(3)V9(2) COMPUTATIONAL VALUE 300.00.NC1034.2
+036200     02  COMP-DATA8  PICTURE 9V9(9) COMPUTATIONAL VALUE 3.3000000.NC1034.2
+036300     02  COMP-DATA9  PICTURE 9(8)  COMPUTATIONAL VALUE 100000.    NC1034.2
+036400 01  DISP-DATA.                                                   NC1034.2
+036500     02  DISP-DATA1  PICTURE 9(18) VALUE 300.                     NC1034.2
+036600     02  DISP-DATA2  PICTURE 9(8)  VALUE 100000.                  NC1034.2
+036700     02  DISP-DATA3  PICTURE 9     VALUE 9.                       NC1034.2
+036800     02  DISP-DATA4  PICTURE 9(7)V9(9) VALUE 3.3.                 NC1034.2
+036900     02  DISP-DATA5  PICTURE 9(2)V9(2) VALUE 52.25.               NC1034.2
+037000     02  DISP-DATA6  PICTURE 9V9   VALUE 8.8.                     NC1034.2
+037100 PROCEDURE DIVISION.                                              NC1034.2
+037200 CCVS1 SECTION.                                                   NC1034.2
+037300 OPEN-FILES.                                                      NC1034.2
+037400     OPEN     OUTPUT PRINT-FILE.                                  NC1034.2
+037500     MOVE CCVS-PGM-ID TO TEST-ID. MOVE CCVS-PGM-ID TO ID-AGAIN.   NC1034.2
+037600     MOVE    SPACE TO TEST-RESULTS.                               NC1034.2
+037700     PERFORM  HEAD-ROUTINE THRU COLUMN-NAMES-ROUTINE.             NC1034.2
+037800     GO TO CCVS1-EXIT.                                            NC1034.2
+037900 CLOSE-FILES.                                                     NC1034.2
+038000     PERFORM END-ROUTINE THRU END-ROUTINE-13. CLOSE PRINT-FILE.   NC1034.2
+038100 TERMINATE-CCVS.                                                  NC1034.2
+038200S    EXIT PROGRAM.                                                NC1034.2
+038300STERMINATE-CALL.                                                  NC1034.2
+038400     STOP     RUN.                                                NC1034.2
+038500 INSPT. MOVE "INSPT" TO P-OR-F. ADD 1 TO INSPECT-COUNTER.         NC1034.2
+038600 PASS.  MOVE "PASS " TO P-OR-F.  ADD 1 TO PASS-COUNTER.           NC1034.2
+038700 FAIL.  MOVE "FAIL*" TO P-OR-F.  ADD 1 TO ERROR-COUNTER.          NC1034.2
+038800 DE-LETE.  MOVE "*****" TO P-OR-F.  ADD 1 TO DELETE-COUNTER.      NC1034.2
+038900     MOVE "****TEST DELETED****" TO RE-MARK.                      NC1034.2
+039000 PRINT-DETAIL.                                                    NC1034.2
+039100     IF REC-CT NOT EQUAL TO ZERO                                  NC1034.2
+039200             MOVE "." TO PARDOT-X                                 NC1034.2
+039300             MOVE REC-CT TO DOTVALUE.                             NC1034.2
+039400     MOVE     TEST-RESULTS TO PRINT-REC. PERFORM WRITE-LINE.      NC1034.2
+039500     IF P-OR-F EQUAL TO "FAIL*"  PERFORM WRITE-LINE               NC1034.2
+039600        PERFORM FAIL-ROUTINE THRU FAIL-ROUTINE-EX                 NC1034.2
+039700          ELSE PERFORM BAIL-OUT THRU BAIL-OUT-EX.                 NC1034.2
+039800     MOVE SPACE TO P-OR-F. MOVE SPACE TO COMPUTED-X.              NC1034.2
+039900     MOVE SPACE TO CORRECT-X.                                     NC1034.2
+040000     IF     REC-CT EQUAL TO ZERO  MOVE SPACE TO PAR-NAME.         NC1034.2
+040100     MOVE     SPACE TO RE-MARK.                                   NC1034.2
+040200 HEAD-ROUTINE.                                                    NC1034.2
+040300     MOVE CCVS-H-1  TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  NC1034.2
+040400     MOVE CCVS-H-2A TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.  NC1034.2
+040500     MOVE CCVS-H-2B TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  NC1034.2
+040600     MOVE CCVS-H-3  TO DUMMY-RECORD. PERFORM WRITE-LINE 3 TIMES.  NC1034.2
+040700 COLUMN-NAMES-ROUTINE.                                            NC1034.2
+040800     MOVE CCVS-C-1 TO DUMMY-RECORD. PERFORM WRITE-LINE.           NC1034.2
+040900     MOVE CCVS-C-2 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   NC1034.2
+041000     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE.        NC1034.2
+041100 END-ROUTINE.                                                     NC1034.2
+041200     MOVE HYPHEN-LINE TO DUMMY-RECORD. PERFORM WRITE-LINE 5 TIMES.NC1034.2
+041300 END-RTN-EXIT.                                                    NC1034.2
+041400     MOVE CCVS-E-1 TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   NC1034.2
+041500 END-ROUTINE-1.                                                   NC1034.2
+041600      ADD ERROR-COUNTER TO ERROR-HOLD ADD INSPECT-COUNTER TO      NC1034.2
+041700      ERROR-HOLD. ADD DELETE-COUNTER TO ERROR-HOLD.               NC1034.2
+041800      ADD PASS-COUNTER TO ERROR-HOLD.                             NC1034.2
+041900*     IF PASS-COUNTER EQUAL TO ERROR-HOLD GO TO END-ROUTINE-12.   NC1034.2
+042000      MOVE PASS-COUNTER TO CCVS-E-4-1.                            NC1034.2
+042100      MOVE ERROR-HOLD TO CCVS-E-4-2.                              NC1034.2
+042200      MOVE CCVS-E-4 TO CCVS-E-2-2.                                NC1034.2
+042300      MOVE CCVS-E-2 TO DUMMY-RECORD PERFORM WRITE-LINE.           NC1034.2
+042400  END-ROUTINE-12.                                                 NC1034.2
+042500      MOVE "TEST(S) FAILED" TO ENDER-DESC.                        NC1034.2
+042600     IF       ERROR-COUNTER IS EQUAL TO ZERO                      NC1034.2
+042700         MOVE "NO " TO ERROR-TOTAL                                NC1034.2
+042800         ELSE                                                     NC1034.2
+042900         MOVE ERROR-COUNTER TO ERROR-TOTAL.                       NC1034.2
+043000     MOVE     CCVS-E-2 TO DUMMY-RECORD.                           NC1034.2
+043100     PERFORM WRITE-LINE.                                          NC1034.2
+043200 END-ROUTINE-13.                                                  NC1034.2
+043300     IF DELETE-COUNTER IS EQUAL TO ZERO                           NC1034.2
+043400         MOVE "NO " TO ERROR-TOTAL  ELSE                          NC1034.2
+043500         MOVE DELETE-COUNTER TO ERROR-TOTAL.                      NC1034.2
+043600     MOVE "TEST(S) DELETED     " TO ENDER-DESC.                   NC1034.2
+043700     MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.           NC1034.2
+043800      IF   INSPECT-COUNTER EQUAL TO ZERO                          NC1034.2
+043900          MOVE "NO " TO ERROR-TOTAL                               NC1034.2
+044000      ELSE MOVE INSPECT-COUNTER TO ERROR-TOTAL.                   NC1034.2
+044100      MOVE "TEST(S) REQUIRE INSPECTION" TO ENDER-DESC.            NC1034.2
+044200      MOVE CCVS-E-2 TO DUMMY-RECORD. PERFORM WRITE-LINE.          NC1034.2
+044300     MOVE CCVS-E-3 TO DUMMY-RECORD. PERFORM WRITE-LINE.           NC1034.2
+044400 WRITE-LINE.                                                      NC1034.2
+044500     ADD 1 TO RECORD-COUNT.                                       NC1034.2
+044600Y    IF RECORD-COUNT GREATER 42                                   NC1034.2
+044700Y        MOVE DUMMY-RECORD TO DUMMY-HOLD                          NC1034.2
+044800Y        MOVE SPACE TO DUMMY-RECORD                               NC1034.2
+044900Y        WRITE DUMMY-RECORD AFTER ADVANCING PAGE                  NC1034.2
+045000Y        MOVE CCVS-H-1  TO DUMMY-RECORD  PERFORM WRT-LN 2 TIMES   NC1034.2
+045100Y        MOVE CCVS-H-2A TO DUMMY-RECORD  PERFORM WRT-LN 2 TIMES   NC1034.2
+045200Y        MOVE CCVS-H-2B TO DUMMY-RECORD  PERFORM WRT-LN 3 TIMES   NC1034.2
+045300Y        MOVE CCVS-H-3  TO DUMMY-RECORD  PERFORM WRT-LN 3 TIMES   NC1034.2
+045400Y        MOVE CCVS-C-1  TO DUMMY-RECORD  PERFORM WRT-LN           NC1034.2
+045500Y        MOVE CCVS-C-2  TO DUMMY-RECORD  PERFORM WRT-LN           NC1034.2
+045600Y        MOVE HYPHEN-LINE TO DUMMY-RECORD PERFORM WRT-LN          NC1034.2
+045700Y        MOVE DUMMY-HOLD TO DUMMY-RECORD                          NC1034.2
+045800Y        MOVE ZERO TO RECORD-COUNT.                               NC1034.2
+045900     PERFORM WRT-LN.                                              NC1034.2
+046000 WRT-LN.                                                          NC1034.2
+046100     WRITE    DUMMY-RECORD AFTER ADVANCING 1 LINES.               NC1034.2
+046200     MOVE SPACE TO DUMMY-RECORD.                                  NC1034.2
+046300 BLANK-LINE-PRINT.                                                NC1034.2
+046400     PERFORM WRT-LN.                                              NC1034.2
+046500 FAIL-ROUTINE.                                                    NC1034.2
+046600     IF     COMPUTED-X NOT EQUAL TO SPACE                         NC1034.2
+046700            GO TO FAIL-ROUTINE-WRITE.                             NC1034.2
+046800     IF     CORRECT-X NOT EQUAL TO SPACE GO TO FAIL-ROUTINE-WRITE.NC1034.2
+046900     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 NC1034.2
+047000     MOVE  "NO FURTHER INFORMATION, SEE PROGRAM." TO INFO-TEXT.   NC1034.2
+047100     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   NC1034.2
+047200     MOVE   SPACES TO INF-ANSI-REFERENCE.                         NC1034.2
+047300     GO TO  FAIL-ROUTINE-EX.                                      NC1034.2
+047400 FAIL-ROUTINE-WRITE.                                              NC1034.2
+047500     MOVE   TEST-COMPUTED TO PRINT-REC PERFORM WRITE-LINE         NC1034.2
+047600     MOVE   ANSI-REFERENCE TO COR-ANSI-REFERENCE.                 NC1034.2
+047700     MOVE   TEST-CORRECT TO PRINT-REC PERFORM WRITE-LINE 2 TIMES. NC1034.2
+047800     MOVE   SPACES TO COR-ANSI-REFERENCE.                         NC1034.2
+047900 FAIL-ROUTINE-EX. EXIT.                                           NC1034.2
+048000 BAIL-OUT.                                                        NC1034.2
+048100     IF     COMPUTED-A NOT EQUAL TO SPACE GO TO BAIL-OUT-WRITE.   NC1034.2
+048200     IF     CORRECT-A EQUAL TO SPACE GO TO BAIL-OUT-EX.           NC1034.2
+048300 BAIL-OUT-WRITE.                                                  NC1034.2
+048400     MOVE CORRECT-A TO XXCORRECT. MOVE COMPUTED-A TO XXCOMPUTED.  NC1034.2
+048500     MOVE   ANSI-REFERENCE TO INF-ANSI-REFERENCE.                 NC1034.2
+048600     MOVE   XXINFO TO DUMMY-RECORD. PERFORM WRITE-LINE 2 TIMES.   NC1034.2
+048700     MOVE   SPACES TO INF-ANSI-REFERENCE.                         NC1034.2
+048800 BAIL-OUT-EX. EXIT.                                               NC1034.2
+048900 CCVS1-EXIT.                                                      NC1034.2
+049000     EXIT.                                                        NC1034.2
+049100 SECT-NC103A-001 SECTION.                                         NC1034.2
+049200 NC-03-001.                                                       NC1034.2
+049300     MOVE "THE FOLLOWING TESTS        " TO RE-MARK.               NC1034.2
+049400     PERFORM  PRINT-DETAIL.                                       NC1034.2
+049500     MOVE "COMPARE NUMERIC, ALPHA-    " TO RE-MARK.               NC1034.2
+049600     PERFORM  PRINT-DETAIL.                                       NC1034.2
+049700     MOVE "NUMERIC, ALPHABETIC, AND   " TO RE-MARK.               NC1034.2
+049800     PERFORM  PRINT-DETAIL.                                       NC1034.2
+049900     MOVE  "GROUP ITEMS IN VARYING     " TO RE-MARK.              NC1034.2
+050000     PERFORM PRINT-DETAIL.                                        NC1034.2
+050100     MOVE  "COMBINATIONS.              " TO RE-MARK.              NC1034.2
+050200     PERFORM PRINT-DETAIL.                                        NC1034.2
+050300     MOVE    SPACE TO TEST-RESULTS.                               NC1034.2
+050400 IF--INIT-GF-1.                                                   NC1034.2
+050500     MOVE  "COMPARE--EQUAL" TO FEATURE.                           NC1034.2
+050600     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+050700     MOVE   0 TO IF-D1.                                           NC1034.2
+050800 IF--TEST-GF-1.                                                   NC1034.2
+050900     IF      ZERO IS EQUAL TO IF-D1                               NC1034.2
+051000             PERFORM PASS                                         NC1034.2
+051100     ELSE                                                         NC1034.2
+051200             PERFORM FAIL.                                        NC1034.2
+051300     GO TO   IF--WRITE-GF-1.                                      NC1034.2
+051400 IF--DELETE-GF-1.                                                 NC1034.2
+051500     PERFORM DE-LETE.                                             NC1034.2
+051600 IF--WRITE-GF-1.                                                  NC1034.2
+051700     MOVE  "IF--TEST-GF-1 " TO PAR-NAME.                          NC1034.2
+051800     PERFORM PRINT-DETAIL.                                        NC1034.2
+051900 IF--INIT-GF-2.                                                   NC1034.2
+052000     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+052100     MOVE   ZERO TO IF-D2.                                        NC1034.2
+052200 IF--TEST-GF-2.                                                   NC1034.2
+052300     IF      ZERO IS EQUAL TO IF-D2                               NC1034.2
+052400             PERFORM PASS                                         NC1034.2
+052500     ELSE                                                         NC1034.2
+052600             PERFORM FAIL.                                        NC1034.2
+052700     GO TO   IF--WRITE-GF-2.                                      NC1034.2
+052800 IF--DELETE-GF-2.                                                 NC1034.2
+052900     PERFORM DE-LETE.                                             NC1034.2
+053000 IF--WRITE-GF-2.                                                  NC1034.2
+053100     MOVE "IF--TEST-GF-2 " TO PAR-NAME.                           NC1034.2
+053200     PERFORM PRINT-DETAIL.                                        NC1034.2
+053300 IF--INIT-GF-3.                                                   NC1034.2
+053400     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+053500     MOVE   "123" TO IF-D9.                                       NC1034.2
+053600 IF--TEST-GF-3.                                                   NC1034.2
+053700     IF      IF-D9 EQUAL TO 123                                   NC1034.2
+053800             PERFORM PASS                                         NC1034.2
+053900     ELSE                                                         NC1034.2
+054000             PERFORM FAIL.                                        NC1034.2
+054100     GO TO   IF--WRITE-GF-3.                                      NC1034.2
+054200 IF--DELETE-GF-3.                                                 NC1034.2
+054300     PERFORM DE-LETE.                                             NC1034.2
+054400 IF--WRITE-GF-3.                                                  NC1034.2
+054500     MOVE  "IF--TEST-GF-3 " TO PAR-NAME.                          NC1034.2
+054600     PERFORM PRINT-DETAIL.                                        NC1034.2
+054700 IF--INIT-GF-4.                                                   NC1034.2
+054800     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+054900     MOVE   "012345678912" TO IF-D10.                             NC1034.2
+055000 IF--TEST-GF-4.                                                   NC1034.2
+055100     IF      IF-D10 EQUAL TO 012345678912                         NC1034.2
+055200             PERFORM PASS                                         NC1034.2
+055300     ELSE                                                         NC1034.2
+055400             PERFORM FAIL.                                        NC1034.2
+055500     GO TO   IF--WRITE-GF-4.                                      NC1034.2
+055600 IF--DELETE-GF-4.                                                 NC1034.2
+055700     PERFORM DE-LETE.                                             NC1034.2
+055800 IF--WRITE-GF-4.                                                  NC1034.2
+055900     MOVE  "IF--TEST-GF-4 " TO PAR-NAME.                          NC1034.2
+056000     PERFORM PRINT-DETAIL.                                        NC1034.2
+056100 IF--INIT-GF-5.                                                   NC1034.2
+056200     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+056300     MOVE   "ABCDEF" TO IF-D11.                                   NC1034.2
+056400 IF--TEST-GF-5.                                                   NC1034.2
+056500     IF      IF-D11 EQUAL TO "ABCDEF"                             NC1034.2
+056600             PERFORM PASS                                         NC1034.2
+056700     ELSE                                                         NC1034.2
+056800             PERFORM FAIL.                                        NC1034.2
+056900     GO TO    IF--WRITE-GF-5.                                     NC1034.2
+057000 IF--DELETE-GF-5.                                                 NC1034.2
+057100     PERFORM  DE-LETE.                                            NC1034.2
+057200 IF--WRITE-GF-5.                                                  NC1034.2
+057300     MOVE "IF--TEST-GF-5 " TO PAR-NAME.                           NC1034.2
+057400     PERFORM  PRINT-DETAIL.                                       NC1034.2
+057500 IF--INIT-GF-6.                                                   NC1034.2
+057600     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+057700     MOVE   "ABCDEF" TO IF-D12.                                   NC1034.2
+057800 IF--TEST-GF-6.                                                   NC1034.2
+057900     IF       IF-D12 EQUAL TO "ABCDEF"                            NC1034.2
+058000              PERFORM PASS                                        NC1034.2
+058100     ELSE                                                         NC1034.2
+058200              PERFORM FAIL.                                       NC1034.2
+058300     GO TO    IF--WRITE-GF-6.                                     NC1034.2
+058400 IF--DELETE-GF-6.                                                 NC1034.2
+058500     PERFORM  DE-LETE.                                            NC1034.2
+058600 IF--WRITE-GF-6.                                                  NC1034.2
+058700     MOVE "IF--TEST-GF-6 " TO PAR-NAME.                           NC1034.2
+058800     PERFORM  PRINT-DETAIL.                                       NC1034.2
+058900 IF--INIT-GF-7.                                                   NC1034.2
+059000     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+059100     MOVE   +123.45 TO IF-D7.                                     NC1034.2
+059200 IF--TEST-GF-7.                                                   NC1034.2
+059300     IF       IF-D7 EQUAL TO +123.45                              NC1034.2
+059400              PERFORM PASS                                        NC1034.2
+059500              ELSE                                                NC1034.2
+059600              PERFORM FAIL.                                       NC1034.2
+059700     GO TO    IF--WRITE-GF-7.                                     NC1034.2
+059800 IF--DELETE-GF-7.                                                 NC1034.2
+059900     PERFORM  DE-LETE.                                            NC1034.2
+060000 IF--WRITE-GF-7.                                                  NC1034.2
+060100     MOVE "IF--TEST-GF-7 " TO PAR-NAME.                           NC1034.2
+060200     PERFORM  PRINT-DETAIL.                                       NC1034.2
+060300 IF--INIT-GF-8.                                                   NC1034.2
+060400     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+060500     MOVE    12300 TO IF-D8.                                      NC1034.2
+060600 IF--TEST-GF-8.                                                   NC1034.2
+060700     IF       IF-D8 EQUAL TO 12300                                NC1034.2
+060800              PERFORM PASS                                        NC1034.2
+060900              ELSE                                                NC1034.2
+061000              PERFORM FAIL.                                       NC1034.2
+061100     GO TO    IF--WRITE-GF-8.                                     NC1034.2
+061200 IF--DELETE-GF-8.                                                 NC1034.2
+061300     PERFORM  DE-LETE.                                            NC1034.2
+061400 IF--WRITE-GF-8.                                                  NC1034.2
+061500     MOVE "IF--TEST-GF-8 " TO PAR-NAME.                           NC1034.2
+061600     PERFORM  PRINT-DETAIL.                                       NC1034.2
+061700 IF--INIT-GF-9.                                                   NC1034.2
+061800     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+061900     MOVE    12300 TO IF-D8.                                      NC1034.2
+062000     MOVE    12300 TO IF-D13.                                     NC1034.2
+062100 IF--TEST-GF-9.                                                   NC1034.2
+062200     IF       IF-D13 EQUAL TO IF-D8                               NC1034.2
+062300              PERFORM PASS                                        NC1034.2
+062400              ELSE                                                NC1034.2
+062500              PERFORM FAIL.                                       NC1034.2
+062600     GO TO    IF--WRITE-GF-9.                                     NC1034.2
+062700 IF--DELETE-GF-9.                                                 NC1034.2
+062800     PERFORM  DE-LETE.                                            NC1034.2
+062900 IF--WRITE-GF-9.                                                  NC1034.2
+063000     MOVE "IF--TEST-GF-9 " TO PAR-NAME.                           NC1034.2
+063100     PERFORM  PRINT-DETAIL.                                       NC1034.2
+063200 IF--INIT-GF-10.                                                  NC1034.2
+063300     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+063400     MOVE    .0012 TO IF-D16.                                     NC1034.2
+063500     MOVE    .0012 TO IF-D17.                                     NC1034.2
+063600 IF--TEST-GF-10.                                                  NC1034.2
+063700     IF       IF-D16 EQUAL TO IF-D17                              NC1034.2
+063800              PERFORM PASS                                        NC1034.2
+063900              ELSE                                                NC1034.2
+064000              PERFORM FAIL.                                       NC1034.2
+064100     GO TO    IF--WRITE-GF-10.                                    NC1034.2
+064200 IF--DELETE-GF-10.                                                NC1034.2
+064300     PERFORM  DE-LETE.                                            NC1034.2
+064400 IF--WRITE-GF-10.                                                 NC1034.2
+064500     MOVE "IF--TEST-GF-10" TO PAR-NAME.                           NC1034.2
+064600     PERFORM  PRINT-DETAIL.                                       NC1034.2
+064700 IF--INIT-GF-11.                                                  NC1034.2
+064800     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+064900     MOVE    2137.45 TO IF-D27.                                   NC1034.2
+065000     MOVE    2137.45 TO IF-D28.                                   NC1034.2
+065100 IF--TEST-GF-11.                                                  NC1034.2
+065200     IF       IF-D27 EQUAL TO IF-D28                              NC1034.2
+065300              PERFORM PASS ELSE PERFORM FAIL.                     NC1034.2
+065400     GO       TO IF-WRITE-GF-11.                                  NC1034.2
+065500 IF-DELETE-GF-11.                                                 NC1034.2
+065600     PERFORM  DE-LETE.                                            NC1034.2
+065700 IF-WRITE-GF-11.                                                  NC1034.2
+065800     MOVE "IF--TEST-GF-11" TO PAR-NAME.                           NC1034.2
+065900     PERFORM  PRINT-DETAIL.                                       NC1034.2
+066000 IF--INIT-GF-12.                                                  NC1034.2
+066100     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+066200     MOVE   +123.45 TO IF-D14.                                    NC1034.2
+066300     MOVE   +123.45 TO IF-D7.                                     NC1034.2
+066400 IF--TEST-GF-12.                                                  NC1034.2
+066500     IF       IF-D14 EQUAL TO IF-D7                               NC1034.2
+066600              PERFORM PASS                                        NC1034.2
+066700              ELSE                                                NC1034.2
+066800              PERFORM FAIL.                                       NC1034.2
+066900     GO TO    IF--WRITE-GF-12.                                    NC1034.2
+067000 IF--DELETE-GF-12.                                                NC1034.2
+067100     PERFORM  DE-LETE.                                            NC1034.2
+067200 IF--WRITE-GF-12.                                                 NC1034.2
+067300     MOVE "IF--TEST-GF-12" TO PAR-NAME.                           NC1034.2
+067400     PERFORM  PRINT-DETAIL.                                       NC1034.2
+067500 IF--INIT-GF-13.                                                  NC1034.2
+067600     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+067700     MOVE    12300  TO IF-D15.                                    NC1034.2
+067800     MOVE    12300  TO IF-D8.                                     NC1034.2
+067900 IF--TEST-GF-13.                                                  NC1034.2
+068000     IF       IF-D15 EQUAL TO IF-D8                               NC1034.2
+068100              PERFORM PASS                                        NC1034.2
+068200              ELSE                                                NC1034.2
+068300              PERFORM FAIL.                                       NC1034.2
+068400     GO TO    IF--WRITE-GF-13.                                    NC1034.2
+068500 IF--DELETE-GF-13.                                                NC1034.2
+068600     PERFORM  DE-LETE.                                            NC1034.2
+068700 IF--WRITE-GF-13.                                                 NC1034.2
+068800     MOVE "IF--TEST-GF-13" TO PAR-NAME.                           NC1034.2
+068900     PERFORM  PRINT-DETAIL.                                       NC1034.2
+069000 IF--INIT-GF-14.                                                  NC1034.2
+069100     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+069200     MOVE    0000012345  TO IF-D20.                               NC1034.2
+069300     MOVE    0000012345  TO IF-D21.                               NC1034.2
+069400 IF--TEST-GF-14.                                                  NC1034.2
+069500     IF       IF-D20 EQUAL TO IF-D21                              NC1034.2
+069600              PERFORM PASS                                        NC1034.2
+069700              ELSE                                                NC1034.2
+069800              PERFORM FAIL.                                       NC1034.2
+069900     GO TO    IF--WRITE-GF-14.                                    NC1034.2
+070000 IF--DELETE-GF-14.                                                NC1034.2
+070100     PERFORM  DE-LETE.                                            NC1034.2
+070200 IF--WRITE-GF-14.                                                 NC1034.2
+070300     MOVE "IF--TEST-GF-14" TO PAR-NAME.                           NC1034.2
+070400     PERFORM  PRINT-DETAIL.                                       NC1034.2
+070500 IF--INIT-GF-15.                                                  NC1034.2
+070600     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+070700     MOVE    "$1,2 3.40+" TO IF-D24.                              NC1034.2
+070800     MOVE     +123.4 TO IF-D23.                                   NC1034.2
+070900 IF--TEST-GF-15.                                                  NC1034.2
+071000     IF       IF-D23 EQUAL TO IF-D24                              NC1034.2
+071100              PERFORM PASS                                        NC1034.2
+071200              ELSE                                                NC1034.2
+071300              PERFORM FAIL.                                       NC1034.2
+071400     GO TO    IF--WRITE-GF-15.                                    NC1034.2
+071500 IF--DELETE-GF-15.                                                NC1034.2
+071600     PERFORM  DE-LETE.                                            NC1034.2
+071700 IF--WRITE-GF-15.                                                 NC1034.2
+071800     MOVE "IF--TEST-GF-15" TO PAR-NAME.                           NC1034.2
+071900     PERFORM  PRINT-DETAIL.                                       NC1034.2
+072000 IF--INIT-GF-16.                                                  NC1034.2
+072100     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+072200     MOVE    "A C D0E" TO IF-D26.                                 NC1034.2
+072300     MOVE    "ACDE" TO IF-D25.                                    NC1034.2
+072400 IF--TEST-GF-16.                                                  NC1034.2
+072500     IF       IF-D25 EQUAL TO IF-D26                              NC1034.2
+072600              PERFORM PASS                                        NC1034.2
+072700              ELSE                                                NC1034.2
+072800              PERFORM FAIL.                                       NC1034.2
+072900     GO TO    IF--WRITE-GF-16.                                    NC1034.2
+073000 IF--DELETE-GF-16.                                                NC1034.2
+073100     PERFORM  DE-LETE.                                            NC1034.2
+073200 IF--WRITE-GF-16.                                                 NC1034.2
+073300     MOVE "IF--TEST-GF-16" TO PAR-NAME.                           NC1034.2
+073400     PERFORM  PRINT-DETAIL.                                       NC1034.2
+073500 IF--INIT-GF-17.                                                  NC1034.2
+073600     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+073700     MOVE    "BABABABABA" TO IF-D6.                               NC1034.2
+073800     MOVE    "BABABABABA" TO IF-D18.                              NC1034.2
+073900 IF--TEST-GF-17.                                                  NC1034.2
+074000     IF       IF-D6 EQUAL TO IF-D18                               NC1034.2
+074100              PERFORM PASS                                        NC1034.2
+074200              ELSE                                                NC1034.2
+074300              PERFORM FAIL.                                       NC1034.2
+074400     GO TO    IF--WRITE-GF-17.                                    NC1034.2
+074500 IF--DELETE-GF-17.                                                NC1034.2
+074600     PERFORM  DE-LETE.                                            NC1034.2
+074700 IF--WRITE-GF-17.                                                 NC1034.2
+074800     MOVE "IF--TEST-GF-17" TO PAR-NAME.                           NC1034.2
+074900     PERFORM  PRINT-DETAIL.                                       NC1034.2
+075000 IF--INIT-GF-18.                                                  NC1034.2
+075100     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+075200     MOVE    "ABCDEF" TO IF-D22.                                  NC1034.2
+075300     MOVE    "ABCDEF" TO IF-D12.                                  NC1034.2
+075400 IF--TEST-GF-18.                                                  NC1034.2
+075500     IF       IF-D22 EQUAL TO IF-D12                              NC1034.2
+075600              PERFORM PASS                                        NC1034.2
+075700              ELSE                                                NC1034.2
+075800              PERFORM FAIL.                                       NC1034.2
+075900     GO TO    IF--WRITE-GF-18.                                    NC1034.2
+076000 IF--DELETE-GF-18.                                                NC1034.2
+076100     PERFORM  DE-LETE.                                            NC1034.2
+076200 IF--WRITE-GF-18.                                                 NC1034.2
+076300     MOVE "IF--TEST-GF-18" TO PAR-NAME.                           NC1034.2
+076400     PERFORM  PRINT-DETAIL.                                       NC1034.2
+076500 IF--INIT-GF-19.                                                  NC1034.2
+076600     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+076700     MOVE    "ABCDEF    " TO IF-D39.                              NC1034.2
+076800     MOVE    "ABCDEF    " TO IF-D19.                              NC1034.2
+076900 IF--TEST-GF-19.                                                  NC1034.2
+077000     IF IF-D39 EQUAL TO IF-D19                                    NC1034.2
+077100              PERFORM PASS                                        NC1034.2
+077200              ELSE                                                NC1034.2
+077300              PERFORM FAIL.                                       NC1034.2
+077400     GO TO    IF--WRITE-GF-19.                                    NC1034.2
+077500 IF--DELETE-GF-19.                                                NC1034.2
+077600     PERFORM  DE-LETE.                                            NC1034.2
+077700 IF--WRITE-GF-19.                                                 NC1034.2
+077800     MOVE "IF--TEST-GF-19" TO PAR-NAME.                           NC1034.2
+077900     PERFORM  PRINT-DETAIL.                                       NC1034.2
+078000 IF--INIT-GF-20.                                                  NC1034.2
+078100     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+078200     MOVE "COMPARE--GREATER" TO FEATURE.                          NC1034.2
+078300     MOVE     0 TO IF-D1.                                         NC1034.2
+078400 IF--TEST-GF-20.                                                  NC1034.2
+078500     IF       IF-D1 IS GREATER THAN ZERO                          NC1034.2
+078600              PERFORM FAIL                                        NC1034.2
+078700              ELSE                                                NC1034.2
+078800              PERFORM PASS.                                       NC1034.2
+078900     GO TO    IF--WRITE-GF-20.                                    NC1034.2
+079000 IF--DELETE-GF-20.                                                NC1034.2
+079100     PERFORM  DE-LETE.                                            NC1034.2
+079200 IF--WRITE-GF-20.                                                 NC1034.2
+079300     MOVE "IF--TEST-GF-20" TO PAR-NAME.                           NC1034.2
+079400     PERFORM  PRINT-DETAIL.                                       NC1034.2
+079500 IF--INIT-GF-21.                                                  NC1034.2
+079600     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+079700     MOVE    "123" TO IF-D9.                                      NC1034.2
+079800 IF--TEST-GF-21.                                                  NC1034.2
+079900     IF       IF-D9 GREATER THAN 123                              NC1034.2
+080000              PERFORM FAIL                                        NC1034.2
+080100              ELSE                                                NC1034.2
+080200              PERFORM PASS.                                       NC1034.2
+080300     GO TO    IF--WRITE-GF-21.                                    NC1034.2
+080400 IF--DELETE-GF-21.                                                NC1034.2
+080500     PERFORM  DE-LETE.                                            NC1034.2
+080600 IF--WRITE-GF-21.                                                 NC1034.2
+080700     MOVE "IF--TEST-GF-21" TO PAR-NAME.                           NC1034.2
+080800     PERFORM  PRINT-DETAIL.                                       NC1034.2
+080900 IF--INIT-GF-22.                                                  NC1034.2
+081000     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+081100     MOVE    "012345678912" TO IF-D10.                            NC1034.2
+081200 IF--TEST-GF-22.                                                  NC1034.2
+081300     IF       IF-D10 GREATER THAN 012345678912                    NC1034.2
+081400              PERFORM FAIL                                        NC1034.2
+081500              ELSE                                                NC1034.2
+081600              PERFORM PASS.                                       NC1034.2
+081700     GO TO    IF--WRITE-GF-22.                                    NC1034.2
+081800 IF--DELETE-GF-22.                                                NC1034.2
+081900     PERFORM  DE-LETE.                                            NC1034.2
+082000 IF--WRITE-GF-22.                                                 NC1034.2
+082100     MOVE "IF--TEST-GF-22" TO PAR-NAME.                           NC1034.2
+082200     PERFORM  PRINT-DETAIL.                                       NC1034.2
+082300 IF--INIT-GF-23.                                                  NC1034.2
+082400     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+082500     MOVE    "ABCDEF" TO IF-D10.                                  NC1034.2
+082600 IF--TEST-GF-23.                                                  NC1034.2
+082700     IF       IF-D11 GREATER THAN "ABCDEF"                        NC1034.2
+082800              PERFORM FAIL                                        NC1034.2
+082900              ELSE                                                NC1034.2
+083000              PERFORM PASS.                                       NC1034.2
+083100     GO TO    IF--WRITE-GF-23.                                    NC1034.2
+083200 IF--DELETE-GF-23.                                                NC1034.2
+083300     PERFORM  DE-LETE.                                            NC1034.2
+083400 IF--WRITE-GF-23.                                                 NC1034.2
+083500     MOVE "IF--TEST-GF-23" TO PAR-NAME.                           NC1034.2
+083600     PERFORM  PRINT-DETAIL.                                       NC1034.2
+083700 IF--INIT-GF-24.                                                  NC1034.2
+083800     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+083900     MOVE    "ABCDEF" TO IF-D12.                                  NC1034.2
+084000 IF--TEST-GF-24.                                                  NC1034.2
+084100     IF       IF-D12 GREATER THAN "ABCDEF"                        NC1034.2
+084200              PERFORM FAIL                                        NC1034.2
+084300              ELSE                                                NC1034.2
+084400              PERFORM PASS.                                       NC1034.2
+084500     GO TO    IF--WRITE-GF-24.                                    NC1034.2
+084600 IF--DELETE-GF-24.                                                NC1034.2
+084700     PERFORM  DE-LETE.                                            NC1034.2
+084800 IF--WRITE-GF-24.                                                 NC1034.2
+084900     MOVE "IF--TEST-GF-24" TO PAR-NAME.                           NC1034.2
+085000     PERFORM  PRINT-DETAIL.                                       NC1034.2
+085100 IF--INIT-GF-25.                                                  NC1034.2
+085200     MOVE    +123.45 TO IF-D7.                                    NC1034.2
+085300 IF--TEST-GF-25.                                                  NC1034.2
+085400     IF       IF-D7 GREATER THAN +123.45                          NC1034.2
+085500              PERFORM FAIL                                        NC1034.2
+085600              ELSE                                                NC1034.2
+085700              PERFORM PASS.                                       NC1034.2
+085800     GO TO    IF--WRITE-GF-25.                                    NC1034.2
+085900 IF--DELETE-GF-25.                                                NC1034.2
+086000     PERFORM  DE-LETE.                                            NC1034.2
+086100 IF--WRITE-GF-25.                                                 NC1034.2
+086200     MOVE "IF--TEST-GF-25" TO PAR-NAME.                           NC1034.2
+086300     PERFORM  PRINT-DETAIL.                                       NC1034.2
+086400 IF--INIT-GF-26.                                                  NC1034.2
+086500     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+086600     MOVE     12300 TO IF-D8.                                     NC1034.2
+086700 IF--TEST-GF-26.                                                  NC1034.2
+086800     IF       IF-D8 GREATER THAN 12300                            NC1034.2
+086900              PERFORM FAIL                                        NC1034.2
+087000              ELSE                                                NC1034.2
+087100              PERFORM PASS.                                       NC1034.2
+087200     GO TO    IF--WRITE-GF-26.                                    NC1034.2
+087300 IF--DELETE-GF-26.                                                NC1034.2
+087400     PERFORM  DE-LETE.                                            NC1034.2
+087500 IF--WRITE-GF-26.                                                 NC1034.2
+087600     MOVE "IF--TEST-GF-26" TO PAR-NAME.                           NC1034.2
+087700     PERFORM  PRINT-DETAIL.                                       NC1034.2
+087800 IF--INIT-GF-27.                                                  NC1034.2
+087900     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+088000     MOVE     12300 TO IF-D8.                                     NC1034.2
+088100     MOVE     12300 TO IF-D13.                                    NC1034.2
+088200 IF--TEST-GF-27.                                                  NC1034.2
+088300     IF       IF-D13 GREATER THAN IF-D8                           NC1034.2
+088400              PERFORM FAIL                                        NC1034.2
+088500              ELSE                                                NC1034.2
+088600              PERFORM PASS.                                       NC1034.2
+088700     GO TO    IF--WRITE-GF-27.                                    NC1034.2
+088800 IF--DELETE-GF-27.                                                NC1034.2
+088900     PERFORM  DE-LETE.                                            NC1034.2
+089000 IF--WRITE-GF-27.                                                 NC1034.2
+089100     MOVE "IF--TEST-GF-27" TO PAR-NAME.                           NC1034.2
+089200     PERFORM  PRINT-DETAIL.                                       NC1034.2
+089300 IF--INIT-GF-28.                                                  NC1034.2
+089400     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+089500     MOVE     .0012 TO IF-D16.                                    NC1034.2
+089600     MOVE     .0012 TO IF-D17.                                    NC1034.2
+089700 IF--TEST-GF-28.                                                  NC1034.2
+089800     IF       IF-D16 GREATER THAN IF-D17                          NC1034.2
+089900              PERFORM FAIL                                        NC1034.2
+090000              ELSE                                                NC1034.2
+090100              PERFORM PASS.                                       NC1034.2
+090200     GO TO    IF--WRITE-GF-28.                                    NC1034.2
+090300 IF--DELETE-GF-28.                                                NC1034.2
+090400     PERFORM  DE-LETE.                                            NC1034.2
+090500 IF--WRITE-GF-28.                                                 NC1034.2
+090600     MOVE "IF--TEST-GF-28" TO PAR-NAME.                           NC1034.2
+090700     PERFORM  PRINT-DETAIL.                                       NC1034.2
+090800 IF--INIT-GF-29.                                                  NC1034.2
+090900     MOVE    2137.45 TO IF-D27.                                   NC1034.2
+091000     MOVE    2137.45 TO IF-D28.                                   NC1034.2
+091100 IF--TEST-GF-29.                                                  NC1034.2
+091200     IF       IF-D27 GREATER THAN IF-D28                          NC1034.2
+091300              PERFORM FAIL                                        NC1034.2
+091400              ELSE                                                NC1034.2
+091500              PERFORM PASS.                                       NC1034.2
+091600     GO       TO IF-WRITE-GF-29.                                  NC1034.2
+091700 IF-DELETE-GF-29.                                                 NC1034.2
+091800     PERFORM  DE-LETE.                                            NC1034.2
+091900 IF-WRITE-GF-29.                                                  NC1034.2
+092000     MOVE "IF--TEST-GF-29" TO PAR-NAME.                           NC1034.2
+092100     PERFORM  PRINT-DETAIL.                                       NC1034.2
+092200 IF--INIT-GF-30.                                                  NC1034.2
+092300     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+092400     MOVE    +123.45 TO IF-D7.                                    NC1034.2
+092500     MOVE    +123.45 TO IF-D14.                                   NC1034.2
+092600 IF--TEST-GF-30.                                                  NC1034.2
+092700     IF       IF-D14 GREATER THAN IF-D7                           NC1034.2
+092800              PERFORM FAIL                                        NC1034.2
+092900              ELSE                                                NC1034.2
+093000              PERFORM PASS.                                       NC1034.2
+093100     GO TO    IF--WRITE-GF-30.                                    NC1034.2
+093200 IF--DELETE-GF-30.                                                NC1034.2
+093300     PERFORM  DE-LETE.                                            NC1034.2
+093400 IF--WRITE-GF-30.                                                 NC1034.2
+093500     MOVE "IF--TEST-GF-30" TO PAR-NAME.                           NC1034.2
+093600     PERFORM  PRINT-DETAIL.                                       NC1034.2
+093700 IF--INIT-GF-31.                                                  NC1034.2
+093800     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+093900     MOVE     12300  TO IF-D8.                                    NC1034.2
+094000     MOVE     12300  TO IF-D15.                                   NC1034.2
+094100 IF--TEST-GF-31.                                                  NC1034.2
+094200     IF       IF-D15 GREATER THAN IF-D8                           NC1034.2
+094300              PERFORM FAIL                                        NC1034.2
+094400              ELSE                                                NC1034.2
+094500              PERFORM PASS.                                       NC1034.2
+094600     GO TO    IF--WRITE-GF-31.                                    NC1034.2
+094700 IF--DELETE-GF-31.                                                NC1034.2
+094800     PERFORM  DE-LETE.                                            NC1034.2
+094900 IF--WRITE-GF-31.                                                 NC1034.2
+095000     MOVE "IF--TEST-GF-31" TO PAR-NAME.                           NC1034.2
+095100     PERFORM  PRINT-DETAIL.                                       NC1034.2
+095200 IF--INIT-GF-32.                                                  NC1034.2
+095300     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+095400     MOVE     0000012345  TO IF-D20.                              NC1034.2
+095500     MOVE     0000012345  TO IF-D21.                              NC1034.2
+095600 IF--TEST-GF-32.                                                  NC1034.2
+095700     IF       IF-D20 GREATER THAN IF-D21                          NC1034.2
+095800              PERFORM FAIL                                        NC1034.2
+095900              ELSE                                                NC1034.2
+096000              PERFORM PASS.                                       NC1034.2
+096100     GO TO    IF--WRITE-GF-32.                                    NC1034.2
+096200 IF--DELETE-GF-32.                                                NC1034.2
+096300     PERFORM  DE-LETE.                                            NC1034.2
+096400 IF--WRITE-GF-32.                                                 NC1034.2
+096500     MOVE "IF--TEST-GF-32" TO PAR-NAME.                           NC1034.2
+096600     PERFORM  PRINT-DETAIL.                                       NC1034.2
+096700 IF--INIT-GF-33.                                                  NC1034.2
+096800     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+096900     MOVE    "A C D0E"    TO IF-D26.                              NC1034.2
+097000     MOVE    "ABCD" TO IF-D25.                                    NC1034.2
+097100 IF--TEST-GF-33.                                                  NC1034.2
+097200     IF       IF-D26 GREATER THAN IF-D25                          NC1034.2
+097300              PERFORM PASS                                        NC1034.2
+097400              ELSE                                                NC1034.2
+097500              PERFORM FAIL.                                       NC1034.2
+097600     GO TO    IF--WRITE-GF-33.                                    NC1034.2
+097700 IF--DELETE-GF-33.                                                NC1034.2
+097800     PERFORM  DE-LETE.                                            NC1034.2
+097900 IF--WRITE-GF-33.                                                 NC1034.2
+098000     MOVE "IF--TEST-GF-33" TO PAR-NAME.                           NC1034.2
+098100     PERFORM  PRINT-DETAIL.                                       NC1034.2
+098200 IF--INIT-GF-34.                                                  NC1034.2
+098300     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+098400     MOVE    "A C D0E"    TO IF-D26.                              NC1034.2
+098500     MOVE    "ABCD" TO IF-D25.                                    NC1034.2
+098600 IF--TEST-GF-34.                                                  NC1034.2
+098700     IF       IF-D25 GREATER THAN IF-D26                          NC1034.2
+098800              PERFORM FAIL                                        NC1034.2
+098900              ELSE                                                NC1034.2
+099000              PERFORM PASS.                                       NC1034.2
+099100     GO TO    IF--WRITE-GF-34.                                    NC1034.2
+099200 IF--DELETE-GF-34.                                                NC1034.2
+099300     PERFORM  DE-LETE.                                            NC1034.2
+099400 IF--WRITE-GF-34.                                                 NC1034.2
+099500     MOVE "IF--TEST-GF-34" TO PAR-NAME.                           NC1034.2
+099600     PERFORM  PRINT-DETAIL.                                       NC1034.2
+099700 IF--INIT-GF-35.                                                  NC1034.2
+099800     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+099900     MOVE    "BABABABABA" TO IF-D6.                               NC1034.2
+100000     MOVE    "BABABABABA" TO IF-D18.                              NC1034.2
+100100 IF--TEST-GF-35.                                                  NC1034.2
+100200     IF       IF-D6 GREATER THAN IF-D18                           NC1034.2
+100300              PERFORM FAIL                                        NC1034.2
+100400              ELSE                                                NC1034.2
+100500              PERFORM PASS.                                       NC1034.2
+100600     GO TO    IF--WRITE-GF-35.                                    NC1034.2
+100700 IF--DELETE-GF-35.                                                NC1034.2
+100800     PERFORM  DE-LETE.                                            NC1034.2
+100900 IF--WRITE-GF-35.                                                 NC1034.2
+101000     MOVE "IF--TEST-GF-35" TO PAR-NAME.                           NC1034.2
+101100     PERFORM  PRINT-DETAIL.                                       NC1034.2
+101200 IF--INIT-GF-36.                                                  NC1034.2
+101300     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+101400     MOVE    "ABCDEF" TO IF-D12.                                  NC1034.2
+101500     MOVE    "ABCDEF" TO IF-D22.                                  NC1034.2
+101600 IF--TEST-GF-36.                                                  NC1034.2
+101700     IF       IF-D22 GREATER THAN IF-D12                          NC1034.2
+101800              PERFORM FAIL                                        NC1034.2
+101900              ELSE                                                NC1034.2
+102000              PERFORM PASS.                                       NC1034.2
+102100     GO TO    IF--WRITE-GF-36.                                    NC1034.2
+102200 IF--DELETE-GF-36.                                                NC1034.2
+102300     PERFORM  DE-LETE.                                            NC1034.2
+102400 IF--WRITE-GF-36.                                                 NC1034.2
+102500     MOVE "IF--TEST-GF-36" TO PAR-NAME.                           NC1034.2
+102600     PERFORM  PRINT-DETAIL.                                       NC1034.2
+102700 IF--INIT-GF-37.                                                  NC1034.2
+102800     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+102900     MOVE    "COMPARE--LESS THAN" TO FEATURE.                     NC1034.2
+103000     MOVE     +123.45 TO IF-D7.                                   NC1034.2
+103100 IF--TEST-GF-37.                                                  NC1034.2
+103200     IF       IF-D7 IS LESS THAN 123.45                           NC1034.2
+103300              PERFORM FAIL                                        NC1034.2
+103400              ELSE                                                NC1034.2
+103500              PERFORM PASS.                                       NC1034.2
+103600     GO TO    IF--WRITE-GF-37.                                    NC1034.2
+103700 IF--DELETE-GF-37.                                                NC1034.2
+103800     PERFORM  DE-LETE.                                            NC1034.2
+103900 IF--WRITE-GF-37.                                                 NC1034.2
+104000     MOVE "IF--TEST-GF-37" TO PAR-NAME.                           NC1034.2
+104100     PERFORM  PRINT-DETAIL.                                       NC1034.2
+104200 IF--INIT-GF-38.                                                  NC1034.2
+104300     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+104400     MOVE    "ABCDEF" TO IF-D11.                                  NC1034.2
+104500 IF--TEST-GF-38.                                                  NC1034.2
+104600     IF       IF-D11 LESS THAN "ABCDEF"                           NC1034.2
+104700              PERFORM FAIL                                        NC1034.2
+104800              ELSE                                                NC1034.2
+104900              PERFORM PASS.                                       NC1034.2
+105000     GO TO    IF--WRITE-GF-38.                                    NC1034.2
+105100 IF--DELETE-GF-38.                                                NC1034.2
+105200     PERFORM  DE-LETE.                                            NC1034.2
+105300 IF--WRITE-GF-38.                                                 NC1034.2
+105400     MOVE "IF--TEST-GF-38" TO PAR-NAME.                           NC1034.2
+105500     PERFORM  PRINT-DETAIL.                                       NC1034.2
+105600 IF--INIT-GF-39.                                                  NC1034.2
+105700     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+105800     MOVE    "BABABABABA" TO IF-D6.                               NC1034.2
+105900     MOVE    "BABABABABA" TO IF-D18.                              NC1034.2
+106000 IF--TEST-GF-39.                                                  NC1034.2
+106100     IF       IF-D6 LESS THAN IF-D18                              NC1034.2
+106200              PERFORM FAIL                                        NC1034.2
+106300              ELSE                                                NC1034.2
+106400              PERFORM PASS.                                       NC1034.2
+106500     GO TO    IF--WRITE-GF-39.                                    NC1034.2
+106600 IF--DELETE-GF-39.                                                NC1034.2
+106700     PERFORM  DE-LETE.                                            NC1034.2
+106800 IF--WRITE-GF-39.                                                 NC1034.2
+106900     MOVE "IF--TEST-GF-39" TO PAR-NAME.                           NC1034.2
+107000     PERFORM  PRINT-DETAIL.                                       NC1034.2
+107100 IF--INIT-GF-40.                                                  NC1034.2
+107200     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+107300     MOVE    0000012345   TO IF-D20.                              NC1034.2
+107400     MOVE    0000012345   TO IF-D21.                              NC1034.2
+107500 IF--TEST-GF-40.                                                  NC1034.2
+107600     IF       IF-D20 LESS THAN IF-D21                             NC1034.2
+107700              PERFORM FAIL                                        NC1034.2
+107800              ELSE                                                NC1034.2
+107900              PERFORM PASS.                                       NC1034.2
+108000     GO TO    IF--WRITE-GF-40.                                    NC1034.2
+108100 IF--DELETE-GF-40.                                                NC1034.2
+108200     PERFORM  DE-LETE.                                            NC1034.2
+108300 IF--WRITE-GF-40.                                                 NC1034.2
+108400     MOVE "IF--TEST-GF-40" TO PAR-NAME.                           NC1034.2
+108500     PERFORM  PRINT-DETAIL.                                       NC1034.2
+108600 IF--INIT-D.                                                      NC1034.2
+108700     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+108800     MOVE "COMPARE--NOT EQUAL" TO FEATURE.                        NC1034.2
+108900     MOVE  +123.45 TO IF-D7.                                      NC1034.2
+109000 IF--TEST-GF-41.                                                  NC1034.2
+109100     IF       IF-D7 IS NOT EQUAL TO 23.45                         NC1034.2
+109200              PERFORM PASS                                        NC1034.2
+109300              ELSE                                                NC1034.2
+109400              PERFORM FAIL.                                       NC1034.2
+109500     GO TO    IF--WRITE-GF-41.                                    NC1034.2
+109600 IF--DELETE-GF-41.                                                NC1034.2
+109700     PERFORM  DE-LETE.                                            NC1034.2
+109800 IF--WRITE-GF-41.                                                 NC1034.2
+109900     MOVE "IF--TEST-GF-41" TO PAR-NAME.                           NC1034.2
+110000     PERFORM  PRINT-DETAIL.                                       NC1034.2
+110100 IF--INIT-GF-42.                                                  NC1034.2
+110200     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+110300     MOVE    "ABCDEF"   TO IF-D11.                                NC1034.2
+110400 IF--TEST-GF-42.                                                  NC1034.2
+110500     IF       IF-D11 NOT EQUAL TO "ABCDE "                        NC1034.2
+110600              PERFORM PASS                                        NC1034.2
+110700              ELSE                                                NC1034.2
+110800              PERFORM FAIL.                                       NC1034.2
+110900     GO TO    IF--WRITE-GF-42.                                    NC1034.2
+111000 IF--DELETE-GF-42.                                                NC1034.2
+111100     PERFORM  DE-LETE.                                            NC1034.2
+111200 IF--WRITE-GF-42.                                                 NC1034.2
+111300     MOVE "IF--TEST-GF-42" TO PAR-NAME.                           NC1034.2
+111400     PERFORM  PRINT-DETAIL.                                       NC1034.2
+111500 IF--INIT-GF-43.                                                  NC1034.2
+111600     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+111700     MOVE    "BABABABABA" TO IF-D6.                               NC1034.2
+111800     MOVE    "BABABABABA" TO IF-D18.                              NC1034.2
+111900 IF--TEST-GF-43.                                                  NC1034.2
+112000     IF       IF-D6 NOT EQUAL TO IF-D18                           NC1034.2
+112100              PERFORM FAIL                                        NC1034.2
+112200              ELSE                                                NC1034.2
+112300              PERFORM PASS.                                       NC1034.2
+112400     GO TO    IF--WRITE-GF-43.                                    NC1034.2
+112500 IF--DELETE-GF-43.                                                NC1034.2
+112600     PERFORM  DE-LETE.                                            NC1034.2
+112700 IF--WRITE-GF-43.                                                 NC1034.2
+112800     MOVE "IF--TEST-GF-43" TO PAR-NAME.                           NC1034.2
+112900     PERFORM  PRINT-DETAIL.                                       NC1034.2
+113000 IF--INIT-GF-44.                                                  NC1034.2
+113100     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+113200     MOVE    0000012345   TO IF-D20.                              NC1034.2
+113300     MOVE    0000012345   TO IF-D21.                              NC1034.2
+113400 IF--TEST-GF-44.                                                  NC1034.2
+113500     IF       IF-D20 NOT EQUAL TO IF-D21                          NC1034.2
+113600              PERFORM FAIL                                        NC1034.2
+113700              ELSE                                                NC1034.2
+113800              PERFORM PASS.                                       NC1034.2
+113900     GO TO    IF--WRITE-GF-44.                                    NC1034.2
+114000 IF--DELETE-GF-44.                                                NC1034.2
+114100     PERFORM  DE-LETE.                                            NC1034.2
+114200 IF--WRITE-GF-44.                                                 NC1034.2
+114300     MOVE "IF--TEST-GF-44" TO PAR-NAME.                           NC1034.2
+114400     PERFORM  PRINT-DETAIL.                                       NC1034.2
+114500 IF--INIT-GF-45.                                                  NC1034.2
+114600     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+114700     MOVE "COMPARE--NOT LESS" TO FEATURE.                         NC1034.2
+114800     MOVE  +123.45 TO IF-D7.                                      NC1034.2
+114900 IF--TEST-GF-45.                                                  NC1034.2
+115000     IF       IF-D7 IS NOT LESS THAN 123.45                       NC1034.2
+115100              PERFORM PASS                                        NC1034.2
+115200              ELSE                                                NC1034.2
+115300              PERFORM FAIL.                                       NC1034.2
+115400     GO TO    IF--WRITE-GF-45.                                    NC1034.2
+115500 IF--DELETE-GF-45.                                                NC1034.2
+115600     PERFORM  DE-LETE.                                            NC1034.2
+115700 IF--WRITE-GF-45.                                                 NC1034.2
+115800     MOVE "IF--TEST-GF-45" TO PAR-NAME.                           NC1034.2
+115900     PERFORM  PRINT-DETAIL.                                       NC1034.2
+116000 IF--INIT-GF-46.                                                  NC1034.2
+116100     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+116200     MOVE    "ABCDEF"     TO IF-D11.                              NC1034.2
+116300 IF--TEST-GF-46.                                                  NC1034.2
+116400     IF       IF-D11 IS NOT LESS THAN "ABCDEF"                    NC1034.2
+116500              PERFORM PASS                                        NC1034.2
+116600              ELSE                                                NC1034.2
+116700              PERFORM FAIL.                                       NC1034.2
+116800     GO TO    IF--WRITE-GF-46.                                    NC1034.2
+116900 IF--DELETE-GF-46.                                                NC1034.2
+117000     PERFORM  DE-LETE.                                            NC1034.2
+117100 IF--WRITE-GF-46.                                                 NC1034.2
+117200     MOVE "IF--TEST-GF-46" TO PAR-NAME.                           NC1034.2
+117300     PERFORM  PRINT-DETAIL.                                       NC1034.2
+117400 IF--INIT-GF-47.                                                  NC1034.2
+117500     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+117600     MOVE    "BABABABABA" TO IF-D6.                               NC1034.2
+117700     MOVE    "BABABABABA" TO IF-D18.                              NC1034.2
+117800 IF--TEST-GF-47.                                                  NC1034.2
+117900     IF       IF-D6 IS NOT LESS THAN IF-D18                       NC1034.2
+118000              PERFORM PASS                                        NC1034.2
+118100              ELSE                                                NC1034.2
+118200              PERFORM FAIL.                                       NC1034.2
+118300     GO TO    IF--WRITE-GF-47.                                    NC1034.2
+118400 IF--DELETE-GF-47.                                                NC1034.2
+118500     PERFORM  DE-LETE.                                            NC1034.2
+118600 IF--WRITE-GF-47.                                                 NC1034.2
+118700     MOVE "IF--TEST-GF-47" TO PAR-NAME.                           NC1034.2
+118800     PERFORM  PRINT-DETAIL.                                       NC1034.2
+118900 IF--INIT-GF-48.                                                  NC1034.2
+119000     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+119100     MOVE    0000012345   TO IF-D20.                              NC1034.2
+119200     MOVE    0000012345   TO IF-D21.                              NC1034.2
+119300 IF--TEST-GF-48.                                                  NC1034.2
+119400     IF       IF-D20 NOT LESS THAN IF-D21                         NC1034.2
+119500              PERFORM PASS                                        NC1034.2
+119600              ELSE                                                NC1034.2
+119700              PERFORM FAIL.                                       NC1034.2
+119800     GO TO    IF--WRITE-GF-48.                                    NC1034.2
+119900 IF--DELETE-GF-48.                                                NC1034.2
+120000     PERFORM  DE-LETE.                                            NC1034.2
+120100 IF--WRITE-GF-48.                                                 NC1034.2
+120200     MOVE "IF--TEST-GF-48" TO PAR-NAME.                           NC1034.2
+120300     PERFORM  PRINT-DETAIL.                                       NC1034.2
+120400 IF--INIT-GF-49.                                                  NC1034.2
+120500     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+120600     MOVE "COMPARE--NOT GREATER" TO FEATURE.                      NC1034.2
+120700     MOVE   +123.45 TO IF-D7.                                     NC1034.2
+120800 IF--TEST-GF-49.                                                  NC1034.2
+120900     IF       IF-D7 NOT GREATER THAN 123.45                       NC1034.2
+121000              PERFORM PASS                                        NC1034.2
+121100              ELSE                                                NC1034.2
+121200              PERFORM FAIL.                                       NC1034.2
+121300     GO TO    IF--WRITE-GF-49.                                    NC1034.2
+121400 IF--DELETE-GF-49.                                                NC1034.2
+121500     PERFORM  DE-LETE.                                            NC1034.2
+121600 IF--WRITE-GF-49.                                                 NC1034.2
+121700     MOVE "IF--TEST-GF-49" TO PAR-NAME.                           NC1034.2
+121800     PERFORM  PRINT-DETAIL.                                       NC1034.2
+121900 IF--INIT-GF-50.                                                  NC1034.2
+122000     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+122100     MOVE    "ABCDEF"     TO IF-D11.                              NC1034.2
+122200 IF--TEST-GF-50.                                                  NC1034.2
+122300     IF IF-D11 IS NOT GREATER THAN "ABCD  "                       NC1034.2
+122400              PERFORM FAIL                                        NC1034.2
+122500              ELSE                                                NC1034.2
+122600              PERFORM PASS.                                       NC1034.2
+122700*        THIS TEST ASSUMES THAT BLANK PRECEDES THE LETTERS OF     NC1034.2
+122800*    THE ALPHABET IN THE COLLATING SEQUENCE.                      NC1034.2
+122900     GO TO    IF--WRITE-GF-50.                                    NC1034.2
+123000 IF--DELETE-GF-50.                                                NC1034.2
+123100     PERFORM  DE-LETE.                                            NC1034.2
+123200 IF--WRITE-GF-50.                                                 NC1034.2
+123300     MOVE "IF--TEST-GF-50" TO PAR-NAME.                           NC1034.2
+123400     PERFORM  PRINT-DETAIL.                                       NC1034.2
+123500 IF--INIT-GF-51.                                                  NC1034.2
+123600     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+123700     MOVE    "BABABABABA" TO IF-D6.                               NC1034.2
+123800     MOVE    "BABABABABA" TO IF-D18.                              NC1034.2
+123900 IF--TEST-GF-51.                                                  NC1034.2
+124000     IF       IF-D6 NOT GREATER THAN IF-D18                       NC1034.2
+124100              PERFORM PASS                                        NC1034.2
+124200              ELSE                                                NC1034.2
+124300              PERFORM FAIL.                                       NC1034.2
+124400     GO TO    IF--WRITE-GF-51.                                    NC1034.2
+124500 IF--DELETE-GF-51.                                                NC1034.2
+124600     PERFORM  DE-LETE.                                            NC1034.2
+124700 IF--WRITE-GF-51.                                                 NC1034.2
+124800     MOVE "IF--TEST-GF-51" TO PAR-NAME.                           NC1034.2
+124900     PERFORM  PRINT-DETAIL.                                       NC1034.2
+125000 IF--INIT-GF-52.                                                  NC1034.2
+125100     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+125200     MOVE    "ABCDEF"     TO IF-D11.                              NC1034.2
+125300     MOVE    "ABCDEF"     TO IF-D12.                              NC1034.2
+125400 IF--TEST-GF-52.                                                  NC1034.2
+125500     IF       IF-D12 NOT GREATER THAN IF-D11                      NC1034.2
+125600              PERFORM PASS                                        NC1034.2
+125700              ELSE                                                NC1034.2
+125800              PERFORM FAIL.                                       NC1034.2
+125900     GO TO    IF--WRITE-GF-52.                                    NC1034.2
+126000 IF--DELETE-GF-52.                                                NC1034.2
+126100     PERFORM  DE-LETE.                                            NC1034.2
+126200 IF--WRITE-GF-52.                                                 NC1034.2
+126300     MOVE "IF--TEST-GF-52" TO PAR-NAME.                           NC1034.2
+126400     PERFORM  PRINT-DETAIL.                                       NC1034.2
+126500 IF--INIT-GF-53.                                                  NC1034.2
+126600     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+126700     MOVE "COMPARE--HIGH LOW " TO FEATURE.                        NC1034.2
+126800     MOVE   LOW-VALUE TO LOW-VAL.                                 NC1034.2
+126900 IF--TEST-GF-53.                                                  NC1034.2
+127000     IF HIGH-VALUE NOT GREATER THAN LOW-VAL                       NC1034.2
+127100              PERFORM FAIL                                        NC1034.2
+127200              ELSE                                                NC1034.2
+127300              PERFORM PASS.                                       NC1034.2
+127400     GO TO    IF--WRITE-GF-53.                                    NC1034.2
+127500 IF--DELETE-GF-53.                                                NC1034.2
+127600     PERFORM  DE-LETE.                                            NC1034.2
+127700 IF--WRITE-GF-53.                                                 NC1034.2
+127800     MOVE "IF--TEST-GF-53" TO PAR-NAME.                           NC1034.2
+127900     PERFORM  PRINT-DETAIL.                                       NC1034.2
+128000 IF--INIT-GF-54.                                                  NC1034.2
+128100     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+128200     MOVE   LOW-VALUE TO LOW-VAL.                                 NC1034.2
+128300 IF--TEST-GF-54.                                                  NC1034.2
+128400     IF LOW-VAL LESS THAN HIGH-VALUE                              NC1034.2
+128500              PERFORM PASS                                        NC1034.2
+128600              ELSE                                                NC1034.2
+128700              PERFORM FAIL.                                       NC1034.2
+128800     GO TO    IF--WRITE-GF-54.                                    NC1034.2
+128900 IF--DELETE-GF-54.                                                NC1034.2
+129000     PERFORM  DE-LETE.                                            NC1034.2
+129100 IF--WRITE-GF-54.                                                 NC1034.2
+129200     MOVE "IF--TEST-GF-54" TO PAR-NAME.                           NC1034.2
+129300     PERFORM  PRINT-DETAIL.                                       NC1034.2
+129400 IF--INIT-GF-55.                                                  NC1034.2
+129500     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+129600     MOVE   LOW-VALUE TO LOW-VAL.                                 NC1034.2
+129700     MOVE   1 TO ZERO-01.                                         NC1034.2
+129800 IF--TEST-GF-55.                                                  NC1034.2
+129900     IF ZERO-01 GREATER THAN LOW-VALUE                            NC1034.2
+130000              PERFORM PASS                                        NC1034.2
+130100              ELSE                                                NC1034.2
+130200              PERFORM FAIL.                                       NC1034.2
+130300     GO TO    IF--WRITE-GF-55.                                    NC1034.2
+130400 IF--DELETE-GF-55.                                                NC1034.2
+130500     PERFORM  DE-LETE.                                            NC1034.2
+130600 IF--WRITE-GF-55.                                                 NC1034.2
+130700     MOVE "IF--TEST-GF-55" TO PAR-NAME.                           NC1034.2
+130800     PERFORM  PRINT-DETAIL.                                       NC1034.2
+130900 IF--INIT-GF-56.                                                  NC1034.2
+131000     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+131100     MOVE    "ABC"   TO ABC.                                      NC1034.2
+131200 IF--TEST-GF-56.                                                  NC1034.2
+131300     IF ABC GREATER THAN HIGH-VALUE                               NC1034.2
+131400              PERFORM FAIL                                        NC1034.2
+131500              ELSE                                                NC1034.2
+131600              PERFORM PASS.                                       NC1034.2
+131700     GO TO    IF--WRITE-GF-56.                                    NC1034.2
+131800 IF--DELETE-GF-56.                                                NC1034.2
+131900     PERFORM  DE-LETE.                                            NC1034.2
+132000 IF--WRITE-GF-56.                                                 NC1034.2
+132100     MOVE "IF--TEST-GF-56" TO PAR-NAME.                           NC1034.2
+132200     PERFORM  PRINT-DETAIL.                                       NC1034.2
+132300 IF--INIT-GF-57.                                                  NC1034.2
+132400     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+132500     MOVE     999999999999999998 TO NINE-17-8.                    NC1034.2
+132600 IF--TEST-GF-57.                                                  NC1034.2
+132700     IF NINE-17-8 LESS THAN HIGH-VALUE                            NC1034.2
+132800              PERFORM PASS                                        NC1034.2
+132900              ELSE                                                NC1034.2
+133000              PERFORM FAIL.                                       NC1034.2
+133100     GO TO    IF--WRITE-GF-57.                                    NC1034.2
+133200 IF--DELETE-GF-57.                                                NC1034.2
+133300     PERFORM  DE-LETE.                                            NC1034.2
+133400 IF--WRITE-GF-57.                                                 NC1034.2
+133500     MOVE "IF--TEST-GF-57" TO PAR-NAME.                           NC1034.2
+133600     PERFORM  PRINT-DETAIL.                                       NC1034.2
+133700 IF--INIT-GF-58.                                                  NC1034.2
+133800     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+133900     MOVE     0 TO ZERO-NULL.                                     NC1034.2
+134000 IF--TEST-GF-58.                                                  NC1034.2
+134100     IF       ZERO-NULL NOT EQUAL TO HIGH-VALUE                   NC1034.2
+134200              PERFORM PASS                                        NC1034.2
+134300              ELSE                                                NC1034.2
+134400              PERFORM FAIL.                                       NC1034.2
+134500     GO TO    IF--WRITE-GF-58.                                    NC1034.2
+134600 IF--DELETE-GF-58.                                                NC1034.2
+134700     PERFORM  DE-LETE.                                            NC1034.2
+134800 IF--WRITE-GF-58.                                                 NC1034.2
+134900     MOVE "IF--TEST-GF-58" TO PAR-NAME.                           NC1034.2
+135000     PERFORM  PRINT-DETAIL.                                       NC1034.2
+135100 IF--INIT-GF-59.                                                  NC1034.2
+135200     MOVE "ABC" TO ABC.                                           NC1034.2
+135300 IF--TEST-GF-59.                                                  NC1034.2
+135400     IF  ABC LESS THAN LOW-VALUE                                  NC1034.2
+135500         PERFORM FAIL                                             NC1034.2
+135600         GO TO IF--WRITE-GF-59.                                   NC1034.2
+135700     PERFORM PASS.                                                NC1034.2
+135800     GO TO  IF--WRITE-GF-59.                                      NC1034.2
+135900 IF--DELETE-GF-59.                                                NC1034.2
+136000     PERFORM DE-LETE.                                             NC1034.2
+136100 IF--WRITE-GF-59.                                                 NC1034.2
+136200     MOVE  "IF--TEST-GF-59" TO PAR-NAME.                          NC1034.2
+136300     PERFORM PRINT-DETAIL.                                        NC1034.2
+136400 IF--INIT-GF-60.                                                  NC1034.2
+136500     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+136600     MOVE  "COMPARE--EQUAL" TO FEATURE.                           NC1034.2
+136700     MOVE   0 TO IF-D32.                                          NC1034.2
+136800     MOVE  -0 TO IF-D33.                                          NC1034.2
+136900 IF--TEST-GF-60.                                                  NC1034.2
+137000     IF      IF-D32 EQUAL TO IF-D33                               NC1034.2
+137100             PERFORM PASS                                         NC1034.2
+137200             ELSE                                                 NC1034.2
+137300             PERFORM FAIL.                                        NC1034.2
+137400     GO TO   IF--WRITE-GF-60.                                     NC1034.2
+137500 IF--DELETE-GF-60.                                                NC1034.2
+137600     PERFORM  DE-LETE.                                            NC1034.2
+137700 IF--WRITE-GF-60.                                                 NC1034.2
+137800     MOVE "IF--TEST-GF-60" TO PAR-NAME.                           NC1034.2
+137900     PERFORM  PRINT-DETAIL.                                       NC1034.2
+138000 IF--INIT-GF-61.                                                  NC1034.2
+138100     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+138200     MOVE   0 TO IF-D32.                                          NC1034.2
+138300     MOVE  +0 TO IF-D34.                                          NC1034.2
+138400 IF--TEST-GF-61.                                                  NC1034.2
+138500     IF       IF-D32 EQUAL TO IF-D34                              NC1034.2
+138600              PERFORM PASS                                        NC1034.2
+138700              ELSE                                                NC1034.2
+138800              PERFORM FAIL.                                       NC1034.2
+138900     GO TO    IF--WRITE-GF-61.                                    NC1034.2
+139000 IF--DELETE-GF-61.                                                NC1034.2
+139100     PERFORM  DE-LETE.                                            NC1034.2
+139200 IF--WRITE-GF-61.                                                 NC1034.2
+139300     MOVE "IF--TEST-GF-61" TO PAR-NAME.                           NC1034.2
+139400     PERFORM  PRINT-DETAIL.                                       NC1034.2
+139500 IF--INIT-GF-62.                                                  NC1034.2
+139600     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+139700     MOVE  -0 TO IF-D33.                                          NC1034.2
+139800     MOVE  +0 TO IF-D34.                                          NC1034.2
+139900 IF--TEST-GF-62.                                                  NC1034.2
+140000     IF       IF-D33 EQUAL TO IF-D34                              NC1034.2
+140100              PERFORM PASS                                        NC1034.2
+140200              ELSE                                                NC1034.2
+140300              PERFORM FAIL.                                       NC1034.2
+140400     GO TO    IF--WRITE-GF-62.                                    NC1034.2
+140500 IF--DELETE-GF-62.                                                NC1034.2
+140600     PERFORM  DE-LETE.                                            NC1034.2
+140700 IF--WRITE-GF-62.                                                 NC1034.2
+140800     MOVE "IF--TEST-GF-62" TO PAR-NAME.                           NC1034.2
+140900     PERFORM  PRINT-DETAIL.                                       NC1034.2
+141000 IF--INIT-GF-63.                                                  NC1034.2
+141100     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+141200     MOVE   ZERO TO AZERO-DS-05V05.                               NC1034.2
+141300 IF--TEST-GF-63.                                                  NC1034.2
+141400     IF AZERO-DS-05V05 EQUAL TO ZERO                              NC1034.2
+141500         PERFORM PASS                                             NC1034.2
+141600         GO TO IF-WRITE-GF-63.                                    NC1034.2
+141700     GO TO IF-FAIL-GF-63.                                         NC1034.2
+141800 IF-DELETE-GF-63.                                                 NC1034.2
+141900     PERFORM DE-LETE.                                             NC1034.2
+142000     GO TO IF-WRITE-GF-63.                                        NC1034.2
+142100 IF-FAIL-GF-63.                                                   NC1034.2
+142200     MOVE 00000.00000 TO CORRECT-N.                               NC1034.2
+142300     MOVE AZERO-DS-05V05 TO COMPUTED-N.                           NC1034.2
+142400     PERFORM FAIL.                                                NC1034.2
+142500 IF-WRITE-GF-63.                                                  NC1034.2
+142600     MOVE "IF--TEST-GF-63         " TO PAR-NAME.                  NC1034.2
+142700     PERFORM PRINT-DETAIL.                                        NC1034.2
+142800 IF--INIT-GF-64.                                                  NC1034.2
+142900     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+143000     MOVE SPACE TO CORRECT-A.                                     NC1034.2
+143100 IF--TEST-GF-64.                                                  NC1034.2
+143200     IF SPACE EQUAL TO CORRECT-A                                  NC1034.2
+143300         PERFORM PASS                                             NC1034.2
+143400         GO TO IF-WRITE-GF-64.                                    NC1034.2
+143500     GO TO IF-FAIL-GF-64.                                         NC1034.2
+143600 IF-DELETE-GF-64.                                                 NC1034.2
+143700     PERFORM DE-LETE.                                             NC1034.2
+143800     GO TO IF-WRITE-GF-64.                                        NC1034.2
+143900 IF-FAIL-GF-64.                                                   NC1034.2
+144000     MOVE CORRECT-A TO COMPUTED-A.                                NC1034.2
+144100     MOVE SPACE TO CORRECT-A.                                     NC1034.2
+144200     PERFORM FAIL.                                                NC1034.2
+144300 IF-WRITE-GF-64.                                                  NC1034.2
+144400     MOVE "IF--TEST-GF-64         " TO PAR-NAME.                  NC1034.2
+144500     PERFORM PRINT-DETAIL.                                        NC1034.2
+144600 IF--INIT-GF-65.                                                  NC1034.2
+144700     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+144800     MOVE 111111111111111111 TO A18ONES-DS-18V00.                 NC1034.2
+144900     MOVE "111111111111111111" TO ONES-XN-00018.                  NC1034.2
+145000 IF--TEST-GF-65.                                                  NC1034.2
+145100     IF A18ONES-DS-18V00 EQUAL TO ONES-XN-00018                   NC1034.2
+145200         PERFORM PASS                                             NC1034.2
+145300         GO TO IF-WRITE-GF-65.                                    NC1034.2
+145400     GO TO IF-FAIL-GF-65.                                         NC1034.2
+145500 IF-DELETE-GF-65.                                                 NC1034.2
+145600     PERFORM DE-LETE.                                             NC1034.2
+145700     GO TO IF-WRITE-GF-65.                                        NC1034.2
+145800 IF-FAIL-GF-65.                                                   NC1034.2
+145900     MOVE ONES-XN-00018 TO CORRECT-A.                             NC1034.2
+146000     MOVE A18ONES-DS-18V00 TO COMPUTED-A.                         NC1034.2
+146100     MOVE "FIELDS DIDNT COMPARE EQUAL" TO RE-MARK                 NC1034.2
+146200     PERFORM FAIL.                                                NC1034.2
+146300 IF-WRITE-GF-65.                                                  NC1034.2
+146400     MOVE "IF--TEST-GF-65 " TO PAR-NAME.                          NC1034.2
+146500     PERFORM PRINT-DETAIL.                                        NC1034.2
+146600 IF--INIT-GF-66.                                                  NC1034.2
+146700     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+146800     MOVE 22 TO TWOS-XN-00002.                                    NC1034.2
+146900     MOVE 99 TO A99-DS-02V00.                                     NC1034.2
+147000 IF--TEST-GF-66.                                                  NC1034.2
+147100     IF TWOS-XN-00002 IS EQUAL TO A99-DS-02V00                    NC1034.2
+147200         MOVE TWOS-XN-00002 TO COMPUTED-A                         NC1034.2
+147300         MOVE A99-DS-02V00 TO CORRECT-A                           NC1034.2
+147400         PERFORM FAIL                                             NC1034.2
+147500         GO TO IF-WRITE-GF-66.                                    NC1034.2
+147600     PERFORM PASS.                                                NC1034.2
+147700     GO TO IF-WRITE-GF-66.                                        NC1034.2
+147800 IF-DELETE-GF-66.                                                 NC1034.2
+147900     PERFORM DE-LETE.                                             NC1034.2
+148000 IF-WRITE-GF-66.                                                  NC1034.2
+148100     MOVE "IF--TEST-GF-66 " TO PAR-NAME.                          NC1034.2
+148200     PERFORM PRINT-DETAIL.                                        NC1034.2
+148300 IF--INIT-GF-67.                                                  NC1034.2
+148400     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+148500     MOVE     "COMPARE--LESS THAN  " TO FEATURE.                  NC1034.2
+148600     MOVE 111111111.111111111 TO A18ONES-DS-09V09.                NC1034.2
+148700     MOVE 99 TO A99-DS-02V00.                                     NC1034.2
+148800 IF--TEST-GF-67.                                                  NC1034.2
+148900     IF A99-DS-02V00 LESS THAN A18ONES-DS-09V09                   NC1034.2
+149000         PERFORM PASS                                             NC1034.2
+149100         GO TO IF-WRITE-GF-67 ELSE                                NC1034.2
+149200     GO TO IF-FAIL-GF-67.                                         NC1034.2
+149300 IF-DELETE-GF-67.                                                 NC1034.2
+149400     PERFORM DE-LETE.                                             NC1034.2
+149500     GO TO IF-WRITE-GF-67.                                        NC1034.2
+149600 IF-FAIL-GF-67.                                                   NC1034.2
+149700     MOVE A99-DS-02V00 TO CORRECT-A.                              NC1034.2
+149800     MOVE A18ONES-DS-09V09 TO COMPUTED-N.                         NC1034.2
+149900     PERFORM FAIL.                                                NC1034.2
+150000 IF-WRITE-GF-67.                                                  NC1034.2
+150100     MOVE "IF--TEST-GF-67 " TO PAR-NAME.                          NC1034.2
+150200     PERFORM PRINT-DETAIL.                                        NC1034.2
+150300 IF--INIT-GF-68.                                                  NC1034.2
+150400     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+150500     MOVE   "11" TO ONES-XN-00002.                                NC1034.2
+150600 IF--TEST-GF-68.                                                  NC1034.2
+150700     IF "11" LESS THAN ONES-XN-00002                              NC1034.2
+150800         MOVE "11" TO CORRECT-A                                   NC1034.2
+150900         MOVE ONES-XN-00002 TO COMPUTED-A                         NC1034.2
+151000         PERFORM FAIL                                             NC1034.2
+151100         GO TO IF-WRITE-GF-68 ELSE                                NC1034.2
+151200     PERFORM PASS                                                 NC1034.2
+151300     GO TO IF-WRITE-GF-68.                                        NC1034.2
+151400 IF-DELETE-GF-68.                                                 NC1034.2
+151500     PERFORM DE-LETE.                                             NC1034.2
+151600 IF-WRITE-GF-68.                                                  NC1034.2
+151700     MOVE "IF--TEST-GF-68 " TO PAR-NAME.                          NC1034.2
+151800     PERFORM PRINT-DETAIL.                                        NC1034.2
+151900 IF--INIT-GF-69.                                                  NC1034.2
+152000     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+152100     MOVE   "11" TO ONES-XN-00002.                                NC1034.2
+152200     MOVE    22  TO A02TWOS-DU-02V00.                             NC1034.2
+152300 IF--TEST-GF-69.                                                  NC1034.2
+152400     IF  A02TWOS-DU-02V00 LESS THAN ONES-XN-00002                 NC1034.2
+152500         MOVE ONES-XN-00002 TO CORRECT-A                          NC1034.2
+152600         MOVE A02TWOS-DU-02V00 TO COMPUTED-A                      NC1034.2
+152700         PERFORM FAIL                                             NC1034.2
+152800         GO TO IF-WRITE-GF-69 ELSE                                NC1034.2
+152900     PERFORM PASS                                                 NC1034.2
+153000     GO TO IF-WRITE-GF-69.                                        NC1034.2
+153100 IF-DELETE-GF-69.                                                 NC1034.2
+153200     PERFORM DE-LETE.                                             NC1034.2
+153300 IF-WRITE-GF-69.                                                  NC1034.2
+153400     MOVE "IF--TEST-GF-69 " TO PAR-NAME.                          NC1034.2
+153500     PERFORM PRINT-DETAIL.                                        NC1034.2
+153600 IF--INIT-GF-70.                                                  NC1034.2
+153700     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+153800     MOVE   "22" TO TWOS-XN-00002.                                NC1034.2
+153900     MOVE    22  TO A02TWOS-DU-02V00.                             NC1034.2
+154000 IF--TEST-GF-70.                                                  NC1034.2
+154100     IF TWOS-XN-00002 LESS THAN A02TWOS-DU-02V00                  NC1034.2
+154200         MOVE TWOS-XN-00002 TO CORRECT-A                          NC1034.2
+154300         MOVE A02TWOS-DU-02V00 TO COMPUTED-A                      NC1034.2
+154400         PERFORM FAIL                                             NC1034.2
+154500         GO TO IF-WRITE-GF-70  ELSE                               NC1034.2
+154600     PERFORM PASS                                                 NC1034.2
+154700     GO TO IF-WRITE-GF-70.                                        NC1034.2
+154800 IF-DELETE-GF-70.                                                 NC1034.2
+154900     PERFORM DE-LETE.                                             NC1034.2
+155000 IF-WRITE-GF-70.                                                  NC1034.2
+155100     MOVE "IF--TEST-70 " TO PAR-NAME.                             NC1034.2
+155200     PERFORM PRINT-DETAIL.                                        NC1034.2
+155300 IF--INIT-GF-71.                                                  NC1034.2
+155400     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+155500     MOVE   "COMPARE--GREATER    " TO FEATURE.                    NC1034.2
+155600     MOVE    99  TO A99-DS-02V00.                                 NC1034.2
+155700 IF--TEST-GF-71.                                                  NC1034.2
+155800     IF A99-DS-02V00 GREATER THAN 88.9 NEXT SENTENCE  ELSE        NC1034.2
+155900         MOVE A99-DS-02V00 TO CORRECT-A                           NC1034.2
+156000         MOVE "88.9" TO COMPUTED-A                                NC1034.2
+156100         PERFORM FAIL                                             NC1034.2
+156200         GO TO IF-WRITE-GF-71.                                    NC1034.2
+156300     PERFORM PASS.                                                NC1034.2
+156400     GO TO IF-WRITE-GF-71.                                        NC1034.2
+156500 IF-DELETE-GF-71.                                                 NC1034.2
+156600     PERFORM DE-LETE.                                             NC1034.2
+156700 IF-WRITE-GF-71.                                                  NC1034.2
+156800     MOVE "IF--TEST-GF-71 " TO PAR-NAME.                          NC1034.2
+156900     PERFORM PRINT-DETAIL.                                        NC1034.2
+157000 IF--INIT-GF-72.                                                  NC1034.2
+157100     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+157200     MOVE   "11" TO ONES-XN-00002.                                NC1034.2
+157300     MOVE   "22" TO TWOS-XN-00002.                                NC1034.2
+157400 IF--TEST-GF-72.                                                  NC1034.2
+157500     IF ONES-XN-00002 GREATER THAN TWOS-XN-00002 NEXT SENTENCE    NC1034.2
+157600         ELSE PERFORM PASS                                        NC1034.2
+157700         GO TO IF-WRITE-GF-72.                                    NC1034.2
+157800     MOVE ONES-XN-00002 TO COMPUTED-A.                            NC1034.2
+157900     MOVE TWOS-XN-00002 TO CORRECT-A.                             NC1034.2
+158000     PERFORM FAIL.                                                NC1034.2
+158100     GO TO IF-WRITE-GF-72.                                        NC1034.2
+158200 IF-DELETE-GF-72.                                                 NC1034.2
+158300     PERFORM DE-LETE.                                             NC1034.2
+158400 IF-WRITE-GF-72.                                                  NC1034.2
+158500     MOVE "IF--TEST-GF-72 " TO PAR-NAME.                          NC1034.2
+158600     PERFORM PRINT-DETAIL.                                        NC1034.2
+158700 IF--INIT-GF-73.                                                  NC1034.2
+158800     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+158900     MOVE   "11" TO ONES-XN-00002.                                NC1034.2
+159000     MOVE    22  TO A02TWOS-DU-02V00.                             NC1034.2
+159100 IF--TEST-GF-73.                                                  NC1034.2
+159200     IF A02TWOS-DU-02V00 GREATER THAN ONES-XN-00002               NC1034.2
+159300         NEXT SENTENCE  ELSE                                      NC1034.2
+159400         MOVE A02TWOS-DU-02V00 TO CORRECT-A                       NC1034.2
+159500         MOVE ONES-XN-00002 TO COMPUTED-A                         NC1034.2
+159600         PERFORM FAIL                                             NC1034.2
+159700         GO TO IF-WRITE-GF-73.                                    NC1034.2
+159800     PERFORM PASS.                                                NC1034.2
+159900     GO TO IF-WRITE-GF-73.                                        NC1034.2
+160000 IF-DELETE-GF-73.                                                 NC1034.2
+160100     PERFORM DE-LETE.                                             NC1034.2
+160200 IF-WRITE-GF-73.                                                  NC1034.2
+160300     MOVE "IF--TEST-GF-73 " TO PAR-NAME.                          NC1034.2
+160400     PERFORM PRINT-DETAIL.                                        NC1034.2
+160500 IF--INIT-GF-74.                                                  NC1034.2
+160600     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+160700     MOVE   "22" TO TWOS-XN-00002.                                NC1034.2
+160800     MOVE    22  TO A02TWOS-DU-02V00.                             NC1034.2
+160900 IF--TEST-GF-74.                                                  NC1034.2
+161000     IF TWOS-XN-00002 GREATER THAN A02TWOS-DU-02V00               NC1034.2
+161100         NEXT SENTENCE  ELSE                                      NC1034.2
+161200         PERFORM PASS                                             NC1034.2
+161300         GO TO IF-WRITE-GF-74.                                    NC1034.2
+161400     MOVE TWOS-XN-00002 TO CORRECT-A.                             NC1034.2
+161500     MOVE A02TWOS-DU-02V00 TO COMPUTED-A.                         NC1034.2
+161600     PERFORM FAIL.                                                NC1034.2
+161700     GO TO IF-WRITE-GF-74.                                        NC1034.2
+161800 IF-DELETE-GF-74.                                                 NC1034.2
+161900     PERFORM DE-LETE.                                             NC1034.2
+162000 IF-WRITE-GF-74.                                                  NC1034.2
+162100     MOVE "IF--TEST-GF-74 " TO PAR-NAME.                          NC1034.2
+162200     PERFORM PRINT-DETAIL.                                        NC1034.2
+162300 IF--INIT-GF-75.                                                  NC1034.2
+162400     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+162500     MOVE     "COMPARE--NOT EQUAL  " TO FEATURE.                  NC1034.2
+162600     MOVE SPACE TO CORRECT-A.                                     NC1034.2
+162700 IF--TEST-GF-75.                                                  NC1034.2
+162800     IF ZERO IS NOT EQUAL TO CORRECT-A                            NC1034.2
+162900         PERFORM PASS                                             NC1034.2
+163000         GO TO IF-WRITE-GF-75.                                    NC1034.2
+163100     MOVE ZERO TO COMPUTED-A.                                     NC1034.2
+163200     PERFORM FAIL.                                                NC1034.2
+163300     GO TO IF-WRITE-GF-75.                                        NC1034.2
+163400 IF-DELETE-GF-75.                                                 NC1034.2
+163500     PERFORM DE-LETE.                                             NC1034.2
+163600 IF-WRITE-GF-75.                                                  NC1034.2
+163700     MOVE "IF--TEST-75 " TO PAR-NAME.                             NC1034.2
+163800     PERFORM PRINT-DETAIL.                                        NC1034.2
+163900 IF--INIT-GF-76.                                                  NC1034.2
+164000     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+164100     MOVE   +022.00 TO A02TWOS-DS-03V02.                          NC1034.2
+164200     MOVE    22  TO A02TWOS-DU-02V00.                             NC1034.2
+164300 IF--TEST-GF-76.                                                  NC1034.2
+164400     IF A02TWOS-DU-02V00 NOT EQUAL TO A02TWOS-DS-03V02            NC1034.2
+164500         MOVE A02TWOS-DU-02V00 TO CORRECT-N                       NC1034.2
+164600         MOVE A02TWOS-DS-03V02 TO COMPUTED-N                      NC1034.2
+164700         PERFORM FAIL                                             NC1034.2
+164800         GO TO IF-WRITE-GF-76  ELSE  NEXT SENTENCE.               NC1034.2
+164900     PERFORM PASS                                                 NC1034.2
+165000     GO TO IF-WRITE-GF-76.                                        NC1034.2
+165100 IF-DELETE-GF-76.                                                 NC1034.2
+165200     PERFORM DE-LETE.                                             NC1034.2
+165300 IF-WRITE-GF-76.                                                  NC1034.2
+165400     MOVE "IF--TEST-GF-76 " TO PAR-NAME.                          NC1034.2
+165500     PERFORM PRINT-DETAIL.                                        NC1034.2
+165600 IF--INIT-GF-77.                                                  NC1034.2
+165700     MOVE     "COMPARE--NOT LESS   " TO FEATURE.                  NC1034.2
+165800     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+165900     MOVE   "22" TO TWOS-XN-00002.                                NC1034.2
+166000     MOVE   "11" TO ONES-XN-00002.                                NC1034.2
+166100 IF--TEST-GF-77.                                                  NC1034.2
+166200     IF TWOS-XN-00002 NOT LESS THAN ONES-XN-00002                 NC1034.2
+166300         PERFORM PASS                                             NC1034.2
+166400         GO TO IF-WRITE-GF-77 ELSE   NEXT SENTENCE.               NC1034.2
+166500     MOVE TWOS-XN-00002 TO CORRECT-A.                             NC1034.2
+166600     MOVE ONES-XN-00002 TO COMPUTED-A.                            NC1034.2
+166700     PERFORM FAIL.                                                NC1034.2
+166800     GO TO IF-WRITE-GF-77.                                        NC1034.2
+166900 IF-DELETE-GF-77.                                                 NC1034.2
+167000     PERFORM DE-LETE.                                             NC1034.2
+167100 IF-WRITE-GF-77.                                                  NC1034.2
+167200     MOVE "IF--TEST-GF-77 " TO PAR-NAME.                          NC1034.2
+167300     PERFORM PRINT-DETAIL.                                        NC1034.2
+167400 IF--INIT-GF-78.                                                  NC1034.2
+167500     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+167600     MOVE   .000000001 TO A01ONE-DS-P0801.                        NC1034.2
+167700 IF--TEST-GF-78.                                                  NC1034.2
+167800     IF 0.0000000001 IS NOT LESS THAN A01ONE-DS-P0801             NC1034.2
+167900         MOVE "0.0000000001" TO CORRECT-A                         NC1034.2
+168000         MOVE A01ONE-DS-P0801 TO COMPUTED-N                       NC1034.2
+168100         PERFORM FAIL                                             NC1034.2
+168200         GO TO IF-WRITE-GF-78  ELSE                               NC1034.2
+168300     PERFORM PASS                                                 NC1034.2
+168400     GO TO IF-WRITE-GF-78.                                        NC1034.2
+168500 IF-DELETE-GF-78.                                                 NC1034.2
+168600     PERFORM DE-LETE.                                             NC1034.2
+168700 IF-WRITE-GF-78.                                                  NC1034.2
+168800     MOVE "IF--TEST-GF-78 " TO PAR-NAME.                          NC1034.2
+168900     PERFORM PRINT-DETAIL.                                        NC1034.2
+169000 IF--INIT-GF-79.                                                  NC1034.2
+169100     MOVE     "COMPARE--NOT GREATER" TO FEATURE.                  NC1034.2
+169200     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+169300     MOVE  "11" TO ONES-XN-00002.                                 NC1034.2
+169400     MOVE  "22" TO TWOS-XN-00002.                                 NC1034.2
+169500 IF--TEST-GF-79.                                                  NC1034.2
+169600     IF ONES-XN-00002 NOT GREATER THAN TWOS-XN-00002              NC1034.2
+169700         PERFORM PASS                                             NC1034.2
+169800         GO TO IF-WRITE-GF-79.                                    NC1034.2
+169900     MOVE ONES-XN-00002 TO CORRECT-A.                             NC1034.2
+170000     MOVE TWOS-XN-00002 TO COMPUTED-A.                            NC1034.2
+170100     PERFORM FAIL.                                                NC1034.2
+170200     GO TO IF-WRITE-GF-79.                                        NC1034.2
+170300 IF-DELETE-GF-79.                                                 NC1034.2
+170400     PERFORM DE-LETE.                                             NC1034.2
+170500 IF-WRITE-GF-79.                                                  NC1034.2
+170600     MOVE "IF--TEST-GF-79 " TO PAR-NAME.                          NC1034.2
+170700     PERFORM PRINT-DETAIL.                                        NC1034.2
+170800 IF--INIT-GF-80.                                                  NC1034.2
+170900     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+171000     MOVE   +990 TO A990-DS-0201P.                                NC1034.2
+171100     MOVE   99  TO A99-DS-02V00.                                  NC1034.2
+171200 IF--TEST-GF-80.                                                  NC1034.2
+171300     IF A990-DS-0201P NOT GREATER THAN A99-DS-02V00               NC1034.2
+171400         MOVE A990-DS-0201P TO COMPUTED-N                         NC1034.2
+171500         MOVE A99-DS-02V00 TO CORRECT-N                           NC1034.2
+171600         PERFORM FAIL                                             NC1034.2
+171700         GO TO IF-WRITE-GF-80.                                    NC1034.2
+171800     PERFORM PASS.                                                NC1034.2
+171900     GO TO IF-WRITE-GF-80.                                        NC1034.2
+172000 IF-DELETE-GF-80.                                                 NC1034.2
+172100     PERFORM DE-LETE.                                             NC1034.2
+172200 IF-WRITE-GF-80.                                                  NC1034.2
+172300     MOVE "IF--TEST-GF-80 " TO PAR-NAME.                          NC1034.2
+172400     PERFORM PRINT-DETAIL.                                        NC1034.2
+172500 IF--INIT-GF-81.                                                  NC1034.2
+172600     MOVE     "COMPARE--GROUP VALUE" TO FEATURE.                  NC1034.2
+172700     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+172800     MOVE  "*ASTERISK/SLASH" TO IF-D35.                           NC1034.2
+172900 IF--TEST-GF-81.                                                  NC1034.2
+173000     IF       IF-D36A EQUAL TO "*ASTER"                           NC1034.2
+173100              PERFORM PASS GO TO IF--WRITE-GF-81.                 NC1034.2
+173200     GO       TO IF--FAIL-GF-81.                                  NC1034.2
+173300 IF--DELETE-GF-81.                                                NC1034.2
+173400     PERFORM  DE-LETE.                                            NC1034.2
+173500     GO       TO IF--WRITE-GF-81.                                 NC1034.2
+173600 IF--FAIL-GF-81.                                                  NC1034.2
+173700     PERFORM  FAIL.                                               NC1034.2
+173800     MOVE     IF-D36A TO COMPUTED-A.                              NC1034.2
+173900     MOVE     "*ASTER" TO CORRECT-A.                              NC1034.2
+174000 IF--WRITE-GF-81.                                                 NC1034.2
+174100     MOVE     "IF--TEST-GF-81" TO PAR-NAME.                       NC1034.2
+174200     PERFORM  PRINT-DETAIL.                                       NC1034.2
+174300 IF--INIT-GF-82.                                                  NC1034.2
+174400     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+174500     MOVE  "*ASTERISK/SLASH" TO IF-D35.                           NC1034.2
+174600 IF--TEST-GF-82.                                                  NC1034.2
+174700     IF       IF-D36B EQUAL TO "ISK"                              NC1034.2
+174800              PERFORM PASS GO TO IF--WRITE-GF-82.                 NC1034.2
+174900     GO       TO IF--FAIL-GF-82.                                  NC1034.2
+175000 IF--DELETE-GF-82.                                                NC1034.2
+175100     PERFORM  DE-LETE.                                            NC1034.2
+175200     GO       TO IF--WRITE-GF-82.                                 NC1034.2
+175300 IF--FAIL-GF-82.                                                  NC1034.2
+175400     PERFORM  FAIL.                                               NC1034.2
+175500     MOVE     IF-D36B TO COMPUTED-A.                              NC1034.2
+175600     MOVE     "ISK" TO CORRECT-A.                                 NC1034.2
+175700 IF--WRITE-GF-82.                                                 NC1034.2
+175800     MOVE     "IF--TEST-GF-82" TO PAR-NAME.                       NC1034.2
+175900     PERFORM  PRINT-DETAIL.                                       NC1034.2
+176000 IF--INIT-GF-83.                                                  NC1034.2
+176100     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+176200     MOVE  "*ASTERISK/SLASH" TO IF-D35.                           NC1034.2
+176300 IF--TEST-GF-83.                                                  NC1034.2
+176400     IF       IF-D36C EQUAL TO "/SLASH"                           NC1034.2
+176500              PERFORM PASS GO TO IF--WRITE-GF-83.                 NC1034.2
+176600     GO       TO IF--FAIL-GF-83.                                  NC1034.2
+176700 IF--DELETE-GF-83.                                                NC1034.2
+176800     PERFORM  DE-LETE.                                            NC1034.2
+176900     GO       TO IF--WRITE-GF-83.                                 NC1034.2
+177000 IF--FAIL-GF-83.                                                  NC1034.2
+177100     PERFORM  FAIL.                                               NC1034.2
+177200     MOVE     IF-D36C TO COMPUTED-A.                              NC1034.2
+177300     MOVE     "/SLASH" TO CORRECT-A.                              NC1034.2
+177400 IF--WRITE-GF-83.                                                 NC1034.2
+177500     MOVE     "IF--TEST-GF-83" TO PAR-NAME.                       NC1034.2
+177600     PERFORM  PRINT-DETAIL.                                       NC1034.2
+177700 IF--INIT-GF-84.                                                  NC1034.2
+177800     MOVE     "COMPARE--EQUAL" TO FEATURE.                        NC1034.2
+177900     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+178000     MOVE   0001234 TO IF-D37.                                    NC1034.2
+178100 IF--TEST-GF-84.                                                  NC1034.2
+178200     IF       IF-D37  EQUAL TO 01234                              NC1034.2
+178300              PERFORM PASS GO TO IF--WRITE-GF-84.                 NC1034.2
+178400     GO       TO IF--FAIL-GF-84.                                  NC1034.2
+178500 IF--DELETE-GF-84.                                                NC1034.2
+178600     PERFORM  DE-LETE.                                            NC1034.2
+178700     GO       TO IF--WRITE-GF-84.                                 NC1034.2
+178800 IF--FAIL-GF-84.                                                  NC1034.2
+178900     PERFORM  FAIL.                                               NC1034.2
+179000     MOVE     IF-D37  TO COMPUTED-N.                              NC1034.2
+179100     MOVE     01234 TO CORRECT-N.                                 NC1034.2
+179200 IF--WRITE-GF-84.                                                 NC1034.2
+179300     MOVE     "IF--TEST-GF-84" TO PAR-NAME.                       NC1034.2
+179400     PERFORM  PRINT-DETAIL.                                       NC1034.2
+179500 IF--INIT-GF-85.                                                  NC1034.2
+179600     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+179700     MOVE  " BABBAGE" TO IF-D38.                                  NC1034.2
+179800 IF--TEST-GF-85.                                                  NC1034.2
+179900     IF       IF-D38  EQUAL TO " BABBAGE            "             NC1034.2
+180000              PERFORM PASS GO TO IF--WRITE-GF-85.                 NC1034.2
+180100     GO       TO IF--FAIL-GF-85.                                  NC1034.2
+180200 IF--DELETE-GF-85.                                                NC1034.2
+180300     PERFORM  DE-LETE.                                            NC1034.2
+180400     GO       TO IF--WRITE-GF-85.                                 NC1034.2
+180500 IF--FAIL-GF-85.                                                  NC1034.2
+180600     PERFORM  FAIL.                                               NC1034.2
+180700     MOVE     IF-D38  TO COMPUTED-A.                              NC1034.2
+180800     MOVE     " BABBAGE            " TO CORRECT-A.                NC1034.2
+180900 IF--WRITE-GF-85.                                                 NC1034.2
+181000     MOVE     "IF--TEST-GF-85" TO PAR-NAME.                       NC1034.2
+181100     PERFORM  PRINT-DETAIL.                                       NC1034.2
+181200 IF--INIT-GF-86.                                                  NC1034.2
+181300     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+181400     MOVE                                                         NC1034.2
+181500     "XXXXX081"                                                   NC1034.2
+181600     TO NON-COBOL-CHARACTERS.                                     NC1034.2
+181700 IF--TEST-GF-86.                                                  NC1034.2
+181800     IF       NON-COBOL-CHARACTERS EQUAL TO                       NC1034.2
+181900     "XXXXX081"                                                   NC1034.2
+182000              PERFORM PASS GO TO IF--WRITE-GF-86.                 NC1034.2
+182100     GO       TO IF--FAIL-GF-86.                                  NC1034.2
+182200 IF--DELETE-GF-86.                                                NC1034.2
+182300     PERFORM DE-LETE.                                             NC1034.2
+182400     GO       TO IF--WRITE-GF-86.                                 NC1034.2
+182500 IF--FAIL-GF-86.                                                  NC1034.2
+182600     PERFORM  FAIL.                                               NC1034.2
+182700     MOVE     NON-COBOL-CHARACTERS TO COMPUTED-A.                 NC1034.2
+182800     MOVE                                                         NC1034.2
+182900     "XXXXX081"                                                   NC1034.2
+183000     TO CORRECT-A.                                                NC1034.2
+183100 IF--WRITE-GF-86.                                                 NC1034.2
+183200     MOVE     "IF--TEST-GF-86" TO PAR-NAME.                       NC1034.2
+183300     MOVE     "NON COBOL CHARACTERS" TO RE-MARK.                  NC1034.2
+183400     PERFORM  PRINT-DETAIL.                                       NC1034.2
+183500 IF--INIT-GF-87.                                                  NC1034.2
+183600     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+183700     MOVE   100000 TO COMP-DATA2.                                 NC1034.2
+183800     MOVE   100000 TO COMP-DATA9.                                 NC1034.2
+183900 IF--TEST-GF-87.                                                  NC1034.2
+184000     IF COMP-DATA2  EQUAL TO COMP-DATA9                           NC1034.2
+184100         PERFORM PASS                                             NC1034.2
+184200         GO TO IF--WRITE-GF-87.                                   NC1034.2
+184300     MOVE COMP-DATA2 TO COMPUTED-18V0.                            NC1034.2
+184400     MOVE COMP-DATA9 TO CORRECT-18V0.                             NC1034.2
+184500     MOVE "ENTRIES DIDNT COMPARE EQUAL" TO RE-MARK.               NC1034.2
+184600     PERFORM FAIL.                                                NC1034.2
+184700     GO TO IF--WRITE-GF-87.                                       NC1034.2
+184800 IF--DELETE-GF-87.                                                NC1034.2
+184900     PERFORM DE-LETE.                                             NC1034.2
+185000 IF--WRITE-GF-87.                                                 NC1034.2
+185100     MOVE "IF--TEST-GF-87" TO PAR-NAME.                           NC1034.2
+185200     PERFORM PRINT-DETAIL.                                        NC1034.2
+185300 IF--INIT-GF-88.                                                  NC1034.2
+185400     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+185500     MOVE   300    TO COMP-DATA1.                                 NC1034.2
+185600     MOVE   300.00 TO COMP-DATA7.                                 NC1034.2
+185700 IF--TEST-GF-88.                                                  NC1034.2
+185800     IF COMP-DATA1 EQUAL TO COMP-DATA7                            NC1034.2
+185900         PERFORM PASS                                             NC1034.2
+186000         GO TO IF--WRITE-GF-88.                                   NC1034.2
+186100     MOVE COMP-DATA1 TO COMPUTED-18V0.                            NC1034.2
+186200     MOVE COMP-DATA7 TO CORRECT-N.                                NC1034.2
+186300     MOVE "ENTRIES DIDNT COMPARE EQUAL" TO RE-MARK.               NC1034.2
+186400     PERFORM FAIL.                                                NC1034.2
+186500     GO TO IF--WRITE-GF-88.                                       NC1034.2
+186600 IF--DELETE-GF-88.                                                NC1034.2
+186700     PERFORM DE-LETE.                                             NC1034.2
+186800 IF--WRITE-GF-88.                                                 NC1034.2
+186900     MOVE "IF--TEST-GF-88" TO PAR-NAME.                           NC1034.2
+187000     PERFORM PRINT-DETAIL.                                        NC1034.2
+187100 IF--INIT-GF-89.                                                  NC1034.2
+187200     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+187300     MOVE   300 TO COMP-DATA1.                                    NC1034.2
+187400     MOVE   300 TO DISP-DATA1.                                    NC1034.2
+187500 IF--TEST-GF-89.                                                  NC1034.2
+187600     IF COMP-DATA1 EQUAL TO DISP-DATA1                            NC1034.2
+187700         PERFORM PASS                                             NC1034.2
+187800         GO TO IF--WRITE-GF-89.                                   NC1034.2
+187900     MOVE COMP-DATA1 TO COMPUTED-18V0.                            NC1034.2
+188000     MOVE DISP-DATA1 TO CORRECT-18V0.                             NC1034.2
+188100     MOVE "ENTRIES DIDNT COMPARE EQUAL" TO RE-MARK.               NC1034.2
+188200     PERFORM FAIL.                                                NC1034.2
+188300     GO TO IF--WRITE-GF-89.                                       NC1034.2
+188400 IF--DELETE-GF-89.                                                NC1034.2
+188500     PERFORM DE-LETE.                                             NC1034.2
+188600 IF--WRITE-GF-89.                                                 NC1034.2
+188700     MOVE "IF--TEST-GF-89" TO PAR-NAME.                           NC1034.2
+188800     PERFORM PRINT-DETAIL.                                        NC1034.2
+188900 IF--INIT-GF-90.                                                  NC1034.2
+189000     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+189100     MOVE   100000 TO COMP-DATA1.                                 NC1034.2
+189200     MOVE   100000 TO DISP-DATA1.                                 NC1034.2
+189300 IF--TEST-GF-90.                                                  NC1034.2
+189400     IF COMP-DATA2 EQUAL TO DISP-DATA2                            NC1034.2
+189500         PERFORM PASS                                             NC1034.2
+189600         GO TO IF--WRITE-GF-90.                                   NC1034.2
+189700     MOVE COMP-DATA2 TO COMPUTED-N.                               NC1034.2
+189800     MOVE DISP-DATA2 TO CORRECT-N.                                NC1034.2
+189900     MOVE "ENTRIES DIDNT COMPARE EQUAL" TO RE-MARK.               NC1034.2
+190000     PERFORM FAIL.                                                NC1034.2
+190100     GO TO IF--WRITE-GF-90.                                       NC1034.2
+190200 IF--DELETE-GF-90.                                                NC1034.2
+190300     PERFORM DE-LETE.                                             NC1034.2
+190400 IF--WRITE-GF-90.                                                 NC1034.2
+190500     MOVE "IF--TEST-GF-90" TO PAR-NAME.                           NC1034.2
+190600     PERFORM PRINT-DETAIL.                                        NC1034.2
+190700 IF--INIT-GF-91.                                                  NC1034.2
+190800     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+190900     MOVE   9 TO COMP-DATA3.                                      NC1034.2
+191000     MOVE   9 TO DISP-DATA3.                                      NC1034.2
+191100 IF--TEST-GF-91.                                                  NC1034.2
+191200     IF COMP-DATA3  EQUAL TO DISP-DATA3                           NC1034.2
+191300         PERFORM PASS                                             NC1034.2
+191400         GO TO IF--WRITE-GF-91.                                   NC1034.2
+191500     MOVE COMP-DATA3 TO COMPUTED-N.                               NC1034.2
+191600     MOVE DISP-DATA3 TO CORRECT-N.                                NC1034.2
+191700     MOVE "ENTRIES DIDNT COMPARE EQUAL" TO RE-MARK.               NC1034.2
+191800     PERFORM FAIL.                                                NC1034.2
+191900     GO TO IF--WRITE-GF-91.                                       NC1034.2
+192000 IF--DELETE-GF-91.                                                NC1034.2
+192100     PERFORM DE-LETE.                                             NC1034.2
+192200 IF--WRITE-GF-91.                                                 NC1034.2
+192300     MOVE "IF--TEST-GF-91" TO PAR-NAME.                           NC1034.2
+192400     PERFORM PRINT-DETAIL.                                        NC1034.2
+192500 IF--INIT-GF-92.                                                  NC1034.2
+192600     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+192700     MOVE   300.00 TO COMP-DATA7.                                 NC1034.2
+192800     MOVE   300    TO DISP-DATA1.                                 NC1034.2
+192900 IF--TEST-GF-92.                                                  NC1034.2
+193000     IF COMP-DATA7 EQUAL TO DISP-DATA1                            NC1034.2
+193100         PERFORM PASS                                             NC1034.2
+193200         GO TO IF--WRITE-GF-92.                                   NC1034.2
+193300     MOVE COMP-DATA7 TO COMPUTED-N.                               NC1034.2
+193400     MOVE DISP-DATA1 TO CORRECT-N.                                NC1034.2
+193500     MOVE "ENTRIES DIDNT COMPARE EQUAL" TO RE-MARK.               NC1034.2
+193600     PERFORM FAIL.                                                NC1034.2
+193700     GO TO IF--WRITE-GF-92.                                       NC1034.2
+193800 IF--DELETE-GF-92.                                                NC1034.2
+193900     PERFORM DE-LETE.                                             NC1034.2
+194000 IF--WRITE-GF-92.                                                 NC1034.2
+194100     MOVE "IF--TEST-GF-92" TO PAR-NAME.                           NC1034.2
+194200     PERFORM PRINT-DETAIL.                                        NC1034.2
+194300 IF--INIT-GF-93.                                                  NC1034.2
+194400     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+194500     MOVE   3.3    TO COMP-DATA4.                                 NC1034.2
+194600     MOVE   3.3000000 TO COMP-DATA8.                              NC1034.2
+194700 IF--TEST-GF-93.                                                  NC1034.2
+194800     IF COMP-DATA4 EQUAL TO COMP-DATA8                            NC1034.2
+194900         PERFORM PASS                                             NC1034.2
+195000         GO TO IF--WRITE-GF-93.                                   NC1034.2
+195100     MOVE COMP-DATA4 TO COMPUTED-N.                               NC1034.2
+195200     MOVE COMP-DATA8 TO CORRECT-N.                                NC1034.2
+195300     MOVE "ENTRIES DIDNT COMPARE EQUAL" TO RE-MARK.               NC1034.2
+195400     PERFORM FAIL.                                                NC1034.2
+195500     GO TO IF--WRITE-GF-93.                                       NC1034.2
+195600 IF--DELETE-GF-93.                                                NC1034.2
+195700     PERFORM DE-LETE.                                             NC1034.2
+195800 IF--WRITE-GF-93.                                                 NC1034.2
+195900     MOVE "IF--TEST-GF-93" TO PAR-NAME.                           NC1034.2
+196000     PERFORM PRINT-DETAIL.                                        NC1034.2
+196100 IF--INIT-GF-94.                                                  NC1034.2
+196200     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+196300     MOVE   300    TO COMP-DATA7.                                 NC1034.2
+196400     MOVE   300    TO DISP-DATA1.                                 NC1034.2
+196500 IF--TEST-GF-94.                                                  NC1034.2
+196600     IF COMP-DATA7 EQUAL TO DISP-DATA1                            NC1034.2
+196700         PERFORM PASS                                             NC1034.2
+196800         GO TO IF--WRITE-GF-94.                                   NC1034.2
+196900     MOVE COMP-DATA7 TO COMPUTED-N.                               NC1034.2
+197000     MOVE DISP-DATA1 TO CORRECT-N.                                NC1034.2
+197100     MOVE "ENTRIES DIDNT COMPARE EQUAL" TO RE-MARK.               NC1034.2
+197200     PERFORM FAIL.                                                NC1034.2
+197300     GO TO IF--WRITE-GF-94.                                       NC1034.2
+197400 IF--DELETE-GF-94.                                                NC1034.2
+197500     PERFORM DE-LETE.                                             NC1034.2
+197600 IF--WRITE-GF-94.                                                 NC1034.2
+197700     MOVE "IF--TEST-GF-94" TO PAR-NAME.                           NC1034.2
+197800     PERFORM PRINT-DETAIL.                                        NC1034.2
+197900 IF--INIT-GF-95.                                                  NC1034.2
+198000     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+198100     MOVE   3.3000000 TO COMP-DATA8.                              NC1034.2
+198200     MOVE   3.3       TO DISP-DATA4.                              NC1034.2
+198300 IF--TEST-GF-95.                                                  NC1034.2
+198400     IF DISP-DATA4 EQUAL TO COMP-DATA8                            NC1034.2
+198500         PERFORM PASS                                             NC1034.2
+198600         GO TO IF--WRITE-GF-95.                                   NC1034.2
+198700     MOVE DISP-DATA4 TO COMPUTED-N.                               NC1034.2
+198800     MOVE COMP-DATA8 TO CORRECT-N.                                NC1034.2
+198900     MOVE "ENTRIES DIDNT COMPARE EQUAL" TO RE-MARK.               NC1034.2
+199000     PERFORM FAIL.                                                NC1034.2
+199100     GO TO IF--WRITE-GF-95.                                       NC1034.2
+199200 IF--DELETE-GF-95.                                                NC1034.2
+199300     PERFORM DE-LETE.                                             NC1034.2
+199400 IF--WRITE-GF-95.                                                 NC1034.2
+199500     MOVE "IF--TEST-GF-95" TO PAR-NAME.                           NC1034.2
+199600     PERFORM PRINT-DETAIL.                                        NC1034.2
+199700     MOVE "COMPARE GROUP-LEVEL " TO FEATURE.                      NC1034.2
+199800 IF--INIT-GF-96.                                                  NC1034.2
+199900     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+200000     MOVE   ZEROS     TO GROUP-1000-1.                            NC1034.2
+200100     MOVE   QUOTES    TO XNAME.                                   NC1034.2
+200200     MOVE   SPACES    TO GROUP-1000-2.                            NC1034.2
+200300     MOVE   "."       TO GROUP-1000-3.                            NC1034.2
+200400     MOVE   ZEROS     TO GROUP-X500-A.                            NC1034.2
+200500     MOVE   QUOTES    TO GROUP-X500-1-1.                          NC1034.2
+200600     MOVE   QUOTES    TO GROUP-X500-1-2.                          NC1034.2
+200700     MOVE   SPACES    TO GROUP-X500-1-3.                          NC1034.2
+200800     MOVE   " ."      TO GROUP-X500-1-4.                          NC1034.2
+200900 IF--TEST-GF-96.                                                  NC1034.2
+201000     IF GROUP-X1000 EQUAL TO GROUP-X500-2                         NC1034.2
+201100         PERFORM PASS                                             NC1034.2
+201200         GO TO IF--WRITE-GF-96.                                   NC1034.2
+201300     MOVE "GROUP LEVEL X(1000) " TO COMPUTED-A.                   NC1034.2
+201400     MOVE "GROUP LEVEL X(1000) " TO CORRECT-A.                    NC1034.2
+201500     MOVE "FIELDS DIDNT COMPARE EQUAL" TO RE-MARK.                NC1034.2
+201600     PERFORM FAIL.                                                NC1034.2
+201700     GO TO IF--WRITE-GF-96.                                       NC1034.2
+201800 IF--DELETE-GF-96.                                                NC1034.2
+201900     PERFORM DE-LETE.                                             NC1034.2
+202000 IF--WRITE-GF-96.                                                 NC1034.2
+202100     MOVE "IF--TEST-GF-96" TO PAR-NAME.                           NC1034.2
+202200     PERFORM PRINT-DETAIL.                                        NC1034.2
+202300 IF--INIT-GF-97.                                                  NC1034.2
+202400     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+202500     MOVE     22      TO A02TWOS-DU-02V00.                        NC1034.2
+202600     MOVE     ZERO TO VAL.                                        NC1034.2
+202700 IF--TEST-GF-97.                                                  NC1034.2
+202800     IF       A02TWOS-DU-02V00 LESS THAN "AA"                     NC1034.2
+202900              ADD 1 TO VAL.                                       NC1034.2
+203000     IF       A02TWOS-DU-02V00 GREATER THAN "AA"                  NC1034.2
+203100              ADD 1 TO VAL.                                       NC1034.2
+203200     IF       VAL EQUAL TO 1                                      NC1034.2
+203300              PERFORM PASS                                        NC1034.2
+203400              GO TO IF--WRITE-GF-97.                              NC1034.2
+203500     PERFORM  FAIL.                                               NC1034.2
+203600     MOVE     VAL TO COMPUTED-N.                                  NC1034.2
+203700     MOVE     1 TO CORRECT-N.                                     NC1034.2
+203800     GO       TO IF--WRITE-GF-97.                                 NC1034.2
+203900 IF--DELETE-GF-97.                                                NC1034.2
+204000     PERFORM  DE-LETE.                                            NC1034.2
+204100 IF--WRITE-GF-97.                                                 NC1034.2
+204200     MOVE     "COMPARE NUM VS ALPH" TO FEATURE.                   NC1034.2
+204300     MOVE     "IF--TEST-GF-97" TO PAR-NAME.                       NC1034.2
+204400     PERFORM  PRINT-DETAIL.                                       NC1034.2
+204500*                                                                 NC1034.2
+204600*                                                                 NC1034.2
+204700 IF--INIT-GF-98.                                                  NC1034.2
+204800     MOVE  "V1-89 6.15.4 GR2" TO ANSI-REFERENCE.                  NC1034.2
+204900     MOVE   -123456789012345678  TO WRK-DS-18V0-1.                NC1034.2
+205000     MOVE   "123456789012345678" TO WRK-XN-18-2.                  NC1034.2
+205100 IF-TEST-GF-98.                                                   NC1034.2
+205200     IF WRK-DS-18V0-1 EQUAL WRK-XN-18-2 PERFORM PASS              NC1034.2
+205300         ELSE PERFORM FAIL.                                       NC1034.2
+205400     GO TO IF-WRITE-GF-98.                                        NC1034.2
+205500 IF-DELETE-GF-98.                                                 NC1034.2
+205600     PERFORM DE-LETE.                                             NC1034.2
+205700 IF-WRITE-GF-98.                                                  NC1034.2
+205800     MOVE "IF-TEST-GF-98" TO PAR-NAME.                            NC1034.2
+205900     MOVE "EQUAL - NO TO" TO FEATURE.                             NC1034.2
+206000     MOVE "PSEUDO-MOVE TO STRIP MINUS SIGN" TO RE-MARK.           NC1034.2
+206100     PERFORM PRINT-DETAIL.                                        NC1034.2
+206200*                                                                 NC1034.2
+206300*                                                                 NC1034.2
+206400 IF--INIT-GF-99.                                                  NC1034.2
+206500*    ==--> OPTIONAL WORD "THEN" <--==                             NC1034.2
+206600     MOVE  "COMPARE--EQUAL" TO FEATURE.                           NC1034.2
+206700     MOVE  "V1-89 6.15.2  " TO ANSI-REFERENCE.                    NC1034.2
+206800     MOVE   0 TO IF-D1.                                           NC1034.2
+206900 IF--TEST-GF-99.                                                  NC1034.2
+207000     IF      ZERO IS EQUAL TO IF-D1                               NC1034.2
+207100        THEN PERFORM PASS                                         NC1034.2
+207200     ELSE                                                         NC1034.2
+207300             PERFORM FAIL.                                        NC1034.2
+207400     GO TO   IF--WRITE-GF-99.                                     NC1034.2
+207500 IF--DELETE-GF-99.                                                NC1034.2
+207600     PERFORM DE-LETE.                                             NC1034.2
+207700 IF--WRITE-GF-99.                                                 NC1034.2
+207800     MOVE  "IF--TEST-GF-99" TO PAR-NAME.                          NC1034.2
+207900     PERFORM PRINT-DETAIL.                                        NC1034.2
+208000*                                                                 NC1034.2
+208100*                                                                 NC1034.2
+208200 IF--INIT-GF-100.                                                 NC1034.2
+208300*    ==-->  EXPLICIT SCOPE TERMINATOR  <--==                      NC1034.2
+208400     MOVE   "V1-89 6.4.3  " TO ANSI-REFERENCE.                    NC1034.2
+208500     MOVE    ZERO TO WRK-DU-02V00.                                NC1034.2
+208600     MOVE    ZERO TO IF-D2.                                       NC1034.2
+208700 IF--TEST-GF-100-1.                                               NC1034.2
+208800     IF      ZERO IS EQUAL TO IF-D2                               NC1034.2
+208900             PERFORM PASS                                         NC1034.2
+209000     ELSE                                                         NC1034.2
+209100             PERFORM FAIL                                         NC1034.2
+209200     END-IF                                                       NC1034.2
+209300     MOVE    99 TO WRK-DU-02V00.                                  NC1034.2
+209400     GO TO   IF--WRITE-GF-100-1.                                  NC1034.2
+209500 IF--DELETE-GF-100-1.                                             NC1034.2
+209600     PERFORM DE-LETE.                                             NC1034.2
+209700 IF--WRITE-GF-100-1.                                              NC1034.2
+209800     MOVE   "IF--TEST-GF-100-1" TO PAR-NAME.                      NC1034.2
+209900     PERFORM PRINT-DETAIL.                                        NC1034.2
+210000 IF--TEST-GF-100-2.                                               NC1034.2
+210100     IF      WRK-DU-02V00 = 99                                    NC1034.2
+210200             PERFORM PASS                                         NC1034.2
+210300     ELSE                                                         NC1034.2
+210400             MOVE    99           TO CORRECT-N                    NC1034.2
+210500             MOVE    WRK-DU-02V00 TO COMPUTED-N                   NC1034.2
+210600             PERFORM FAIL.                                        NC1034.2
+210700     GO TO   IF--WRITE-GF-100-2.                                  NC1034.2
+210800 IF--DELETE-GF-100-2.                                             NC1034.2
+210900     PERFORM DE-LETE.                                             NC1034.2
+211000 IF--WRITE-GF-100-2.                                              NC1034.2
+211100     MOVE "IF--TEST-GF-100-2" TO PAR-NAME.                        NC1034.2
+211200     PERFORM PRINT-DETAIL.                                        NC1034.2
+211300*                                                                 NC1034.2
+211400*                                                                 NC1034.2
+211500 IF--INIT-GF-101.                                                 NC1034.2
+211600     MOVE    " BABBAGE" TO IF-D38.                                NC1034.2
+211700 IF--TEST-GF-101.                                                 NC1034.2
+211800*    ==-->  EXPLICIT SCOPE TERMINATOR  <--==                      NC1034.2
+211900     MOVE   "V1-89 6.4.3  " TO ANSI-REFERENCE.                    NC1034.2
+212000     IF       IF-D38  EQUAL TO " BABBAGE            "             NC1034.2
+212100              PERFORM PASS                                        NC1034.2
+212200              GO TO   IF--WRITE-GF-101                            NC1034.2
+212300     END-IF                                                       NC1034.2
+212400     GO       TO IF--FAIL-GF-101.                                 NC1034.2
+212500 IF--DELETE-GF-101.                                               NC1034.2
+212600     PERFORM  DE-LETE.                                            NC1034.2
+212700     GO       TO IF--WRITE-GF-101.                                NC1034.2
+212800 IF--FAIL-GF-101.                                                 NC1034.2
+212900     PERFORM  FAIL.                                               NC1034.2
+213000     MOVE     IF-D38  TO COMPUTED-A.                              NC1034.2
+213100     MOVE     " BABBAGE            " TO CORRECT-A.                NC1034.2
+213200 IF--WRITE-GF-101.                                                NC1034.2
+213300     MOVE     "IF--TEST-GF-101" TO PAR-NAME.                      NC1034.2
+213400     PERFORM  PRINT-DETAIL.                                       NC1034.2
+213500*                                                                 NC1034.2
+213600*                                                                 NC1034.2
+213700 CCVS-EXIT SECTION.                                               NC1034.2
+213800 CCVS-999999.                                                     NC1034.2
+213900     GO TO CLOSE-FILES.                                           NC1034.2

--- a/z390/RUNNIST.BAT
+++ b/z390/RUNNIST.BAT
@@ -1,0 +1,459 @@
+
+@if /I "%1" == "tron" (echo on) else (echo off)
+rem run z390 zcobol sample regression tests
+
+setlocal
+if /I "%1" == "tron" (set z_TraceMode=tron
+                      shift /1
+              ) else (if /I "%1" == "troff" (set z_TraceMode=troff
+                                             shift /1
+                                     ) else (set z_TraceMode=)
+                      )
+set /A z_NestLevel=%z_NestLevel%+1
+rem ----- Lvl(%z_NestLevel%) Start %0 %1 %2 %3 %4 %5 %6 %7 %8 %9
+
+rem -- *************************************************************
+rem -- 
+rem -- This script runs the NIST cobol test suite using z390 zCobol
+rem -- which can be found in github repository z390development/z390
+rem -- 
+rem -- This bat script reflects the current status of the adoption
+rem -- process of the NIST test suite in z390 / zCobol.
+rem -- We have found 5 sets of the NIST test suite. None of them seem
+rem -- to be ultimately authoritative as the NIST itself has abandoned
+rem -- the entire test suite.
+rem -- 
+rem -- We are moving forward one program at a time, comparing the program
+rem -- versions available and fixing any breakages in zCobol as we go.
+rem -- That is, most compiles end with RC=8 - there are tons of issues
+rem -- to be resolved. What we fix is where the compile process ends
+rem -- abnormally, e.g. with a java exception and a stack trace.
+rem -- 
+rem -- Long story short: we reconcile source versions, and fix compiler breakage.
+rem -- All other issues are left for future maintenance.
+rem -- 
+rem -- *************************************************************
+
+pushd %~dps0..
+if %1. == . goto help
+
+set parmrc=0
+:parmloop
+if /I %1. EQU   .  goto parmdone
+if /I %1. EQU CM. (set test_CM=Y
+                   goto parmnotall)
+if /I %1. EQU DB. (set test_DB=Y
+                   goto parmnotall)
+if /I %1. EQU EX. (set test_EX=Y
+                   goto parmnotall)
+if /I %1. EQU IC. (set test_IC=Y
+                   goto parmnotall)
+if /I %1. EQU IF. (set test_IF=Y
+                   goto parmnotall)
+if /I %1. EQU IX. (set test_IX=Y
+                   goto parmnotall)
+if /I %1. EQU NC. (set test_NC=Y
+                   goto parmnotall)
+if /I %1. EQU cleanup. (set cleanup=Y
+                        goto parmnotall)
+rem -- should be the path to z390
+if exist %1\bat\CBLCLG.BAT (set z390dir=%1
+                            goto parmnext)
+echo %0 Unknown parameter: %1
+set parmrc=8
+:parmnotall
+set test_all=N
+:parmnext
+shift /1
+goto parmloop
+:parmdone
+rem -- check for prior errors and validate path to z390
+set nistdir=%CD%
+if %parmrc%   EQU 8  goto return
+if %cleanup%. EQU Y. goto cleanup
+if %z390dir%. EQU .  goto help
+if not exist %z390dir%\z390.jar goto help
+rem -- switch to z390 directory
+cd %z390dir%
+
+rem --
+rem -- clear leftovers from prior runs
+:cleanup
+echo Cleaning up...
+if exist %nistdir%\src\*.390                del %nistdir%\src\*.390
+if exist %nistdir%\src\*.BAL                del %nistdir%\src\*.BAL
+if exist %nistdir%\src\*.ERR                del %nistdir%\src\*.ERR
+if exist %nistdir%\src\*.LOG                del %nistdir%\src\*.LOG
+if exist %nistdir%\src\*.LST                del %nistdir%\src\*.LST
+if exist %nistdir%\src\*.MLC                del %nistdir%\src\*.MLC
+if exist %nistdir%\src\*.OBJ                del %nistdir%\src\*.OBJ
+if exist %nistdir%\src\*.OUT                del %nistdir%\src\*.OUT
+if exist %nistdir%\src\*.PRN                del %nistdir%\src\*.PRN
+if exist %nistdir%\src\*.CBL_ZC_LABELS.CPY  del %nistdir%\src\*.CBL_ZC_LABELS.CPY
+if exist %nistdir%\z390\*.390               del %nistdir%\z390\*.390
+if exist %nistdir%\z390\*.BAL               del %nistdir%\z390\*.BAL
+if exist %nistdir%\z390\*.ERR               del %nistdir%\z390\*.ERR
+if exist %nistdir%\z390\*.LOG               del %nistdir%\z390\*.LOG
+if exist %nistdir%\z390\*.LST               del %nistdir%\z390\*.LST
+if exist %nistdir%\z390\*.MLC               del %nistdir%\z390\*.MLC
+if exist %nistdir%\z390\*.OBJ               del %nistdir%\z390\*.OBJ
+if exist %nistdir%\z390\*.OUT               del %nistdir%\z390\*.OUT
+if exist %nistdir%\z390\*.PRN               del %nistdir%\z390\*.PRN
+if exist %nistdir%\z390\*.CBL_ZC_LABELS.CPY del %nistdir%\z390\*.CBL_ZC_LABELS.CPY
+echo Cleanup complete
+if %cleanup%. EQU Y. goto return
+
+rem --
+rem -- Copy members and purpose:
+rem ALTL1.CPY - intended for use by EXEC85
+rem ALTLB.CPY - intended for use by EXEC85
+
+rem --
+rem -- CM = Communications Module
+if /I %test_all%. EQU N. if /I %test_CM%. NEQ Y. goto skip_CM
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\CM101M
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\CM102M
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\CM103M
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\CM104M
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\CM105M
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\CM201M
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\CM202M
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\CM303M
+call bat\CBLC   %z_TraceMode% %nistdir%\src\CM401M || rem test error mesages
+:skip_CM
+
+rem --
+rem -- DB = Debug module
+if /I %test_all%. EQU N. if /I %test_DB%. NEQ Y. goto skip_DB
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\DB101A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\DB102A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\DB103M
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\DB104A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\DB105A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\DB201A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\DB202A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\DB203A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\DB204A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\DB205A
+call bat\CBLC   %z_TraceMode% %nistdir%\src\DB301M || rem test error mesages
+call bat\CBLC   %z_TraceMode% %nistdir%\src\DB302M || rem test error mesages
+call bat\CBLC   %z_TraceMode% %nistdir%\src\DB303M || rem test error mesages
+call bat\CBLC   %z_TraceMode% %nistdir%\src\DB304M || rem test error mesages
+call bat\CBLC   %z_TraceMode% %nistdir%\src\DB305M || rem test error mesages
+:skip_DB
+
+rem --
+rem -- EX = Executive module
+if /I %test_all%. EQU N. if /I %test_EX%. NEQ Y. goto skip_EX
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\EXEC85
+:skip_EX
+
+rem --
+rem -- IC = Inter-Program Communication - subprograms must be compiled before each main program!
+if /I %test_all%. EQU N. if /I %test_IC%. NEQ Y. goto skip_IC
+del %nistdir%\src\IC*.OBJ >NUL                     || rem clear out leftovers of prior run
+set XXXXX055=%nistdir%\src\IC101A_XXXXX055.OUT
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC102A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IC101A
+set XXXXX055=%nistdir%\src\IC103A_XXXXX055.OUT
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC104A
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC105A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IC103A
+set XXXXX055=%nistdir%\src\IC106A_XXXXX055.OUT
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC107A
+call bat\CBLCL  %z_TraceMode% %nistdir%\src\IC106A || rem execution ends S0C7
+set XXXXX055=%nistdir%\src\IC108A_XXXXX055.OUT
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC109A
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC110A
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC111A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IC108A
+set XXXXX055=%nistdir%\src\IC112A_XXXXX055.OUT
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC113A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IC112A || rem fails to generate the call to IC113A
+set XXXXX055=%nistdir%\src\IC114A_XXXXX055.OUT
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC115A
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC114A || rem fails to link because of errors in IC115A
+set XXXXX055=%nistdir%\src\IC116M_XXXXX055.OUT
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC117M
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC118M
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IC116M
+set XXXXX055=%nistdir%\src\IC201A_XXXXX055.OUT
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC202A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IC201A
+set XXXXX055=%nistdir%\src\IC203A_XXXXX055.OUT
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC204A
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC205A
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC206A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IC203A
+set XXXXX055=%nistdir%\src\IC207A_XXXXX055.OUT
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC208A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IC207A
+set XXXXX055=%nistdir%\src\IC209A_XXXXX055.OUT
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC210A
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC211A
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC212A
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC209A || rem fails to link because of errors in IC209A
+set XXXXX055=%nistdir%\src\IC213A_XXXXX055.OUT
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC214A
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC215A
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC213A || rem fails to link because of errors in IC215A
+set XXXXX055=%nistdir%\src\IC216A_XXXXX055.OUT
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IC217A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IC216A
+set XXXXX055=
+rem  bat\CBLCLG %z_TraceMode% %nistdir%\src\IC222A   || rem uses multiple programs in 1 source file
+call bat\CBLC   %z_TraceMode% %nistdir%\z390\IC222A1 || instead of the original
+call bat\CBLCLG %z_TraceMode% %nistdir%\z390\IC222A  || instead of the original
+rem  bat\CBLCLG %z_TraceMode% %nistdir%\src\IC223A   || rem uses multiple programs in 1 source file
+call bat\CBLC   %z_TraceMode% %nistdir%\z390\IC223A1 || instead of the original
+call bat\CBLCLG %z_TraceMode% %nistdir%\z390\IC223A  || instead of the original
+rem  bat\CBLCLG %z_TraceMode% %nistdir%\src\IC224A   || rem uses multiple programs in 1 source file
+call bat\CBLC   %z_TraceMode% %nistdir%\z390\IC224A1 || instead of the original
+call bat\CBLCLG %z_TraceMode% %nistdir%\z390\IC224A  || instead of the original
+rem  bat\CBLCLG %z_TraceMode% %nistdir%\src\IC225A   || rem uses multiple programs in 1 source file
+call bat\CBLC   %z_TraceMode% %nistdir%\z390\IC225A1 || instead of the original
+call bat\CBLCLG %z_TraceMode% %nistdir%\z390\IC225A  || instead of the original
+rem  bat\CBLCLG %z_TraceMode% %nistdir%\src\IC226A   || rem uses multiple programs in 1 source file
+call bat\CBLC   %z_TraceMode% %nistdir%\z390\IC226A1 || instead of the original
+call bat\CBLCLG %z_TraceMode% %nistdir%\z390\IC226A  || instead of the original
+rem  bat\CBLCLG %z_TraceMode% %nistdir%\src\IC227A   || rem uses multiple programs in 1 source file
+call bat\CBLC   %z_TraceMode% %nistdir%\z390\IC227A1 || instead of the original
+call bat\CBLCLG %z_TraceMode% %nistdir%\z390\IC227A  || instead of the original
+rem  bat\CBLCLG %z_TraceMode% %nistdir%\src\IC228A   || rem uses multiple programs in 1 source file
+call bat\CBLC   %z_TraceMode% %nistdir%\z390\IC228A1 || instead of the original
+call bat\CBLCLG %z_TraceMode% %nistdir%\z390\IC228A  || instead of the original
+rem  bat\CBLCLG %z_TraceMode% %nistdir%\src\IC233A   || rem uses multiple programs in 1 source file
+call bat\CBLC   %z_TraceMode% %nistdir%\z390\IC233A1 || instead of the original
+call bat\CBLCLG %z_TraceMode% %nistdir%\z390\IC233A  || instead of the original
+rem  bat\CBLCLG %z_TraceMode% %nistdir%\src\IC234A   || rem uses multiple programs in 1 source file
+call bat\CBLC   %z_TraceMode% %nistdir%\z390\IC234A1 || instead of the original
+call bat\CBLC   %z_TraceMode% %nistdir%\z390\IC234A2 || instead of the original
+call bat\CBLC   %z_TraceMode% %nistdir%\z390\IC234A3 || instead of the original
+call bat\CBLCLG %z_TraceMode% %nistdir%\z390\IC234A  || instead of the original
+rem  bat\CBLCLG %z_TraceMode% %nistdir%\src\IC235A   || rem uses multiple programs in 1 source file
+call bat\CBLC   %z_TraceMode% %nistdir%\z390\IC235A1 || instead of the original
+call bat\CBLC   %z_TraceMode% %nistdir%\z390\IC235A2 || instead of the original
+call bat\CBLCLG %z_TraceMode% %nistdir%\z390\IC235A  || instead of the original
+set XXXXX055=%nistdir%\src\IC237A_XXXXX055.OUT
+rem  bat\CBLCLG %z_TraceMode% %nistdir%\src\IC237A   || rem uses multiple programs in 1 source file
+call bat\CBLC   %z_TraceMode% %nistdir%\z390\IC237A1 || instead of the original
+call bat\CBLCL  %z_TraceMode% %nistdir%\z390\IC237A  || instead of the original - incurs S0C5 at runtime
+set XXXXX055=
+rem  bat\CBLCLG %z_TraceMode% %nistdir%\src\IC401M   || rem uses multiple programs in 1 source file
+:skip_IC
+
+rem --
+rem -- IF = Intrinsic Functions
+if /I %test_all%. EQU N. if /I %test_IF%. NEQ Y. goto skip_IF
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF101A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF102A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF103A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF104A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF105A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF106A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF107A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF108A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF109A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF110A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF111A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF112A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF113A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF114A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF115A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF116A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF117A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF118A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF119A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF120A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF121A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF122A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF123A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF124A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF125A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF126A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF127A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF128A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF129A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF130A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF131A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF132A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF133A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF134A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF135A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF136A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF137A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF138A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF139A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF140A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF141A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IF142A
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IF401M || rem test error mesages
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IF402M || rem test error mesages
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IF403M || rem test error mesages
+:skip_IF
+
+rem --
+rem -- IX = Indexed I/O
+if /I %test_all%. EQU N. if /I %test_IX%. NEQ Y. goto skip_IX
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX101A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX102A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX103A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX104A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX105A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX106A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX107A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX108A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX109A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX110A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX111A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX112A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX113A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX114A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX115A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX116A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX117A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX118A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX119A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX120A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX121A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX201A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX202A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX203A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX204A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX205A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX206A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX207A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX208A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX209A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX210A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX211A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX212A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX213A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX214A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX215A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX216A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX217A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\IX218A
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IX301M || rem test error mesages
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IX302M || rem test error mesages
+call bat\CBLC   %z_TraceMode% %nistdir%\src\IX401M || rem test error mesages
+:skip_IX
+
+rem --
+rem -- Copy members and purpose:
+rem K101A.CPY intended usage unknown
+rem K1DAA.CPY intended usage unknown
+rem K1FDA.CPY intended usage unknown
+rem K1P01.CPY intended usage unknown
+rem K1PRA.CPY intended usage unknown
+rem K1PRB.CPY intended usage unknown
+rem K1PRC.CPY intended usage unknown
+rem K1SEA.CPY intended usage unknown
+rem K1W01.CPY intended usage unknown
+rem K1W02.CPY intended usage unknown
+rem K1W03.CPY intended usage unknown
+rem K1W04.CPY intended usage unknown
+rem K1WKA.CPY intended usage unknown
+rem K1WKB.CPY intended usage unknown
+rem K1WKC.CPY intended usage unknown
+rem K1WKY.CPY intended usage unknown
+rem K1WKZ.CPY intended usage unknown
+rem K2PRA.CPY intended usage unknown
+rem K2SEA.CPY intended usage unknown
+rem K3FCA.CPY intended usage unknown
+rem K3FCB.CPY intended usage unknown
+rem K3IOA.CPY intended usage unknown
+rem K3IOB.CPY intended usage unknown
+rem K3LGE.CPY intended usage unknown
+rem K3OCA.CPY intended usage unknown
+rem K3SCA.CPY intended usage unknown
+rem K3SML.CPY intended usage unknown
+rem K3SNA.CPY intended usage unknown
+rem K3SNB.CPY intended usage unknown
+rem K4NTA.CPY intended usage unknown
+rem K501A.CPY intended usage unknown
+rem K501B.CPY intended usage unknown
+rem K5SDA.CPY intended usage unknown
+rem K5SDB.CPY intended usage unknown
+rem K6SCA.CPY intended usage unknown
+rem K7SEA.CPY intended usage unknown
+rem KK208A.CPY intended usage unknown
+rem KP001.CPY intended usage unknown
+rem KP002.CPY intended usage unknown
+rem KP003.CPY intended usage unknown
+rem KP004.CPY intended usage unknown
+rem KP005.CPY intended usage unknown
+rem KP006.CPY intended usage unknown
+rem KP007.CPY intended usage unknown
+rem KP008.CPY intended usage unknown
+rem KP009.CPY intended usage unknown
+rem KP010.CPY intended usage unknown
+rem KSM31.CPY intended usage unknown
+rem KSM41.CPY intended usage unknown
+
+rem --
+rem -- NC = Nucleus
+if /I %test_all%. EQU N. if /I %test_NC%. NEQ Y. goto skip_NC
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\NC101A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\NC102A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\NC103A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\NC104A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\NC105A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\NC106A
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\NC107A
+call bat\CBLC   %z_TraceMode% %nistdir%\src\NC108M || rem test error mesages
+call bat\CBLC   %z_TraceMode% %nistdir%\src\NC109M || rem test error mesages
+call bat\CBLC   %z_TraceMode% %nistdir%\src\NC110M || rem test error mesages
+set XXXXX055=%nistdir%\src\NC111A_XXXXX055.OUT
+call bat\CBLCL  %z_TraceMode% %nistdir%\src\NC111A || rem Abend S0CA
+set XXXXX055=
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\NC112A
+set XXXXX055=%nistdir%\src\NC113M_XXXXX055.OUT
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\NC113M
+set XXXXX055=
+call bat\CBLCLG %z_TraceMode% %nistdir%\src\NC114M
+:skip_NC
+
+rem --
+rem -- sort all error messages from all compiles
+type %nistdir%\src\*.err >%nistdir%\src\$all.err 2>nul
+sort /+26 %nistdir%\src\$all.err /O %nistdir%\src\$allsort.err
+echo .
+echo All compiles completed
+echo See %nistdir%\src\$allsort.err for complete list of all messages
+
+set z_ReturnCode=0
+goto return
+
+:help
+set z_ReturnCode=8
+echo .
+echo %0 ERROR: no arguments provided - path to z390 repository unknown
+echo .
+echo The path to a local clone of the z390 repository with z390.jar available must be specified.
+echo Note: if z390.jar is not available, please run the z390 documented build procedure.
+echo .
+echo When the z390 path is omitted, no tests can be run
+echo When the z390 path is specified, the default is to run all tests
+echo This default can be overriden by specifying one or more of the following parameters:
+echo - cleanup = cleanup only; no compiles
+echo - CM = Communications Module
+echo - DB = Debug module
+echo - EX = Executive module
+echo - IC = Inter-Program Communication
+echo - IF = Intrinsic Functions
+echo - IX = Indexed I/O
+echo - NC = Nucleus
+echo .
+echo There is no prescribed order of parameters
+echo .
+goto return
+
+:error
+set z_ReturnCode=%ERRORLEVEL%
+echo %0 ERROR: Encountered RC %z_ReturnCode% - exiting
+
+:return
+popd
+rem ----- Lvl(%z_NestLevel%)  End %0 %1 %2 %3 %4 %5 %6 %7 %8 %9
+exit /b %z_ReturnCode%


### PR DESCRIPTION
fixes #11 
Or rather this fix creates a workaround until we find time to address the issue in the zCobol compiler.